### PR TITLE
feat(contract): add dispute resolution mechanism

### DIFF
--- a/Contract/earn-quest/src/dispute.rs
+++ b/Contract/earn-quest/src/dispute.rs
@@ -1,0 +1,64 @@
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+use crate::errors::Error;
+
+/// Lifecycle status of a dispute
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeStatus {
+    /// Dispute has been filed and awaits review
+    Pending,
+    /// Evidence is actively being reviewed
+    UnderReview,
+    /// A final decision has been reached
+    Resolved,
+    /// Dispute was withdrawn by the initiator
+    Withdrawn,
+}
+
+/// A dispute record for a contested quest submission
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Dispute {
+    /// Quest the dispute relates to
+    pub quest_id: Symbol,
+    /// Address of the user who filed the dispute
+    pub initiator: Address,
+    /// Address of the assigned arbitrator
+    pub arbitrator: Address,
+    /// Current dispute status
+    pub status: DisputeStatus,
+    /// Ledger timestamp when the dispute was filed
+    pub filed_at: u64,
+}
+
+/// Open a new dispute for a rejected submission.
+///
+/// Requires authentication from the initiator.
+pub fn open_dispute(
+    env: &Env,
+    quest_id: Symbol,
+    initiator: Address,
+    arbitrator: Address,
+) -> Result<Dispute, Error> {
+    initiator.require_auth();
+    Ok(Dispute {
+        quest_id,
+        initiator,
+        arbitrator,
+        status: DisputeStatus::Pending,
+        filed_at: env.ledger().timestamp(),
+    })
+}
+
+/// Resolve an open dispute.
+///
+/// Requires authentication from the assigned arbitrator.
+pub fn resolve_dispute(dispute: &mut Dispute, arbitrator: &Address) -> Result<(), Error> {
+    arbitrator.require_auth();
+    if dispute.status != DisputeStatus::Pending && dispute.status != DisputeStatus::UnderReview {
+        return Err(Error::InvalidQuestStatus);
+    }
+    dispute.status = DisputeStatus::Resolved;
+    Ok(())
+}

--- a/Contract/earn-quest/src/lib.rs
+++ b/Contract/earn-quest/src/lib.rs
@@ -3,6 +3,7 @@
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol};
 
 mod admin;
+pub mod dispute;
 mod errors;
 mod escrow;
 mod init;


### PR DESCRIPTION
## Summary

- Add `DisputeStatus` enum (Pending, UnderReview, Resolved, Withdrawn)
- Add `Dispute` struct linking quest, initiator, and arbitrator with a filed timestamp
- Expose `open_dispute` (requires initiator auth) and `resolve_dispute` (requires arbitrator auth) helpers

closes #203