### PR TITLE
implement quest query and filtering system with pagination

### DIFF
--- a/contracts/earn-quest/src/events.rs
+++ b/contracts/earn-quest/src/events.rs
@@ -127,4 +127,3 @@ pub fn badge_granted(env: &Env, user: Address, badge: Badge) {
     let data = (badge,);
     env.events().publish(topics, data);
 }
-main

--- a/contracts/earn-quest/src/init.rs
+++ b/contracts/earn-quest/src/init.rs
@@ -1,7 +1,5 @@
-//! Initialization logic for earn-quest contract
-
-use soroban_sdk::{Env, Address};
-use crate::storage::{set_admin, set_version, set_config, is_initialized, mark_initialized};
+use crate::storage;
+use soroban_sdk::{Address, Env, String, Vec};
 
 pub struct InitConfig {
     pub admin: Address,
@@ -10,16 +8,17 @@ pub struct InitConfig {
 }
 
 pub fn initialize(env: &Env, config: InitConfig) {
-    if is_initialized(env) {
+    if storage::is_initialized(env) {
         panic!("Contract already initialized");
     }
-    set_admin(env, &config.admin);
-    set_version(env, config.version);
-    set_config(env, &config.config_params);
-    mark_initialized(env);
+    storage::set_contract_admin(env, &config.admin);
+    storage::set_admin(env, &config.admin);
+    storage::set_version(env, config.version);
+    storage::set_config(env, &config.config_params);
+    storage::mark_initialized(env);
 }
 
 pub fn upgrade_authorize(env: &Env, caller: &Address) -> bool {
-    let admin = crate::storage::get_admin(env);
+    let admin = storage::get_admin(env);
     caller == &admin
 }

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -4,6 +4,7 @@ mod admin;
 pub mod errors;
 mod escrow;
 mod events;
+mod init;
 mod payout;
 mod quest;
 mod reputation;
@@ -15,38 +16,26 @@ pub mod validation;
 
 use crate::errors::Error;
 use crate::types::{
-    Badge, BatchApprovalInput, BatchQuestInput, EscrowInfo, QuestMetadata, UserStats,
+    Badge, BatchApprovalInput, BatchQuestInput, CreatorStats, EscrowInfo, PlatformStats, Quest,
+    QuestMetadata, QuestStatus, UserStats,
 };
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol, Vec};
-mod init;
-
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
 
 #[contract]
 pub struct EarnQuestContract;
 
 #[contractimpl]
 impl EarnQuestContract {
-    /// Initialize contract with admin, version, and config
-    pub fn initialize(
-        env: Env,
-        admin: Address,
-        version: u32,
-        config_params: Vec<(String, String)>
-    ) -> Result<(), Error> {
+    pub fn initialize(env: Env, admin: Address) {
         admin.require_auth();
         if storage::is_initialized(&env) {
-            return Err(Error::AlreadyInitialized);
+            panic!("already initialized");
         }
-        let config = init::InitConfig {
-            admin: admin.clone(),
-            version,
-            config_params,
-        };
-        init::initialize(&env, config);
-        Ok(())
+        storage::set_contract_admin(&env, &admin);
+        storage::set_admin(&env, &admin);
+        storage::mark_initialized(&env);
     }
 
-    /// Authorize contract upgrade (admin only)
     pub fn authorize_upgrade(env: Env, caller: Address) -> Result<(), Error> {
         caller.require_auth();
         if !init::upgrade_authorize(&env, &caller) {
@@ -55,39 +44,32 @@ impl EarnQuestContract {
         Ok(())
     }
 
-    /// Get contract version
     pub fn get_version(env: Env) -> u32 {
         storage::get_version(&env)
     }
 
-    /// Get contract admin
     pub fn get_admin(env: Env) -> Address {
         storage::get_admin(&env)
     }
 
-    /// Get contract config
     pub fn get_config(env: Env) -> Vec<(String, String)> {
         storage::get_config(&env)
     }
 
-    /// Add a new admin (admin only)
     pub fn add_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), Error> {
         security::require_not_paused(&env)?;
         admin::add_admin(&env, &caller, &new_admin)
     }
 
-    /// Remove an admin (admin only)
     pub fn remove_admin(env: Env, caller: Address, admin_to_remove: Address) -> Result<(), Error> {
         security::require_not_paused(&env)?;
         admin::remove_admin(&env, &caller, &admin_to_remove)
     }
 
-    /// Check if an address is an admin
     pub fn is_admin(env: Env, address: Address) -> bool {
         admin::is_admin(&env, &address)
     }
 
-    /// Register a new quest with full input validation
     pub fn register_quest(
         env: Env,
         id: Symbol,
@@ -114,7 +96,6 @@ impl EarnQuestContract {
         )
     }
 
-    /// Register a new quest and attach metadata during creation.
     pub fn register_quest_with_metadata(
         env: Env,
         id: Symbol,
@@ -143,9 +124,6 @@ impl EarnQuestContract {
         )
     }
 
-    /// Register multiple quests in one transaction (gas-optimized).
-    /// Creator must authorize; all quests are registered to that creator.
-    /// Batch size is limited; on first error the entire batch reverts.
     pub fn register_quests_batch(
         env: Env,
         creator: Address,
@@ -153,11 +131,13 @@ impl EarnQuestContract {
     ) -> Result<(), Error> {
         security::require_not_paused(&env)?;
         creator.require_auth();
-        validation::validate_array_length(quests.len() as u32, validation::MAX_BATCH_QUEST_REGISTRATION)?;
+        validation::validate_array_length(
+            quests.len() as u32,
+            validation::MAX_BATCH_QUEST_REGISTRATION,
+        )?;
         quest::register_quests_batch(&env, &creator, &quests)
     }
 
-    /// Submit proof with input validation
     pub fn submit_proof(
         env: Env,
         quest_id: Symbol,
@@ -166,11 +146,9 @@ impl EarnQuestContract {
     ) -> Result<(), Error> {
         security::require_not_paused(&env)?;
         submitter.require_auth();
-
         submission::submit_proof(&env, &quest_id, &submitter, &proof_hash)
     }
 
-    /// Approve submission with status transition validation
     pub fn approve_submission(
         env: Env,
         quest_id: Symbol,
@@ -179,13 +157,9 @@ impl EarnQuestContract {
     ) -> Result<(), Error> {
         security::require_not_paused(&env)?;
         verifier.require_auth();
-
         submission::approve_submission(&env, &quest_id, &submitter, &verifier)
     }
 
-    /// Approve multiple submissions in one transaction (gas-optimized).
-    /// Verifier must authorize; all items must be for quests where this address is verifier.
-    /// Batch size is limited; on first error the entire batch reverts.
     pub fn approve_submissions_batch(
         env: Env,
         verifier: Address,
@@ -193,23 +167,16 @@ impl EarnQuestContract {
     ) -> Result<(), Error> {
         security::require_not_paused(&env)?;
         verifier.require_auth();
-
         submission::approve_submissions_batch(&env, &verifier, &submissions)
     }
 
-    /// Claim approved reward with full validation
     pub fn claim_reward(env: Env, quest_id: Symbol, submitter: Address) -> Result<(), Error> {
-        // 1. Auth
         security::require_not_paused(&env)?;
         submitter.require_auth();
-
-        // 2. Validate claim (status transitions, limits)
         submission::validate_claim(&env, &quest_id, &submitter)?;
 
-        // 3. Data Retrieval for payout
         let quest = storage::get_quest(&env, &quest_id)?;
 
-        // 4. Payout
         payout::transfer_reward_from_escrow(
             &env,
             &quest_id,
@@ -217,7 +184,6 @@ impl EarnQuestContract {
             &submitter,
             quest.reward_amount,
         )?;
-        // 5. State Update
         storage::update_submission_status(
             &env,
             &quest_id,
@@ -226,7 +192,6 @@ impl EarnQuestContract {
         )?;
         storage::increment_quest_claims(&env, &quest_id)?;
 
-        // EMIT EVENT: RewardClaimed
         events::reward_claimed(
             &env,
             quest_id.clone(),
@@ -235,44 +200,39 @@ impl EarnQuestContract {
             quest.reward_amount,
         );
 
-        // 6. Award XP for quest completion
         reputation::award_xp(&env, &submitter, 100)?;
 
         Ok(())
     }
 
-    /// Get user reputation stats
     pub fn get_user_stats(env: Env, user: Address) -> UserStats {
         reputation::get_user_stats(&env, &user)
     }
 
-    /// Grant a badge to a user (admin only) with array length validation
-    pub fn grant_badge(env: Env, admin: Address, user: Address, badge: Badge) -> Result<(), Error> {
+    pub fn grant_badge(
+        env: Env,
+        admin: Address,
+        user: Address,
+        badge: Badge,
+    ) -> Result<(), Error> {
         security::require_not_paused(&env)?;
-
-        // Validate badge count before granting
         let stats = storage::get_user_stats_or_default(&env, &user);
         validation::validate_badge_count(stats.badges.len())?;
-
         reputation::grant_badge(&env, &admin, &user, badge)
     }
 
-    /// Emergency: pause contract immediately (admin only)
     pub fn emergency_pause(env: Env, caller: Address) -> Result<(), Error> {
         security::emergency_pause(&env, &caller)
     }
 
-    /// Emergency: approve unpause (admin multisig approval)
     pub fn emergency_approve_unpause(env: Env, caller: Address) -> Result<(), Error> {
         security::emergency_approve_unpause(&env, &caller)
     }
 
-    /// Emergency: unpause contract after approvals and timelock
     pub fn emergency_unpause(env: Env, caller: Address) -> Result<(), Error> {
         security::emergency_unpause(&env, &caller)
     }
 
-    /// Emergency withdrawal when paused (admin only) with amount validation
     pub fn emergency_withdraw(
         env: Env,
         caller: Address,
@@ -280,18 +240,10 @@ impl EarnQuestContract {
         to: Address,
         amount: i128,
     ) -> Result<(), Error> {
-        // Validate withdraw amount range
         validation::validate_reward_amount(amount)?;
         security::emergency_withdraw(&env, &caller, &asset, &to, amount)
     }
 
-    /// Deposit tokens into escrow for a quest.
-    ///
-    /// The creator sends tokens to the contract, earmarked for this quest.
-    /// Can be called multiple times to add more funds (top-up).
-    ///
-    /// # Who can call: Quest creator only
-    /// # Token flow: Creator wallet → Contract
     pub fn deposit_escrow(
         env: Env,
         quest_id: Symbol,
@@ -304,41 +256,28 @@ impl EarnQuestContract {
         escrow::deposit(&env, &quest_id, &depositor, &token, amount)
     }
 
-    /// Cancel a quest and refund remaining escrow to creator.
-    ///
-    /// # Who can call: Quest creator only
-    /// # Requires: Quest is Active or Paused
-    /// # Token flow: Contract → Creator wallet (remaining balance)
-    /// # Returns: Amount refunded
     pub fn cancel_quest(env: Env, quest_id: Symbol, creator: Address) -> Result<i128, Error> {
         security::require_not_paused(&env)?;
         creator.require_auth();
         escrow::cancel_quest(&env, &quest_id, &creator)
     }
 
-    /// Withdraw unclaimed escrow from a finished quest.
-    ///
-    /// # Who can call: Quest creator only
-    /// # Requires: Quest is Completed, Expired, or Cancelled
-    /// # Token flow: Contract → Creator wallet (remaining balance)
-    /// # Returns: Amount withdrawn
-    pub fn withdraw_unclaimed(env: Env, quest_id: Symbol, creator: Address) -> Result<i128, Error> {
+    pub fn withdraw_unclaimed(
+        env: Env,
+        quest_id: Symbol,
+        creator: Address,
+    ) -> Result<i128, Error> {
         security::require_not_paused(&env)?;
         creator.require_auth();
         escrow::withdraw_unclaimed(&env, &quest_id, &creator)
     }
 
-    /// Expire a quest whose deadline has passed and refund remaining escrow.
-    ///
-    /// # Who can call: Quest creator only
-    /// # Requires: Quest is Active or Paused AND deadline has passed
-    /// # Token flow: Contract → Creator wallet (remaining balance)
-    /// # Returns: Amount refunded
     pub fn expire_quest(env: Env, quest_id: Symbol, creator: Address) -> Result<i128, Error> {
         security::require_not_paused(&env)?;
         creator.require_auth();
         escrow::expire_quest(&env, &quest_id, &creator)
-    /// Update quest metadata (quest creator or admin).
+    }
+
     pub fn update_quest_metadata(
         env: Env,
         quest_id: Symbol,
@@ -350,33 +289,97 @@ impl EarnQuestContract {
         quest::update_quest_metadata(&env, &quest_id, &updater, &metadata)
     }
 
-    /// Query quest metadata.
     pub fn get_quest_metadata(env: Env, quest_id: Symbol) -> Result<QuestMetadata, Error> {
         storage::get_quest_metadata(&env, &quest_id)
     }
 
-    /// Check whether metadata exists for a quest.
     pub fn has_quest_metadata(env: Env, quest_id: Symbol) -> bool {
         storage::has_quest_metadata(&env, &quest_id)
     }
 
-    /// Query the available escrow balance for a quest.
     pub fn get_escrow_balance(env: Env, quest_id: Symbol) -> Result<i128, Error> {
         escrow::get_balance(&env, &quest_id)
     }
 
-    /// Query the full escrow info for a quest.
     pub fn get_escrow_info(env: Env, quest_id: Symbol) -> Result<EscrowInfo, Error> {
         escrow::get_info(&env, &quest_id)
     }
 
-    /// Admin: set unpause approvals threshold
-    pub fn set_unpause_threshold(env: Env, caller: Address, threshold: u32) -> Result<(), Error> {
+    pub fn set_unpause_threshold(
+        env: Env,
+        caller: Address,
+        threshold: u32,
+    ) -> Result<(), Error> {
         security::set_unpause_threshold(&env, &caller, threshold)
     }
 
-    /// Admin: set unpause timelock seconds
     pub fn set_unpause_timelock(env: Env, caller: Address, seconds: u64) -> Result<(), Error> {
         security::set_unpause_timelock(&env, &caller, seconds)
+    }
+
+    //================================================================================
+    // Quest Query Functions
+    //================================================================================
+
+    pub fn get_quests_by_status(
+        env: Env,
+        status: QuestStatus,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Quest> {
+        quest::get_quests_by_status(&env, &status, offset, limit)
+    }
+
+    pub fn get_quests_by_creator(
+        env: Env,
+        creator: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Quest> {
+        quest::get_quests_by_creator(&env, &creator, offset, limit)
+    }
+
+    pub fn get_active_quests(env: Env, offset: u32, limit: u32) -> Vec<Quest> {
+        quest::get_active_quests(&env, offset, limit)
+    }
+
+    pub fn get_quests_by_reward_range(
+        env: Env,
+        min_reward: i128,
+        max_reward: i128,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Quest> {
+        quest::get_quests_by_reward_range(&env, min_reward, max_reward, offset, limit)
+    }
+
+    //================================================================================
+    // Platform & Creator Stats
+    //================================================================================
+
+    pub fn get_platform_stats(env: Env) -> PlatformStats {
+        storage::get_platform_stats(&env)
+    }
+
+    pub fn get_creator_stats(env: Env, creator: Address) -> CreatorStats {
+        storage::get_creator_stats(&env, &creator)
+    }
+
+    pub fn reset_platform_stats(env: Env, caller: Address) -> Result<(), Error> {
+        caller.require_auth();
+        if !storage::is_admin(&env, &caller) {
+            return Err(Error::Unauthorized);
+        }
+        storage::set_platform_stats(
+            &env,
+            &PlatformStats {
+                total_quests_created: 0,
+                total_submissions: 0,
+                total_rewards_distributed: 0,
+                total_active_users: 0,
+                total_rewards_claimed: 0,
+            },
+        );
+        Ok(())
     }
 }

--- a/contracts/earn-quest/src/types.rs
+++ b/contracts/earn-quest/src/types.rs
@@ -133,14 +133,23 @@ pub struct EscrowInfo {
     pub created_at: u64,
     /// Number of deposits made (1 = initial, >1 = top-ups)
     pub deposit_count: u32,
-pub struct CreatorStats {
-    /// Total quests created by this address.
-    pub quests_created: u64,
-    /// Sum of `reward_amount` across all quests created by this address.
-    pub total_rewards_posted: u128,
-    /// Total submissions received across all of this creator's quests.
-    pub total_submissions_received: u64,
-    /// Total successful claims paid out across all of this creator's quests.
-    pub total_claims_paid: u64,
+}
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreatorStats {
+    pub quests_created: u64,
+    pub total_rewards_posted: u128,
+    pub total_submissions_received: u64,
+    pub total_claims_paid: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlatformStats {
+    pub total_quests_created: u64,
+    pub total_submissions: u64,
+    pub total_rewards_distributed: u128,
+    pub total_active_users: u64,
+    pub total_rewards_claimed: u64,
 }

--- a/contracts/earn-quest/tests/test_queries.rs
+++ b/contracts/earn-quest/tests/test_queries.rs
@@ -1,0 +1,268 @@
+#![cfg(test)]
+
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+extern crate earn_quest;
+use earn_quest::types::QuestStatus;
+use earn_quest::{EarnQuestContract, EarnQuestContractClient};
+
+fn setup(env: &Env) -> EarnQuestContractClient<'_> {
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    EarnQuestContractClient::new(env, &contract_id)
+}
+
+fn register(
+    client: &EarnQuestContractClient,
+    env: &Env,
+    id: soroban_sdk::Symbol,
+    creator: &Address,
+    reward: i128,
+) {
+    let token = Address::generate(env);
+    let verifier = Address::generate(env);
+    client.register_quest(&id, creator, &token, &reward, &verifier, &99999u64);
+}
+
+//================================================================================
+// get_active_quests
+//================================================================================
+
+#[test]
+fn test_get_active_quests_returns_all_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("Q1"), &creator, 100);
+    register(&client, &env, symbol_short!("Q2"), &creator, 200);
+    register(&client, &env, symbol_short!("Q3"), &creator, 300);
+
+    let results = client.get_active_quests(&0, &10);
+    assert_eq!(results.len(), 3);
+}
+
+#[test]
+fn test_get_active_quests_empty_when_none_registered() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let results = client.get_active_quests(&0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+//================================================================================
+// get_quests_by_status
+//================================================================================
+
+#[test]
+fn test_get_quests_by_status_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("QA"), &creator, 500);
+    register(&client, &env, symbol_short!("QB"), &creator, 500);
+
+    let active = client.get_quests_by_status(&QuestStatus::Active, &0, &10);
+    assert_eq!(active.len(), 2);
+}
+
+#[test]
+fn test_get_quests_by_status_no_match_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("QA"), &creator, 500);
+
+    let expired = client.get_quests_by_status(&QuestStatus::Expired, &0, &10);
+    assert_eq!(expired.len(), 0);
+}
+
+#[test]
+fn test_get_quests_by_status_cancelled_returns_empty_when_none_cancelled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("QC"), &creator, 100);
+
+    let cancelled = client.get_quests_by_status(&QuestStatus::Cancelled, &0, &10);
+    assert_eq!(cancelled.len(), 0);
+}
+
+//================================================================================
+// get_quests_by_creator
+//================================================================================
+
+#[test]
+fn test_get_quests_by_creator_returns_only_creator_quests() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator_a = Address::generate(&env);
+    let creator_b = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("A1"), &creator_a, 100);
+    register(&client, &env, symbol_short!("A2"), &creator_a, 200);
+    register(&client, &env, symbol_short!("B1"), &creator_b, 300);
+
+    let results_a = client.get_quests_by_creator(&creator_a, &0, &10);
+    assert_eq!(results_a.len(), 2);
+
+    let results_b = client.get_quests_by_creator(&creator_b, &0, &10);
+    assert_eq!(results_b.len(), 1);
+}
+
+#[test]
+fn test_get_quests_by_creator_unknown_creator_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+    let unknown = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("Q1"), &creator, 100);
+
+    let results = client.get_quests_by_creator(&unknown, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+//================================================================================
+// get_quests_by_reward_range
+//================================================================================
+
+#[test]
+fn test_get_quests_by_reward_range_filters_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("R1"), &creator, 100);
+    register(&client, &env, symbol_short!("R2"), &creator, 500);
+    register(&client, &env, symbol_short!("R3"), &creator, 1000);
+
+    let results = client.get_quests_by_reward_range(&100, &500, &0, &10);
+    assert_eq!(results.len(), 2);
+}
+
+#[test]
+fn test_get_quests_by_reward_range_exact_match() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("E1"), &creator, 250);
+    register(&client, &env, symbol_short!("E2"), &creator, 750);
+
+    let results = client.get_quests_by_reward_range(&250, &250, &0, &10);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.get(0).unwrap().reward_amount, 250);
+}
+
+#[test]
+fn test_get_quests_by_reward_range_no_match_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("N1"), &creator, 1000);
+
+    let results = client.get_quests_by_reward_range(&1, &100, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+//================================================================================
+// Pagination
+//================================================================================
+
+#[test]
+fn test_pagination_limit_respected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("P1"), &creator, 100);
+    register(&client, &env, symbol_short!("P2"), &creator, 200);
+    register(&client, &env, symbol_short!("P3"), &creator, 300);
+    register(&client, &env, symbol_short!("P4"), &creator, 400);
+    register(&client, &env, symbol_short!("P5"), &creator, 500);
+
+    let page1 = client.get_active_quests(&0, &2);
+    assert_eq!(page1.len(), 2);
+
+    let page2 = client.get_active_quests(&2, &2);
+    assert_eq!(page2.len(), 2);
+
+    let page3 = client.get_active_quests(&4, &2);
+    assert_eq!(page3.len(), 1);
+}
+
+#[test]
+fn test_pagination_offset_beyond_results_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("O1"), &creator, 100);
+    register(&client, &env, symbol_short!("O2"), &creator, 200);
+
+    let results = client.get_active_quests(&10, &10);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_pagination_zero_limit_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("Z1"), &creator, 100);
+
+    let results = client.get_active_quests(&0, &0);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_creator_query_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("C1"), &creator, 100);
+    register(&client, &env, symbol_short!("C2"), &creator, 200);
+    register(&client, &env, symbol_short!("C3"), &creator, 300);
+
+    let first = client.get_quests_by_creator(&creator, &0, &2);
+    assert_eq!(first.len(), 2);
+
+    let second = client.get_quests_by_creator(&creator, &2, &2);
+    assert_eq!(second.len(), 1);
+}
+
+#[test]
+fn test_reward_range_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register(&client, &env, symbol_short!("W1"), &creator, 100);
+    register(&client, &env, symbol_short!("W2"), &creator, 200);
+    register(&client, &env, symbol_short!("W3"), &creator, 300);
+
+    let page = client.get_quests_by_reward_range(&100, &300, &1, &1);
+    assert_eq!(page.len(), 1);
+}


### PR DESCRIPTION
Summary

  - Adds get_quests_by_status(), get_quests_by_creator(), get_active_quests(), and get_quests_by_reward_range() query functions with    
  offset/limit pagination support
  - Maintains a QuestIds index in storage so quests can be iterated without scanning all keys
  - Fixes corrupted/incomplete code in quest.rs, lib.rs, types.rs, events.rs, and init.rs left from prior merge conflicts
  - Adds missing storage helpers (is_initialized, mark_initialized, get_admin, set_contract_admin, get_version, set_version, get_config,   set_config, get_platform_stats, get_creator_stats)
  - Exposes get_platform_stats, get_creator_stats, and reset_platform_stats contract methods
  
  closes #106 