### PR TITLE
feat(docs): Add Swagger/OpenAPI documentation and annotate DTOs/controllers

### DIFF
--- a/BackEnd/src/common/decorators/api-docs.decorator.ts
+++ b/BackEnd/src/common/decorators/api-docs.decorator.ts
@@ -1,0 +1,25 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
+
+type ApiResponseShape = { status: number; description: string; type?: any };
+
+export const ApiDocs = (options: {
+  tags?: string[];
+  summary?: string;
+  bearer?: boolean;
+  responses?: ApiResponseShape[];
+} = {}) => {
+  const decorators = [] as any[];
+  if (options.tags && options.tags.length) decorators.push(ApiTags(...options.tags));
+  if (options.bearer) decorators.push(ApiBearerAuth('JWT-auth'));
+  if (options.summary) decorators.push(ApiOperation({ summary: options.summary }));
+  if (options.responses)
+    options.responses.forEach((r) => decorators.push(ApiResponse(r)));
+
+  return applyDecorators(...decorators);
+};

--- a/BackEnd/src/config/swagger.config.ts
+++ b/BackEnd/src/config/swagger.config.ts
@@ -1,0 +1,30 @@
+import { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+
+export function setupSwagger(app: INestApplication, configService?: ConfigService) {
+  const title = configService?.get('APP_NAME') || 'StellarEarn API';
+  const version = configService?.get('API_VERSION') || '1.0';
+  const description =
+    configService?.get('API_DESCRIPTION') ||
+    'Quest-based earning platform on Stellar blockchain';
+
+  const builder = new DocumentBuilder()
+    .setTitle(title)
+    .setDescription(description)
+    .setVersion(version)
+    .addBearerAuth(
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      'JWT-auth',
+    )
+    .addTag('Authentication')
+    .addTag('Health', 'System health and readiness probes');
+
+  const document = SwaggerModule.createDocument(app, builder.build(), {
+    deepScanRoutes: true,
+  });
+
+  SwaggerModule.setup('api/docs', app, document, {
+    swaggerOptions: { persistAuthorization: true },
+  });
+}

--- a/BackEnd/src/main.ts
+++ b/BackEnd/src/main.ts
@@ -1,48 +1,10 @@
-// import { NestFactory } from '@nestjs/core';
-// import { ValidationPipe } from '@nestjs/common';
-// import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-// import { AppModule } from './app.module';
-
-// async function bootstrap() {
-//   const app = await NestFactory.create(AppModule);
-
-//   app.enableCors({
-//     origin: process.env.CORS_ORIGINS?.split(',') || ['http://localhost:3000'],
-//     credentials: true,
-//   });
-
-//   app.useGlobalPipes(
-//     new ValidationPipe({
-//       whitelist: true,
-//       forbidNonWhitelisted: true,
-//       transform: true,
-//     }),
-//   );
-
-//   const config = new DocumentBuilder()
-//     .setTitle('StellarEarn API')
-//     .setDescription('Quest-based earning platform on Stellar blockchain')
-//     .setVersion('1.0')
-//     .addBearerAuth()
-//     .addTag('Authentication')
-//     .build();
-
-//   const document = SwaggerModule.createDocument(app, config);
-//   SwaggerModule.setup('api/docs', app, document);
-
-//   const port = process.env.PORT || 3001;
-//   await app.listen(port);
-//   console.log(`🚀 Application is running on: http://localhost:${port}`);
-//   console.log(
-//     `📚 Swagger docs available at: http://localhost:${port}/api/docs`,
-//   );
-// }
-// bootstrap();
 
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { SwaggerModule } from '@nestjs/swagger';
+import { VersioningType } from '@nestjs/common';
+import { setupSwagger } from './config/swagger.config';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { CustomValidationPipe } from './common/pipes/validation.pipe';
@@ -117,20 +79,14 @@ async function bootstrap() {
 
     console.log('✅ Middleware configured');
 
-    // Swagger
-    const config = new DocumentBuilder()
-      .setTitle('StellarEarn API')
-      .setDescription('Quest-based earning platform on Stellar blockchain')
-      .setVersion('1.0')
-      .addBearerAuth()
-      .addTag('Authentication')
-      .addTag('Health', 'System health and readiness probes')
-      .build();
+    // API versioning and global prefix
+    app.setGlobalPrefix('api');
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
 
-    const document = SwaggerModule.createDocument(app, config);
-    SwaggerModule.setup('api/docs', app, document);
+    // Swagger (centralized setup)
+    setupSwagger(app, configService);
 
-    console.log('✅ Swagger configured');
+    console.log('✅ Swagger configured and versioning enabled');
 
     // Terminus handles SIGTERM/SIGINT: marks health checks unhealthy first,
     // drains in-flight requests, then closes the app cleanly.

--- a/BackEnd/src/modules/payouts/dto/claim-payout.dto.ts
+++ b/BackEnd/src/modules/payouts/dto/claim-payout.dto.ts
@@ -7,39 +7,57 @@ import {
   IsNumber,
   Min,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PayoutType } from '../entities/payout.entity';
 
 export class ClaimPayoutDto {
+  @ApiProperty({
+    description: 'Submission ID for the payout claim',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   @IsNotEmpty()
   submissionId: string;
 
+  @ApiProperty({
+    description: 'Stellar public key address to receive payout',
+    example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  })
   @IsString()
   @IsNotEmpty()
   stellarAddress: string;
 }
 
 export class CreatePayoutDto {
+  @ApiProperty({
+    description: 'Stellar destination address',
+    example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  })
   @IsString()
   @IsNotEmpty()
   stellarAddress: string;
 
+  @ApiProperty({ description: 'Amount to payout', example: 10.5, minimum: 0.0000001 })
   @IsNumber()
   @Min(0.0000001)
   amount: number;
 
+  @ApiPropertyOptional({ description: 'Asset code (e.g., XLM, USDC)', example: 'XLM' })
   @IsString()
   @IsOptional()
   asset?: string;
 
+  @ApiPropertyOptional({ description: 'Payout type', enum: PayoutType })
   @IsEnum(PayoutType)
   @IsOptional()
   type?: PayoutType;
 
+  @ApiPropertyOptional({ description: 'Related quest ID', example: '123e4567-e89b-12d3-a456-426614174000' })
   @IsUUID()
   @IsOptional()
   questId?: string;
 
+  @ApiPropertyOptional({ description: 'Related submission ID', example: '123e4567-e89b-12d3-a456-426614174000' })
   @IsUUID()
   @IsOptional()
   submissionId?: string;

--- a/BackEnd/src/modules/payouts/dto/payout-query.dto.ts
+++ b/BackEnd/src/modules/payouts/dto/payout-query.dto.ts
@@ -1,16 +1,20 @@
 import { IsOptional, IsEnum, IsString, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
 import { PayoutStatus, PayoutType } from '../entities/payout.entity';
 
 export class PayoutQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by Stellar address', example: 'GXXXX...' })
   @IsOptional()
   @IsString()
   stellarAddress?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by payout status', enum: PayoutStatus })
   @IsOptional()
   @IsEnum(PayoutStatus)
   status?: PayoutStatus;
 
+  @ApiPropertyOptional({ description: 'Filter by payout type', enum: PayoutType })
   @IsOptional()
   @IsEnum(PayoutType)
   type?: PayoutType;
@@ -28,39 +32,89 @@ export class PayoutQueryDto {
   @Max(100)
   limit?: number = 20;
 }
-
-export class PayoutHistoryResponseDto {
-  payouts: PayoutResponseDto[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-}
-
 export class PayoutResponseDto {
+  @ApiProperty()
   id: string;
+
+  @ApiProperty()
   stellarAddress: string;
+
+  @ApiProperty()
   amount: number;
+
+  @ApiProperty({ nullable: true })
   asset: string;
+
+  @ApiProperty({ enum: PayoutStatus })
   status: PayoutStatus;
+
+  @ApiProperty({ enum: PayoutType })
   type: PayoutType;
+
+  @ApiProperty({ nullable: true })
   questId: string | null;
+
+  @ApiProperty({ nullable: true })
   submissionId: string | null;
+
+  @ApiProperty({ nullable: true })
   transactionHash: string | null;
+
+  @ApiProperty({ nullable: true })
   stellarLedger: number | null;
+
+  @ApiProperty({ nullable: true })
   failureReason: string | null;
+
+  @ApiProperty()
   retryCount: number;
+
+  @ApiProperty({ nullable: true })
   processedAt: Date | null;
+
+  @ApiProperty({ nullable: true })
   claimedAt: Date | null;
+
+  @ApiProperty()
   createdAt: Date;
 }
 
+export class PayoutHistoryResponseDto {
+  @ApiProperty({ type: [PayoutResponseDto] })
+  payouts: PayoutResponseDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty()
+  totalPages: number;
+}
+
 export class PayoutStatsDto {
+  @ApiProperty()
   totalPayouts: number;
+
+  @ApiProperty()
   totalAmount: number;
+
+  @ApiProperty()
   pendingPayouts: number;
+
+  @ApiProperty()
   pendingAmount: number;
+
+  @ApiProperty()
   completedPayouts: number;
+
+  @ApiProperty()
   completedAmount: number;
+
+  @ApiProperty()
   failedPayouts: number;
 }

--- a/BackEnd/src/modules/quests/dto/quest-response.dto.ts
+++ b/BackEnd/src/modules/quests/dto/quest-response.dto.ts
@@ -2,28 +2,28 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Quest } from '../entities/quest.entity';
 
 export class QuestResponseDto {
-  @ApiProperty()
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
   id: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'Complete KYC Verification' })
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'Complete the KYC verification process to earn rewards' })
   description: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 10.5 })
   rewardAmount: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'ACTIVE' })
   status: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' })
   createdBy: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: '2026-01-23T12:34:56.000Z' })
   createdAt: Date;
 
-  @ApiProperty()
+  @ApiProperty({ example: '2026-01-24T08:00:00.000Z' })
   updatedAt: Date;
 
   static fromEntity(quest: Quest): QuestResponseDto {

--- a/BackEnd/src/modules/submissions/dto/approve-submission.dto.ts
+++ b/BackEnd/src/modules/submissions/dto/approve-submission.dto.ts
@@ -1,6 +1,8 @@
 import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ApproveSubmissionDto {
+  @ApiPropertyOptional({ description: 'Optional notes for approval', example: 'Looks good, reward issued.' })
   @IsOptional()
   @IsString()
   @MaxLength(1000)

--- a/BackEnd/src/modules/submissions/dto/reject-submission.dto.ts
+++ b/BackEnd/src/modules/submissions/dto/reject-submission.dto.ts
@@ -5,14 +5,17 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class RejectSubmissionDto {
+  @ApiProperty({ description: 'Reason for rejection', minLength: 10, maxLength: 500, example: 'Insufficient proof of identity' })
   @IsNotEmpty({ message: 'Rejection reason is required' })
   @IsString()
   @MinLength(10, { message: 'Rejection reason must be at least 10 characters' })
   @MaxLength(500, { message: 'Rejection reason cannot exceed 500 characters' })
   reason: string;
 
+  @ApiPropertyOptional({ description: 'Optional notes for the rejection', maxLength: 1000 })
   @IsOptional()
   @IsString()
   @MaxLength(1000)

--- a/BackEnd/src/modules/submissions/submissions.controller.ts
+++ b/BackEnd/src/modules/submissions/submissions.controller.ts
@@ -9,14 +9,23 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { SubmissionsService } from './submissions.service';
 import { ApproveSubmissionDto } from './dto/approve-submission.dto';
 import { RejectSubmissionDto } from './dto/reject-submission.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { VerifierGuard } from '../auth/guards/verifier.guard';
 
+@ApiTags('Submissions')
 @Controller('quests/:questId/submissions')
 @UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
 export class SubmissionsController {
   constructor(private readonly submissionsService: SubmissionsService) {}
 
@@ -27,6 +36,32 @@ export class SubmissionsController {
   @Post(':id/approve')
   @UseGuards(VerifierGuard)
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Approve a quest submission' })
+  @ApiParam({ name: 'questId', description: 'Quest UUID' })
+  @ApiParam({ name: 'id', description: 'Submission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Submission approved successfully',
+    schema: {
+      example: {
+        success: true,
+        message: 'Submission approved successfully',
+        data: {
+          submission: {
+            id: 'subm_123',
+            status: 'APPROVED',
+            approvedAt: '2026-01-24T08:00:00.000Z',
+            approvedBy: 'verifier_1',
+            quest: { id: 'quest_123', title: 'Complete KYC', rewardAmount: 10.5 },
+            user: { id: 'user_123', stellarAddress: 'G...'
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Verifier role required' })
   async approveSubmission(
     @Param('questId') questId: string,
     @Param('id') submissionId: string,
@@ -70,6 +105,32 @@ export class SubmissionsController {
   @Post(':id/reject')
   @UseGuards(VerifierGuard)
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reject a quest submission' })
+  @ApiParam({ name: 'questId', description: 'Quest UUID' })
+  @ApiParam({ name: 'id', description: 'Submission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Submission rejected',
+    schema: {
+      example: {
+        success: true,
+        message: 'Submission rejected',
+        data: {
+          submission: {
+            id: 'subm_123',
+            status: 'REJECTED',
+            rejectedAt: '2026-01-24T09:00:00.000Z',
+            rejectedBy: 'verifier_1',
+            rejectionReason: 'Insufficient proof of identity',
+            quest: { id: 'quest_123', title: 'Complete KYC' },
+            user: { id: 'user_123' },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Verifier role required' })
   async rejectSubmission(
     @Param('questId') questId: string,
     @Param('id') submissionId: string,
@@ -110,6 +171,11 @@ export class SubmissionsController {
    * GET /quests/:questId/submissions/:id
    */
   @Get(':id')
+  @ApiOperation({ summary: 'Get submission details' })
+  @ApiParam({ name: 'questId', description: 'Quest UUID' })
+  @ApiParam({ name: 'id', description: 'Submission UUID' })
+  @ApiResponse({ status: 200, description: 'Submission details retrieved' })
+  @ApiResponse({ status: 404, description: 'Submission not found' })
   async getSubmission(
     @Param('questId') questId: string,
     @Param('id') submissionId: string,
@@ -127,6 +193,9 @@ export class SubmissionsController {
    * GET /quests/:questId/submissions
    */
   @Get()
+  @ApiOperation({ summary: 'Get all submissions for a quest' })
+  @ApiParam({ name: 'questId', description: 'Quest UUID' })
+  @ApiResponse({ status: 200, description: 'Submissions retrieved' })
   async getQuestSubmissions(@Param('questId') questId: string) {
     const submissions = await this.submissionsService.findByQuest(questId);
 

--- a/BackEnd/src/modules/users/dto/create.dto.ts
+++ b/BackEnd/src/modules/users/dto/create.dto.ts
@@ -7,9 +7,16 @@ import {
   IsEnum,
   Matches,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PrivacyLevel } from '../entities/user.entity';
 
 export class CreateUserDto {
+  @ApiProperty({
+    description: 'Unique username',
+    example: 'alice_123',
+    minLength: 3,
+    maxLength: 30,
+  })
   @IsString()
   @MinLength(3)
   @MaxLength(30)
@@ -18,9 +25,19 @@ export class CreateUserDto {
   })
   username: string;
 
+  @ApiProperty({
+    description: 'User email address',
+    example: 'alice@example.com',
+  })
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    description: 'Stellar public key address',
+    example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    minLength: 56,
+    maxLength: 56,
+  })
   @IsString()
   @MinLength(56)
   @MaxLength(56)
@@ -29,15 +46,29 @@ export class CreateUserDto {
   })
   stellarAddress: string;
 
+  @ApiPropertyOptional({
+    description: 'Short user biography',
+    example: 'Builder and blockchain enthusiast',
+    maxLength: 500,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(500)
   bio?: string;
 
+  @ApiPropertyOptional({
+    description: 'Avatar image URL',
+    example: 'https://example.com/avatar.png',
+  })
   @IsOptional()
   @IsString()
   avatarUrl?: string;
 
+  @ApiPropertyOptional({
+    description: 'Profile privacy level',
+    enum: PrivacyLevel,
+    example: PrivacyLevel.PUBLIC,
+  })
   @IsOptional()
   @IsEnum(PrivacyLevel)
   privacyLevel?: PrivacyLevel;

--- a/BackEnd/src/modules/users/dto/search-users.dto.ts
+++ b/BackEnd/src/modules/users/dto/search-users.dto.ts
@@ -1,17 +1,21 @@
 import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SearchUsersDto {
+  @ApiPropertyOptional({ description: 'Search query string (username or address)', example: 'alice' })
   @IsOptional()
   @IsString()
   query?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, default: 1 })
   @IsOptional()
   @IsInt()
   @Min(1)
   @Type(() => Number)
   page?: number = 1;
 
+  @ApiPropertyOptional({ description: 'Items per page', example: 20, default: 20, minimum: 1, maximum: 100 })
   @IsOptional()
   @IsInt()
   @Min(1)
@@ -19,10 +23,12 @@ export class SearchUsersDto {
   @Type(() => Number)
   limit?: number = 20;
 
+  @ApiPropertyOptional({ description: 'Sort field', example: 'xp', default: 'xp' })
   @IsOptional()
   @IsString()
   sortBy?: string = 'xp';
 
+  @ApiPropertyOptional({ description: 'Sort order', example: 'DESC', default: 'DESC', enum: ['ASC', 'DESC'] })
   @IsOptional()
   @IsString()
   order?: 'ASC' | 'DESC' = 'DESC';

--- a/BackEnd/src/modules/users/dto/update.dto.ts
+++ b/BackEnd/src/modules/users/dto/update.dto.ts
@@ -7,40 +7,53 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { PrivacyLevel } from '../entities/user.entity';
 
 export class SocialLinksDto {
+  @ApiPropertyOptional({ description: 'Twitter handle', example: '@alice' })
   @IsOptional()
   @IsString()
   twitter?: string;
 
+  @ApiPropertyOptional({ description: 'GitHub username', example: 'alice' })
   @IsOptional()
   @IsString()
   github?: string;
 
+  @ApiPropertyOptional({ description: 'Discord handle', example: 'alice#1234' })
   @IsOptional()
   @IsString()
   discord?: string;
 
+  @ApiPropertyOptional({ description: 'Website URL', example: 'https://alice.dev' })
   @IsOptional()
   @IsUrl()
   website?: string;
 }
 
 export class UpdateProfileDto {
+  @ApiPropertyOptional({
+    description: 'Short user biography',
+    example: 'Builder and blockchain enthusiast',
+    maxLength: 500,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(500)
   bio?: string;
 
+  @ApiPropertyOptional({ description: 'Avatar image URL', example: 'https://example.com/avatar.png' })
   @IsOptional()
   @IsUrl()
   avatarUrl?: string;
 
+  @ApiPropertyOptional({ description: 'Profile privacy level', enum: PrivacyLevel })
   @IsOptional()
   @IsEnum(PrivacyLevel)
   privacyLevel?: PrivacyLevel;
 
+  @ApiPropertyOptional({ type: SocialLinksDto, description: 'Social links' })
   @IsOptional()
   @ValidateNested()
   @Type(() => SocialLinksDto)

--- a/BackEnd/src/modules/webhooks/webhooks.controller.ts
+++ b/BackEnd/src/modules/webhooks/webhooks.controller.ts
@@ -11,11 +11,19 @@ import {
   Param,
 } from '@nestjs/common';
 import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiConsumes,
+  ApiBody,
+} from '@nestjs/swagger';
+import {
   WebhooksService,
   WebhookEvent,
   WebhookResponse,
 } from './webhooks.service';
 
+@ApiTags('Webhooks')
 @Controller('webhooks')
 export class WebhooksController {
   private readonly logger = new Logger(WebhooksController.name);
@@ -28,6 +36,12 @@ export class WebhooksController {
    */
   @Post('github')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Receive GitHub webhook events' })
+  @ApiConsumes('application/json')
+  @ApiBody({ schema: { type: 'object' } })
+  @ApiResponse({ status: 200, description: 'Webhook processed successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid webhook payload' })
+  @ApiResponse({ status: 401, description: 'Unauthorized or invalid signature' })
   async handleGithubWebhook(
     @Body() payload: any,
     @Headers('x-github-event') eventType: string,
@@ -81,6 +95,12 @@ export class WebhooksController {
    */
   @Post('api-verify')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'API verification webhook endpoint' })
+  @ApiConsumes('application/json')
+  @ApiBody({ schema: { type: 'object' } })
+  @ApiResponse({ status: 200, description: 'Verification processed' })
+  @ApiResponse({ status: 400, description: 'Invalid webhook headers or payload' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async handleApiVerificationWebhook(
     @Body() payload: any,
     @Headers('x-event-type') eventType: string,
@@ -140,6 +160,11 @@ export class WebhooksController {
    */
   @Post('generic/:service')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Generic webhook receiver for external services' })
+  @ApiConsumes('application/json')
+  @ApiBody({ schema: { type: 'object' } })
+  @ApiResponse({ status: 200, description: 'Webhook processed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async handleGenericWebhook(
     @Body() payload: any,
     @Headers() headers: any,
@@ -178,6 +203,8 @@ export class WebhooksController {
    */
   @Post('health')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Webhook-specific health check' })
+  @ApiResponse({ status: 200, description: 'Service healthy' })
   async healthCheck(): Promise<{ status: string; timestamp: Date }> {
     return {
       status: 'ok',


### PR DESCRIPTION
Closes #97

---

Closes: #97 

## Summary

This PR introduces comprehensive API documentation using Swagger/OpenAPI, centralizes Swagger configuration, enables URI-based API versioning, and annotates DTOs and controllers with Swagger decorators and examples to improve developer experience and integration speed.

## Key Changes

- Add centralized Swagger setup and mount UI at `/api/docs`.
- Enable URI versioning and set global `api` prefix.
- Add reusable `ApiDocs` decorator for common Swagger patterns.
- Annotate DTOs with `@ApiProperty`/`@ApiPropertyOptional` and add examples where appropriate.
- Annotate controllers with `@ApiOperation`, `@ApiResponse`, `@ApiParam`, and response examples for complex endpoints.
- Fix TypeScript ordering error by reordering payout DTO declarations.

## Files Touched (high level)

- `BackEnd/src/config/swagger.config.ts` (new)
- `BackEnd/src/common/decorators/api-docs.decorator.ts` (new)
- `BackEnd/src/main.ts` (updated)
- `BackEnd/src/modules/*/dto/*` (multiple DTOs updated: users, payouts, submissions, notifications, analytics, quests)
- `BackEnd/src/modules/submissions/submissions.controller.ts` (updated)
- `BackEnd/src/modules/webhooks/webhooks.controller.ts` (updated)
- `BackEnd/src/modules/payouts/dto/payout-query.dto.ts` (ordering fix)

## How to Test

1. Install dependencies and build:

```bash
cd "BackEnd"
npm install
npm run build
```

2. Run the development server and open Swagger UI:

```bash
npm run start:dev
# Open: http://localhost:3001/api/docs
```

3. Verify:
- Swagger UI loads and shows API versioning (URI-based, e.g. `/api/v1/...`).
- Endpoints include request/response schemas and examples.
- Use the **Authorize** button to test protected endpoints with a JWT.

## Notes & Remaining Work

- Swagger persistence of authorization is enabled.
- A few endpoints still need richer request/response examples — tracked in the TODO list.
- Recommended follow-up: run an API sweep to add any missing `@ApiProperty` annotations and finalize example payloads.

---