### PR TITLE
feat(security): implement commit-reveal scheme for front-running prevention

### DIFF
--- a/contracts/earn-quest/src/errors.rs
+++ b/contracts/earn-quest/src/errors.rs
@@ -64,4 +64,19 @@ pub enum Error {
     DisputeNotPending = 83,
     DisputeNotAuthorized = 84,
     DisputeAlreadyResolved = 85,
+
+    // Oracle Errors
+    OracleInactive = 90,
+    NoValidOracleData = 91,
+    InvalidOracleConfiguration = 92,
+    OracleResponseMismatch = 93,
+    StaleOracleData = 94,
+    InvalidOracleData = 95,
+    InsufficientOracleConfidence = 96,
+    OracleAlreadyExists = 97,
+    OracleNotFound = 98,
+
+    // Commitment Errors (Front-running prevention)
+    CommitmentNotFound = 100,
+    InvalidCommitment = 101,
 }

--- a/contracts/earn-quest/src/events.rs
+++ b/contracts/earn-quest/src/events.rs
@@ -24,6 +24,8 @@ const TOPIC_DISPUTE_WITHDRAWN: Symbol = symbol_short!("disp_wd");
 const TOPIC_ESCROW_DEPOSITED: Symbol = symbol_short!("esc_dep");
 const TOPIC_ESCROW_PAYOUT: Symbol = symbol_short!("esc_pay");
 const TOPIC_ESCROW_REFUNDED: Symbol = symbol_short!("esc_ref");
+const TOPIC_COMMITMENT_SUBMITTED: Symbol = symbol_short!("com_sub");
+const TOPIC_SUBMISSION_REVEALED: Symbol = symbol_short!("sub_rev");
 
 // ═══════════════════════════════════════════════════════════════
 // Enhanced Event Emission with Indexing for Subgraph/Indexer Integration
@@ -337,5 +339,17 @@ pub fn dispute_resolved(env: &Env, quest_id: Symbol, initiator: Address, arbitra
 pub fn dispute_withdrawn(env: &Env, quest_id: Symbol, initiator: Address) {
     let topics = (TOPIC_DISPUTE_WITHDRAWN, quest_id, initiator.clone());
     let data = ();
+    env.events().publish(topics, data);
+}
+
+pub fn commitment_submitted(env: &Env, quest_id: Symbol, submitter: Address, hash: BytesN<32>) {
+    let topics = (TOPIC_COMMITMENT_SUBMITTED, quest_id, submitter);
+    let data = (hash,);
+    env.events().publish(topics, data);
+}
+
+pub fn submission_revealed(env: &Env, quest_id: Symbol, submitter: Address, proof_hash: BytesN<32>) {
+    let topics = (TOPIC_SUBMISSION_REVEALED, quest_id, submitter);
+    let data = (proof_hash,);
     env.events().publish(topics, data);
 }

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -17,7 +17,7 @@ pub mod types;
 pub mod validation;
 
 use crate::errors::Error;
-use crate::types::{Badge, BatchApprovalInput, BatchQuestInput, CreatorStats, Dispute, EscrowInfo, PlatformStats, Quest, QuestMetadata, QuestStatus, UserStats, Submission};
+use crate::types::{Badge, BatchApprovalInput, BatchQuestInput, CreatorStats, Dispute, EscrowInfo, PlatformStats, Quest, QuestMetadata, QuestStatus, UserStats, Submission, Commitment};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
 
 #[contract]
@@ -149,6 +149,31 @@ impl EarnQuestContract {
         security::require_not_paused(&env)?;
         admin::require_admin(&env, &caller)?;
         quest::resume_quest(&env, &quest_id, &caller)
+    }
+
+    /// Commit to a submission (Front-running prevention)
+    pub fn commit_submission(
+        env: Env,
+        quest_id: Symbol,
+        submitter: Address,
+        commitment_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        security::require_not_paused(&env)?;
+        submitter.require_auth();
+        submission::commit_submission(&env, &quest_id, &submitter, &commitment_hash)
+    }
+
+    /// Reveal submission details (Front-running prevention)
+    pub fn reveal_submission(
+        env: Env,
+        quest_id: Symbol,
+        submitter: Address,
+        proof_hash: BytesN<32>,
+        salt: BytesN<32>,
+    ) -> Result<(), Error> {
+        security::require_not_paused(&env)?;
+        submitter.require_auth();
+        submission::reveal_submission(&env, &quest_id, &submitter, &proof_hash, &salt)
     }
 
     /// Submit proof with input validation

--- a/contracts/earn-quest/src/storage.rs
+++ b/contracts/earn-quest/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::errors::Error;
-use crate::types::{Quest, QuestStatus, Submission, SubmissionStatus, UserStats, EscrowInfo, QuestMetadata, PlatformStats, CreatorStats, OracleConfig};
+use crate::types::{Quest, QuestStatus, Submission, SubmissionStatus, UserStats, EscrowInfo, QuestMetadata, PlatformStats, CreatorStats, OracleConfig, Commitment};
 use crate::validation;
 use soroban_sdk::{contracttype, Address, Env, Symbol, Vec, String};
 
@@ -67,6 +67,8 @@ pub enum DataKey {
     ReentrancyGuard,
     /// Dispute record keyed by (quest_id, initiator)
     Dispute(Symbol, Address),
+    /// Commitment record for front-running prevention, keyed by (quest_id, submitter)
+    Commitment(Symbol, Address),
 }
 
 //================================================================================
@@ -836,6 +838,35 @@ pub fn get_escrow(env: &Env, quest_id: &Symbol) -> Result<EscrowInfo, Error> {
         created_at: meta.created_at,
         deposit_count: balances.deposit_count,
     })
+}
+
+//================================================================================
+// Commitment Storage Functions
+//================================================================================
+
+pub fn has_commitment(env: &Env, quest_id: &Symbol, submitter: &Address) -> bool {
+    env.storage()
+        .instance()
+        .has(&DataKey::Commitment(quest_id.clone(), submitter.clone()))
+}
+
+pub fn get_commitment(env: &Env, quest_id: &Symbol, submitter: &Address) -> Result<Commitment, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Commitment(quest_id.clone(), submitter.clone()))
+        .ok_or(Error::CommitmentNotFound)
+}
+
+pub fn set_commitment(env: &Env, quest_id: &Symbol, submitter: &Address, commitment: &Commitment) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Commitment(quest_id.clone(), submitter.clone()), commitment);
+}
+
+pub fn delete_commitment(env: &Env, quest_id: &Symbol, submitter: &Address) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::Commitment(quest_id.clone(), submitter.clone()));
 }
 
 /// Delete both escrow entries for a quest (cleanup after terminal state)

--- a/contracts/earn-quest/src/submission.rs
+++ b/contracts/earn-quest/src/submission.rs
@@ -1,9 +1,106 @@
 use crate::errors::Error;
 use crate::events;
 use crate::storage;
-use crate::types::{BatchApprovalInput, EscrowInfo, Submission, SubmissionStatus};
+use crate::types::{BatchApprovalInput, Commitment, EscrowInfo, Submission, SubmissionStatus};
 use crate::validation;
-use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env, Symbol, Vec};
+
+/// Commit to a submission by providing a hash of the proof and a secret salt.
+/// This prevents front-running by hiding the actual proof until the reveal phase.
+///
+/// Validates:
+/// - Quest exists and is Active
+/// - Quest has not expired
+/// - User does not already have a submission or commitment
+pub fn commit_submission(
+    env: &Env,
+    quest_id: &Symbol,
+    submitter: &Address,
+    commitment_hash: &BytesN<32>,
+) -> Result<(), Error> {
+    // Verify quest exists and get its data
+    let quest = storage::get_quest(env, quest_id)?;
+    // Validate quest is active
+    validation::validate_quest_is_active(&quest.status)?;
+    // Validate quest has not expired
+    validation::validate_quest_not_expired(env, quest.deadline)?;
+
+    // Check for existing submission to prevent double submission
+    if storage::has_submission(env, quest_id, submitter) {
+        return Err(Error::AlreadyClaimed);
+    }
+
+    // Check for existing commitment
+    if storage::has_commitment(env, quest_id, submitter) {
+        return Err(Error::AlreadyApproved);
+    }
+
+    let commitment = Commitment {
+        hash: commitment_hash.clone(),
+        timestamp: env.ledger().timestamp(),
+    };
+
+    storage::set_commitment(env, quest_id, submitter, &commitment);
+
+    // EMIT EVENT: CommitmentSubmitted
+    events::commitment_submitted(
+        env,
+        quest_id.clone(),
+        submitter.clone(),
+        commitment_hash.clone(),
+    );
+
+    Ok(())
+}
+
+/// Reveal the proof and salt to complete the submission process.
+/// The contract verifies that hash(proof_hash + salt + submitter) matches the commitment.
+///
+/// Validates:
+/// - Commitment exists for the user
+/// - Provided proof and salt match the stored commitment
+pub fn reveal_submission(
+    env: &Env,
+    quest_id: &Symbol,
+    submitter: &Address,
+    proof_hash: &BytesN<32>,
+    salt: &BytesN<32>,
+) -> Result<(), Error> {
+    // 1. Retrieve the stored commitment
+    let commitment = storage::get_commitment(env, quest_id, submitter)?;
+
+    // 2. Verify the commitment: hash(proof_hash + salt + submitter_xdr)
+    let mut data = Bytes::new(env);
+    data.append(&proof_hash.clone().into());
+    data.append(&salt.clone().into());
+    data.append(&submitter.to_xdr(env));
+
+    let calculated_hash = env.crypto().sha256(&data);
+
+    if calculated_hash != commitment.hash {
+        return Err(Error::InvalidCommitment);
+    }
+
+    // 3. Create the actual submission
+    let submission = Submission {
+        quest_id: quest_id.clone(),
+        submitter: submitter.clone(),
+        proof_hash: proof_hash.clone(),
+        status: SubmissionStatus::Pending,
+        timestamp: env.ledger().timestamp(),
+    };
+
+    storage::set_submission(env, quest_id, submitter, &submission);
+
+    // 4. Cleanup the commitment to free up storage
+    storage::delete_commitment(env, quest_id, submitter);
+
+    // 5. EMIT EVENTS
+    events::submission_revealed(env, quest_id.clone(), submitter.clone(), proof_hash.clone());
+    events::proof_submitted(env, quest_id.clone(), submitter.clone(), proof_hash.clone());
+
+    Ok(())
+}
 
 /// Submit proof for a quest with full input validation.
 ///

--- a/contracts/earn-quest/src/types.rs
+++ b/contracts/earn-quest/src/types.rs
@@ -93,6 +93,13 @@ pub struct Dispute {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Commitment {
+    pub hash: BytesN<32>,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UserStats {
     pub xp: u64,
     /// Current user level (1–5)

--- a/contracts/earn-quest/tests/test_submission_security.rs
+++ b/contracts/earn-quest/tests/test_submission_security.rs
@@ -1,0 +1,150 @@
+#![cfg(test)]
+
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Bytes, BytesN, Env, xdr::ToXdr};
+
+// Import from the library
+extern crate earn_quest;
+use earn_quest::{EarnQuestContract, EarnQuestContractClient};
+
+#[test]
+fn test_commit_reveal_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    // Setup
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let quest_id = symbol_short!("Q1");
+    let asset = Address::generate(&env);
+
+    client.register_quest(&quest_id, &creator, &asset, &100, &verifier, &10000);
+
+    // 1. Prepare commitment
+    // In a real scenario, user does this off-chain
+    let proof_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let salt = BytesN::from_array(&env, &[2u8; 32]);
+    
+    let mut data = Bytes::new(&env);
+    data.append(&proof_hash.clone().into());
+    data.append(&salt.clone().into());
+    data.append(&submitter.to_xdr(&env));
+    let commitment_hash = env.crypto().sha256(&data);
+
+    // 2. Commit
+    client.commit_submission(&quest_id, &submitter, &commitment_hash);
+
+    // 3. Reveal
+    client.reveal_submission(&quest_id, &submitter, &proof_hash, &salt);
+
+    // 4. Verify submission exists and is in Pending status
+    let submission = client.get_submission(&quest_id, &submitter);
+    assert_eq!(submission.proof_hash, proof_hash);
+    
+    // 5. Verify commitment is deleted (reveal again should fail)
+    let res = client.try_reveal_submission(&quest_id, &submitter, &proof_hash, &salt);
+    assert!(res.is_err(), "Commitment should be deleted after reveal");
+}
+
+#[test]
+fn test_reveal_with_invalid_salt_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let quest_id = symbol_short!("Q2");
+    let asset = Address::generate(&env);
+
+    client.register_quest(&quest_id, &creator, &asset, &100, &verifier, &10000);
+
+    let proof_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let salt = BytesN::from_array(&env, &[2u8; 32]);
+    let wrong_salt = BytesN::from_array(&env, &[3u8; 32]);
+    
+    let mut data = Bytes::new(&env);
+    data.append(&proof_hash.clone().into());
+    data.append(&salt.clone().into());
+    data.append(&submitter.to_xdr(&env));
+    let commitment_hash = env.crypto().sha256(&data);
+
+    client.commit_submission(&quest_id, &submitter, &commitment_hash);
+
+    // Reveal with wrong salt should fail
+    let res = client.try_reveal_submission(&quest_id, &submitter, &proof_hash, &wrong_salt);
+    assert!(res.is_err(), "Reveal with wrong salt must fail");
+}
+
+#[test]
+fn test_front_running_prevention() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let quest_id = symbol_short!("Q3");
+    let asset = Address::generate(&env);
+
+    client.register_quest(&quest_id, &creator, &asset, &100, &verifier, &10000);
+
+    // Submitter commits
+    let proof_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let salt = BytesN::from_array(&env, &[2u8; 32]);
+    
+    let mut data = Bytes::new(&env);
+    data.append(&proof_hash.clone().into());
+    data.append(&salt.clone().into());
+    data.append(&submitter.to_xdr(&env));
+    let commitment_hash = env.crypto().sha256(&data);
+
+    client.commit_submission(&quest_id, &submitter, &commitment_hash);
+
+    // Attacker tries to reveal the same proof_hash and salt for themselves
+    // but they haven't committed anything.
+    let res = client.try_reveal_submission(&quest_id, &attacker, &proof_hash, &salt);
+    assert!(res.is_err(), "Attacker cannot reveal without a commitment");
+
+    // Even if attacker tries to use the same proof_hash and salt, they would need 
+    // to have committed hash(proof_hash, salt, attacker) earlier.
+    // If they try to reveal with the SUBMITTER's address (impersonation), require_auth will stop them.
+    // If they use their own address, the hash won't match the commitment if they managed to steal it,
+    // or they simply won't have a commitment record.
+}
+
+#[test]
+fn test_double_commitment_prevention() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let quest_id = symbol_short!("Q4");
+    let asset = Address::generate(&env);
+
+    client.register_quest(&quest_id, &creator, &asset, &100, &verifier, &10000);
+
+    let hash1 = BytesN::from_array(&env, &[1u8; 32]);
+    let hash2 = BytesN::from_array(&env, &[2u8; 32]);
+
+    client.commit_submission(&quest_id, &submitter, &hash1);
+    
+    // Second commit should fail
+    let res = client.try_commit_submission(&quest_id, &submitter, &hash2);
+    assert!(res.is_err(), "Should not allow double commitment");
+}


### PR DESCRIPTION
This PR implements a commit-reveal scheme for quest submissions to prevent front-running and MEV attacks. Users now commit a hash of their proof and a secret salt, tied to their address, before revealing the proof in a second step.

  Changes:
   * New Commitment data structure and storage tracking.
   * commit_submission and reveal_submission functions.
   * Cryptographic verification of commitments using SHA-256.
   * Security events for commitment tracking.
   * Comprehensive security test suite.

  How to test:
  Run cargo test --test test_submission_security.

  Notes:
  This change is essential for the integrity of the reward system, ensuring that only the original prover can claim the rewards associated with their proof.

  Closes #272 