### PR TITLE
refactor: fix hook dependency arrays and resolve linting errors

### DIFF
--- a/FrontEnd/my-app/lib/hooks/useQuests.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuests.ts
@@ -63,7 +63,8 @@ export function useQuests(
     setQuestsLoading,
     setQuestsError,
     setQuests,
-    setPagination
+    setPagination,
+    getQuests
   ]);
 
   useEffect(() => {

--- a/FrontEnd/my-app/lib/hooks/useQuests.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuests.ts
@@ -57,7 +57,14 @@ export function useQuests(
     } finally {
       setQuestsLoading(false);
     }
-  }, [memoizedFilters, memoizedPagination]);
+  }, [
+    memoizedFilters,
+    memoizedPagination,
+    setQuestsLoading,
+    setQuestsError,
+    setQuests,
+    setPagination
+  ]);
 
   useEffect(() => {
     fetchQuests();

--- a/FrontEnd/my-app/lib/hooks/useQuests.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuests.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import { useStore } from '@/lib/store';
 import { getQuests } from '@/lib/api/quests';
 import type { QuestQueryParams, PaginationParams } from '@/lib/types/api.types';
@@ -18,12 +18,31 @@ export function useQuests(
   const setQuestsError   = useStore((s) => s.setQuestsError);
   const setPagination    = useStore((s) => s.setQuestPagination);
 
+  // Memoize filters to avoid unnecessary re-renders when the object reference changes
+  // but the values remain the same.
+  const memoizedFilters = useMemo(() => filters, [
+    filters?.status,
+    filters?.category,
+    filters?.difficulty,
+    filters?.search,
+    filters?.minReward,
+    filters?.maxReward,
+    filters?.sortBy,
+    filters?.order,
+  ]);
+
+  const memoizedPagination = useMemo(() => pagination, [
+    pagination?.page,
+    pagination?.limit,
+    pagination?.cursor,
+  ]);
+
   const fetchQuests = useCallback(async () => {
     try {
       setQuestsLoading(true);
       setQuestsError(null);
 
-      const response = await getQuests({ ...filters, ...pagination });
+      const response = await getQuests({ ...memoizedFilters, ...memoizedPagination });
       setQuests(response.quests as any);
       setPagination({
         page: response.page ?? 1,
@@ -38,7 +57,7 @@ export function useQuests(
     } finally {
       setQuestsLoading(false);
     }
-  }, [JSON.stringify(filters), JSON.stringify(pagination)]);
+  }, [memoizedFilters, memoizedPagination]);
 
   useEffect(() => {
     fetchQuests();

--- a/FrontEnd/my-app/lib/hooks/useSubmissions.ts
+++ b/FrontEnd/my-app/lib/hooks/useSubmissions.ts
@@ -59,7 +59,8 @@ export function useSubmissions(
     setLoading,
     setError,
     setSubmissions,
-    setPagination
+    setPagination,
+    fetchSubmissions
   ]);
 
   useEffect(() => {

--- a/FrontEnd/my-app/lib/hooks/useSubmissions.ts
+++ b/FrontEnd/my-app/lib/hooks/useSubmissions.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import { useStore } from '@/lib/store';
 import { fetchSubmissions } from '@/lib/api/submissions';
 import type { SubmissionFilters, PaginationParams } from '@/lib/types/submission';
@@ -21,15 +21,22 @@ export function useSubmissions(
   const setFilters         = useStore((s) => s.setSubmissionFilters);
   const optimisticUpdate   = useStore((s) => s.optimisticallyUpdateSubmission);
 
+  const memoizedFilters = useMemo(() => filters, [filters?.status]);
+  const memoizedInitialPagination = useMemo(() => initialPagination, [
+    initialPagination?.page,
+    initialPagination?.limit,
+    initialPagination?.cursor,
+  ]);
+
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
 
     try {
-      const response = await fetchSubmissions(filters as any, {
+      const response = await fetchSubmissions(memoizedFilters as any, {
         page:   pagination.page,
         limit:  pagination.limit,
-        ...initialPagination,
+        ...memoizedInitialPagination,
       });
 
       setSubmissions(response.data as any);
@@ -44,11 +51,11 @@ export function useSubmissions(
     } finally {
       setLoading(false);
     }
-  }, [filters?.status, pagination.page, pagination.limit]);
+  }, [memoizedFilters, pagination.page, pagination.limit, memoizedInitialPagination]);
 
   useEffect(() => {
-    if (filters) setFilters(filters);
-  }, [filters?.status]);
+    if (memoizedFilters) setFilters(memoizedFilters);
+  }, [memoizedFilters, setFilters]);
 
   useEffect(() => {
     load();

--- a/FrontEnd/my-app/lib/hooks/useSubmissions.ts
+++ b/FrontEnd/my-app/lib/hooks/useSubmissions.ts
@@ -51,7 +51,16 @@ export function useSubmissions(
     } finally {
       setLoading(false);
     }
-  }, [memoizedFilters, pagination.page, pagination.limit, memoizedInitialPagination]);
+  }, [
+    memoizedFilters,
+    pagination.page,
+    pagination.limit,
+    memoizedInitialPagination,
+    setLoading,
+    setError,
+    setSubmissions,
+    setPagination
+  ]);
 
   useEffect(() => {
     if (memoizedFilters) setFilters(memoizedFilters);

--- a/FrontEnd/my-app/lib/hooks/useSubmissions.ts
+++ b/FrontEnd/my-app/lib/hooks/useSubmissions.ts
@@ -72,11 +72,11 @@ export function useSubmissions(
 
   const goToPage = useCallback((page: number) => {
     setPagination({ page });
-  }, []);
+  }, [setPagination]);
 
   const loadMore = useCallback(() => {
     if (pagination.hasMore) setPagination({ page: pagination.page + 1 });
-  }, [pagination.hasMore, pagination.page]);
+  }, [pagination.hasMore, pagination.page, setPagination]);
 
   return {
     submissions,


### PR DESCRIPTION
Closes #229 

## Overview
This PR addresses issue #229 by removing `JSON.stringify` from dependency arrays and implementing proper memoization. It also fixes all exhaustive dependency linting warnings in the affected hooks.

## Changes
- Replaced `JSON.stringify` with `useMemo` for filters and pagination.
- Added all missing dependencies to `useCallback` and `useEffect`.
- Ensured stable callback creation for navigation actions.

