### PR TITLE
test: add multisig edge case and payout service test coverage

### DIFF
--- a/BackEnd/package-lock.json
+++ b/BackEnd/package-lock.json
@@ -78,6 +78,7 @@
         "eslint": "^10.0.1",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
+        "fast-check": "^4.7.0",
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "prettier": "^3.4.2",
@@ -7139,6 +7140,46 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/BackEnd/package.json
+++ b/BackEnd/package.json
@@ -101,6 +101,7 @@
     "eslint": "^10.0.1",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
+    "fast-check": "^4.7.0",
     "globals": "^16.0.0",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",

--- a/BackEnd/test/stellar/multisig-payout.service.spec.ts
+++ b/BackEnd/test/stellar/multisig-payout.service.spec.ts
@@ -1,0 +1,356 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import fc from 'fast-check';
+import { MultiSigPayoutService } from 'src/modules/stellar/multisig/services/multisig-payout.service';
+import { MultiSigWalletService } from 'src/modules/stellar/multisig/services/multisig-wallet.service';
+import { MultiSigTransaction, MultiSigTransactionStatus } from 'src/modules/stellar/multisig/entities/multisig-transaction.entity';
+import { MultiSigWallet, MultiSigWalletStatus } from 'src/modules/stellar/multisig/entities/multisig-wallet.entity';
+import { Payout, PayoutStatus, PayoutType } from 'src/modules/payouts/entities/payout.entity';
+
+// ─── Arbitraries ────────────────────────────────────────────────────────────
+
+/** Any payout status that is NOT PENDING */
+const nonPendingPayoutStatus = fc.constantFrom(
+  PayoutStatus.AWAITING_APPROVAL,
+  PayoutStatus.PROCESSING,
+  PayoutStatus.COMPLETED,
+  PayoutStatus.FAILED,
+  PayoutStatus.RETRY_SCHEDULED,
+);
+
+/** Any transaction status that is NOT APPROVED */
+const nonApprovedTransactionStatus = fc.constantFrom(
+  MultiSigTransactionStatus.PENDING,
+  MultiSigTransactionStatus.REJECTED,
+  MultiSigTransactionStatus.CANCELLED,
+  MultiSigTransactionStatus.EXECUTING,
+  MultiSigTransactionStatus.COMPLETED,
+  MultiSigTransactionStatus.FAILED,
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makePayout = (overrides: Partial<Payout> = {}): Payout =>
+  ({
+    id: 'payout-123',
+    stellarAddress: 'GBZXN7PIRZNT4Z5TZHTG2793CFAND3P5PMXEVII27KSKNM7TOTF7YLT2',
+    amount: 500,
+    asset: 'XLM',
+    status: PayoutStatus.PENDING,
+    type: PayoutType.QUEST_REWARD,
+    questId: 'quest-1',
+    submissionId: 'sub-1',
+    transactionHash: null,
+    stellarLedger: null,
+    failureReason: null,
+    retryCount: 0,
+    maxRetries: 3,
+    nextRetryAt: null,
+    processedAt: null,
+    claimedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    canRetry: () => false,
+    isClaimable: () => true,
+    ...overrides,
+  } as Payout);
+
+const makeTransaction = (overrides: Partial<MultiSigTransaction> = {}): MultiSigTransaction =>
+  ({
+    id: 'tx-123',
+    multiSigWalletId: 'wallet-123',
+    transactionType: 'PAYOUT' as any,
+    status: MultiSigTransactionStatus.APPROVED,
+    destinationAddress: 'GBZXN7PIRZNT4Z5TZHTG2793CFAND3P5PMXEVII27KSKNM7TOTF7YLT2',
+    amount: 500,
+    asset: 'XLM',
+    transactionPayload: JSON.stringify({ payoutId: 'payout-123', questId: 'quest-1', submissionId: 'sub-1' }),
+    description: 'Test payout',
+    approvalsReceived: 2,
+    rejectionsReceived: 0,
+    threshold: 2,
+    initiatedBy: 'user-1',
+    lastModifiedBy: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+    stellarTransactionHash: null,
+    stellarLedger: null,
+    failureReason: null,
+    completedAt: null,
+    cancelledAt: null,
+    cancelledBy: null,
+    ...overrides,
+  } as MultiSigTransaction);
+
+const makeWallet = (overrides: Partial<MultiSigWallet> = {}): MultiSigWallet =>
+  ({
+    id: 'wallet-123',
+    organizationId: 'org-1',
+    walletAddress: 'GBZXN7PIRZNT4Z5TZHTG2793CFAND3P5PMXEVII27KSKNM7TOTF7YLT2',
+    name: 'Test Wallet',
+    description: null,
+    threshold: 2,
+    totalSigners: 3,
+    status: MultiSigWalletStatus.ACTIVE,
+    totalTransactions: 0,
+    approvedTransactions: 0,
+    totalAmountApproved: 0,
+    createdBy: 'user-1',
+    lastModifiedBy: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActivityAt: new Date(),
+    ...overrides,
+  } as MultiSigWallet);
+
+// ─── Test Suite ───────────────────────────────────────────────────────────────
+
+describe('MultiSigPayoutService', () => {
+  let service: MultiSigPayoutService;
+  let mockPayoutRepo: any;
+  let mockTransactionRepo: any;
+  let mockWalletRepo: any;
+  let mockMultiSigWalletService: any;
+  let mockEventEmitter: any;
+
+  beforeEach(async () => {
+    mockPayoutRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    };
+
+    mockTransactionRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+
+    mockWalletRepo = {
+      findOne: jest.fn(),
+    };
+
+    mockMultiSigWalletService = {
+      createTransaction: jest.fn(),
+    };
+
+    mockEventEmitter = {
+      emit: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MultiSigPayoutService,
+        {
+          provide: getRepositoryToken(Payout),
+          useValue: mockPayoutRepo,
+        },
+        {
+          provide: getRepositoryToken(MultiSigTransaction),
+          useValue: mockTransactionRepo,
+        },
+        {
+          provide: getRepositoryToken(MultiSigWallet),
+          useValue: mockWalletRepo,
+        },
+        {
+          provide: MultiSigWalletService,
+          useValue: mockMultiSigWalletService,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: mockEventEmitter,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MultiSigPayoutService>(MultiSigPayoutService);
+  });
+
+  // ── createPayoutEscrow ────────────────────────────────────────────────────
+
+  describe('createPayoutEscrow', () => {
+    it('should create escrow, update payout to AWAITING_APPROVAL, and emit event', async () => {
+      const payout = makePayout();
+      const tx = makeTransaction({ status: MultiSigTransactionStatus.PENDING, approvalsReceived: 0 });
+
+      mockPayoutRepo.findOne.mockResolvedValue(payout);
+      mockMultiSigWalletService.createTransaction.mockResolvedValue(tx);
+      mockPayoutRepo.save.mockResolvedValue({ ...payout, status: PayoutStatus.AWAITING_APPROVAL });
+
+      const result = await service.createPayoutEscrow(
+        'payout-123',
+        'wallet-123',
+        'GBZXN7PIRZNT4Z5TZHTG2793CFAND3P5PMXEVII27KSKNM7TOTF7YLT2',
+        500,
+        'user-1',
+      );
+
+      expect(mockMultiSigWalletService.createTransaction).toHaveBeenCalled();
+      expect(mockPayoutRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PayoutStatus.AWAITING_APPROVAL }),
+      );
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        'multisig.payout.escrow_created',
+        expect.objectContaining({ payoutId: 'payout-123' }),
+      );
+      expect(result.payoutId).toBe('payout-123');
+    });
+
+    it('should throw NotFoundException when payout does not exist', async () => {
+      mockPayoutRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.createPayoutEscrow('missing-payout', 'wallet-123', 'addr', 100, 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    // Property 13: Non-PENDING payout rejects escrow creation
+    // Feature: multisig-edge-case-testing, Property 13: Non-PENDING payout rejects escrow creation
+    it('should throw BadRequestException for any non-PENDING payout status', async () => {
+      await fc.assert(
+        fc.asyncProperty(nonPendingPayoutStatus, async (status) => {
+          jest.clearAllMocks();
+          mockPayoutRepo.findOne.mockResolvedValue(makePayout({ status }));
+
+          await expect(
+            service.createPayoutEscrow('payout-123', 'wallet-123', 'addr', 100, 'user-1'),
+          ).rejects.toThrow(BadRequestException);
+        }),
+      );
+    });
+  });
+
+  // ── processApprovedPayout ─────────────────────────────────────────────────
+
+  describe('processApprovedPayout', () => {
+    it('should update payout to PROCESSING and emit event', async () => {
+      const tx = makeTransaction();
+      const payout = makePayout({ status: PayoutStatus.AWAITING_APPROVAL });
+
+      mockTransactionRepo.findOne.mockResolvedValue(tx);
+      mockPayoutRepo.findOne.mockResolvedValue(payout);
+      mockPayoutRepo.save.mockResolvedValue({ ...payout, status: PayoutStatus.PROCESSING });
+
+      const result = await service.processApprovedPayout('tx-123');
+
+      expect(mockPayoutRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PayoutStatus.PROCESSING }),
+      );
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        'multisig.payout.approved',
+        expect.objectContaining({ payoutId: 'payout-123' }),
+      );
+      expect(result.status).toBe(PayoutStatus.PROCESSING);
+    });
+
+    it('should throw NotFoundException when transaction does not exist', async () => {
+      mockTransactionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.processApprovedPayout('missing-tx')).rejects.toThrow(NotFoundException);
+    });
+
+    // Property 14: Non-APPROVED transaction rejects payout processing
+    // Feature: multisig-edge-case-testing, Property 14: Non-APPROVED transaction rejects payout processing
+    it('should throw BadRequestException for any non-APPROVED transaction status', async () => {
+      await fc.assert(
+        fc.asyncProperty(nonApprovedTransactionStatus, async (status) => {
+          jest.clearAllMocks();
+          mockTransactionRepo.findOne.mockResolvedValue(makeTransaction({ status }));
+
+          await expect(service.processApprovedPayout('tx-123')).rejects.toThrow(BadRequestException);
+        }),
+      );
+    });
+  });
+
+  // ── handleRejectedPayout ──────────────────────────────────────────────────
+
+  describe('handleRejectedPayout', () => {
+    it('should set payout to FAILED with failureReason and emit event', async () => {
+      const tx = makeTransaction({ status: MultiSigTransactionStatus.REJECTED });
+      const payout = makePayout({ status: PayoutStatus.AWAITING_APPROVAL });
+
+      mockTransactionRepo.findOne.mockResolvedValue(tx);
+      mockPayoutRepo.findOne.mockResolvedValue(payout);
+      mockPayoutRepo.save.mockImplementation((p: Payout) => Promise.resolve(p));
+
+      const result = await service.handleRejectedPayout('tx-123', 'Insufficient funds');
+
+      expect(mockPayoutRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: PayoutStatus.FAILED,
+          failureReason: expect.stringContaining('Insufficient funds'),
+        }),
+      );
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        'multisig.payout.rejected',
+        expect.objectContaining({ payoutId: 'payout-123', reason: 'Insufficient funds' }),
+      );
+      expect(result.status).toBe(PayoutStatus.FAILED);
+      expect(result.failureReason).toContain('Insufficient funds');
+    });
+
+    it('should throw NotFoundException when transaction does not exist', async () => {
+      mockTransactionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.handleRejectedPayout('missing-tx', 'reason')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── getPayoutApprovalDashboard ────────────────────────────────────────────
+
+  describe('getPayoutApprovalDashboard', () => {
+    it('should return dashboard with correct pending and approved counts', async () => {
+      const wallet = makeWallet();
+      const pendingTxs = [
+        makeTransaction({ id: 'tx-1', status: MultiSigTransactionStatus.PENDING }),
+        makeTransaction({ id: 'tx-2', status: MultiSigTransactionStatus.PENDING }),
+      ];
+      const approvedTxs = [makeTransaction({ id: 'tx-3', status: MultiSigTransactionStatus.APPROVED })];
+
+      mockWalletRepo.findOne.mockResolvedValue(wallet);
+      mockTransactionRepo.find
+        .mockResolvedValueOnce(pendingTxs)
+        .mockResolvedValueOnce(approvedTxs);
+
+      const result = await service.getPayoutApprovalDashboard('wallet-123');
+
+      expect(result.pendingCount).toBe(2);
+      expect(result.approvedCount).toBe(1);
+      expect(result.walletAddress).toBe(wallet.walletAddress);
+    });
+
+    it('should throw NotFoundException when wallet does not exist', async () => {
+      mockWalletRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getPayoutApprovalDashboard('missing-wallet')).rejects.toThrow(NotFoundException);
+    });
+
+    // Property 12: Dashboard counts match actual transaction counts
+    // Feature: multisig-edge-case-testing, Property 12: Dashboard counts match actual transaction counts
+    it('should return pendingCount matching the number of pending transactions', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.integer({ min: 0, max: 8 }), async (pendingCount) => {
+          jest.clearAllMocks();
+
+          const wallet = makeWallet();
+          const pendingTxs = Array.from({ length: pendingCount }, (_, i) =>
+            makeTransaction({ id: `tx-pending-${i}`, status: MultiSigTransactionStatus.PENDING }),
+          );
+
+          mockWalletRepo.findOne.mockResolvedValue(wallet);
+          mockTransactionRepo.find
+            .mockResolvedValueOnce(pendingTxs)
+            .mockResolvedValueOnce([]);
+
+          const result = await service.getPayoutApprovalDashboard('wallet-123');
+
+          return result.pendingCount === pendingCount;
+        }),
+      );
+    });
+  });
+});

--- a/BackEnd/test/stellar/multisig-wallet.service.spec.ts
+++ b/BackEnd/test/stellar/multisig-wallet.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { MultiSigWalletService } from '../stellar/multisig/services/multisig-wallet.service';
-import { MultiSigWallet, MultiSigWalletStatus } from '../stellar/multisig/entities/multisig-wallet.entity';
-import { MultiSigSigner, SignerRole, SignerStatus } from '../stellar/multisig/entities/multisig-signer.entity';
-import { MultiSigTransaction, MultiSigTransactionStatus } from '../stellar/multisig/entities/multisig-transaction.entity';
-import { MultiSigSignature, SignatureStatus } from '../stellar/multisig/entities/multisig-signature.entity';
-import { CreateMultiSigWalletDto, ApproveTransactionDto } from '../stellar/multisig/dto/multisig.dto';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { MultiSigWalletService } from 'src/modules/stellar/multisig/services/multisig-wallet.service';
+import { MultiSigWallet, MultiSigWalletStatus } from 'src/modules/stellar/multisig/entities/multisig-wallet.entity';
+import { MultiSigSigner, SignerRole, SignerStatus } from 'src/modules/stellar/multisig/entities/multisig-signer.entity';
+import { MultiSigTransaction, MultiSigTransactionStatus, MultiSigTransactionType } from 'src/modules/stellar/multisig/entities/multisig-transaction.entity';
+import { MultiSigSignature, SignatureStatus } from 'src/modules/stellar/multisig/entities/multisig-signature.entity';
+import { CreateMultiSigWalletDto, ApproveTransactionDto, UpdateThresholdDto, CreateMultiSigTransactionDto, RejectTransactionDto } from 'src/modules/stellar/multisig/dto/multisig.dto';
 
 describe('MultiSigWalletService', () => {
   let service: MultiSigWalletService;
@@ -94,7 +95,7 @@ describe('MultiSigWalletService', () => {
         totalSigners: 3,
       };
 
-      const expectedWallet: MultiSigWallet = {
+      const expectedWallet = {
         id: 'wallet-123',
         ...createDto,
         status: MultiSigWalletStatus.ACTIVE,
@@ -106,7 +107,7 @@ describe('MultiSigWalletService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         lastActivityAt: new Date(),
-      };
+      } as MultiSigWallet;
 
       mockWalletRepo.findOne.mockResolvedValue(null);
       mockWalletRepo.create.mockReturnValue(expectedWallet);
@@ -160,7 +161,7 @@ describe('MultiSigWalletService', () => {
     it('should add a new signer to wallet', async () => {
       const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
 
-      const mockWallet: MultiSigWallet = {
+      const mockWallet = {
         id: 'wallet-123',
         organizationId: testOrgId,
         walletAddress: testWalletAddress,
@@ -176,9 +177,9 @@ describe('MultiSigWalletService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         lastActivityAt: new Date(),
-      };
+      } as MultiSigWallet;
 
-      const expectedSigner: MultiSigSigner = {
+      const expectedSigner = {
         id: 'signer-123',
         multiSigWalletId: 'wallet-123',
         signerAddress,
@@ -190,7 +191,7 @@ describe('MultiSigWalletService', () => {
         addedBy: testUserId,
         addedAt: new Date(),
         updatedAt: new Date(),
-      };
+      } as MultiSigSigner;
 
       mockWalletRepo.findOne.mockResolvedValue(mockWallet);
       mockSignerRepo.findOne.mockResolvedValue(null);
@@ -211,6 +212,145 @@ describe('MultiSigWalletService', () => {
       expect(result).toEqual(expectedSigner);
       expect(mockEventEmitter.emit).toHaveBeenCalledWith('multisig.signer.added', expect.any(Object));
     });
+
+    it('should re-add a previously removed signer successfully', async () => {
+      const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
+
+      const mockWallet = {
+        id: 'wallet-123',
+        organizationId: testOrgId,
+        walletAddress: testWalletAddress,
+        name: 'Test Wallet',
+        threshold: 2,
+        totalSigners: 3,
+        status: MultiSigWalletStatus.ACTIVE,
+        totalTransactions: 0,
+        approvedTransactions: 0,
+        totalAmountApproved: 0,
+        createdBy: testUserId,
+        lastModifiedBy: testUserId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastActivityAt: new Date(),
+      } as MultiSigWallet;
+
+      const removedSigner = {
+        id: 'signer-old',
+        multiSigWalletId: 'wallet-123',
+        signerAddress,
+        signerName: 'Signer 1',
+        role: SignerRole.APPROVER,
+        status: SignerStatus.REMOVED,
+        approvalCount: 2,
+        rejectionCount: 0,
+        addedBy: testUserId,
+        addedAt: new Date(),
+        updatedAt: new Date(),
+        removedBy: testUserId,
+        removedAt: new Date(),
+      } as MultiSigSigner;
+
+      const newActiveSigner = {
+        id: 'signer-new',
+        multiSigWalletId: 'wallet-123',
+        signerAddress,
+        signerName: 'Signer 1',
+        role: SignerRole.APPROVER,
+        status: SignerStatus.ACTIVE,
+        approvalCount: 0,
+        rejectionCount: 0,
+        addedBy: testUserId,
+        addedAt: new Date(),
+        updatedAt: new Date(),
+      } as MultiSigSigner;
+
+      mockWalletRepo.findOne.mockResolvedValue(mockWallet);
+      // findOne returns the previously-removed signer
+      mockSignerRepo.findOne.mockResolvedValue(removedSigner);
+      mockSignerRepo.create.mockReturnValue(newActiveSigner);
+      mockSignerRepo.save.mockResolvedValue(newActiveSigner);
+      mockWalletRepo.save.mockResolvedValue(mockWallet);
+
+      const result = await service.addSigner(
+        {
+          multiSigWalletId: 'wallet-123',
+          signerAddress,
+          signerName: 'Signer 1',
+          role: SignerRole.APPROVER,
+        },
+        testUserId,
+      );
+
+      expect(result.status).toBe(SignerStatus.ACTIVE);
+      expect(mockSignerRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signerAddress,
+          status: SignerStatus.ACTIVE,
+        }),
+      );
+      expect(mockSignerRepo.save).toHaveBeenCalled();
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('multisig.signer.added', expect.any(Object));
+    });
+  });
+
+  describe('removeSigner', () => {
+    it('should remove a signer and emit multisig.signer.removed event', async () => {
+      const walletId = 'wallet-123';
+      const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
+
+      const mockSigner = {
+        id: 'signer-123',
+        multiSigWalletId: walletId,
+        signerAddress,
+        signerName: 'Signer 1',
+        role: SignerRole.APPROVER,
+        status: SignerStatus.ACTIVE,
+        approvalCount: 0,
+        rejectionCount: 0,
+        addedBy: testUserId,
+        addedAt: new Date(),
+        updatedAt: new Date(),
+      } as MultiSigSigner;
+
+      const mockWallet = {
+        id: walletId,
+        organizationId: testOrgId,
+        walletAddress: testWalletAddress,
+        name: 'Test Wallet',
+        threshold: 2,
+        totalSigners: 3,
+        status: MultiSigWalletStatus.ACTIVE,
+        totalTransactions: 0,
+        approvedTransactions: 0,
+        totalAmountApproved: 0,
+        createdBy: testUserId,
+        lastModifiedBy: testUserId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastActivityAt: new Date(),
+      } as MultiSigWallet;
+
+      const removedSigner = {
+        ...mockSigner,
+        status: SignerStatus.REMOVED,
+        removedBy: testUserId,
+        removedAt: new Date(),
+      } as MultiSigSigner;
+
+      mockSignerRepo.findOne.mockResolvedValue(mockSigner);
+      mockSignerRepo.save.mockResolvedValue(removedSigner);
+      mockWalletRepo.findOne.mockResolvedValue(mockWallet);
+      mockWalletRepo.save.mockResolvedValue(mockWallet);
+
+      const result = await service.removeSigner(walletId, signerAddress, testUserId);
+
+      expect(result.status).toBe(SignerStatus.REMOVED);
+      expect(result.removedAt).toBeInstanceOf(Date);
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('multisig.signer.removed', {
+        walletId,
+        signerAddress,
+      });
+    });
   });
 
   describe('approveTransaction', () => {
@@ -218,10 +358,10 @@ describe('MultiSigWalletService', () => {
       const transactionId = 'tx-123';
       const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
 
-      const mockTx: MultiSigTransaction = {
+      const mockTx = {
         id: transactionId,
         multiSigWalletId: 'wallet-123',
-        transactionType: 'PAYOUT',
+        transactionType: MultiSigTransactionType.PAYOUT,
         status: MultiSigTransactionStatus.PENDING,
         destinationAddress: signerAddress,
         amount: 1000,
@@ -232,26 +372,22 @@ describe('MultiSigWalletService', () => {
         initiatedBy: testUserId,
         createdAt: new Date(),
         updatedAt: new Date(),
-        transactionPayload: null,
         description: 'Test payout',
         lastModifiedBy: testUserId,
-      };
+      } as MultiSigTransaction;
 
-      const mockSignature: MultiSigSignature = {
+      const mockSignature = {
         id: 'sig-123',
         multiSigTransactionId: transactionId,
         signerAddress,
         signerName: 'Signer 1',
         status: SignatureStatus.PENDING,
-        signature: null,
         comment: 'Approved',
-        signedAt: null,
         createdAt: new Date(),
         updatedAt: new Date(),
-        signatureExpiresAt: null,
-      };
+      } as MultiSigSignature;
 
-      const mockSigner: MultiSigSigner = {
+      const mockSigner = {
         id: 'signer-123',
         multiSigWalletId: 'wallet-123',
         signerAddress,
@@ -263,7 +399,7 @@ describe('MultiSigWalletService', () => {
         addedBy: testUserId,
         addedAt: new Date(),
         updatedAt: new Date(),
-      };
+      } as MultiSigSigner;
 
       mockTransactionRepo.findOne.mockResolvedValue(mockTx);
       mockSignatureRepo.findOne.mockResolvedValue(mockSignature);
@@ -292,10 +428,10 @@ describe('MultiSigWalletService', () => {
       const transactionId = 'tx-123';
       const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
 
-      const mockTx: MultiSigTransaction = {
+      const mockTx = {
         id: transactionId,
         multiSigWalletId: 'wallet-123',
-        transactionType: 'PAYOUT',
+        transactionType: MultiSigTransactionType.PAYOUT,
         status: MultiSigTransactionStatus.PENDING,
         destinationAddress: signerAddress,
         amount: 1000,
@@ -306,24 +442,20 @@ describe('MultiSigWalletService', () => {
         initiatedBy: testUserId,
         createdAt: new Date(),
         updatedAt: new Date(),
-        transactionPayload: null,
         description: 'Test payout',
         lastModifiedBy: testUserId,
-      };
+      } as MultiSigTransaction;
 
-      const mockSignature: MultiSigSignature = {
+      const mockSignature = {
         id: 'sig-123',
         multiSigTransactionId: transactionId,
         signerAddress,
         signerName: 'Signer 2',
         status: SignatureStatus.PENDING,
-        signature: null,
         comment: 'Approved',
-        signedAt: null,
         createdAt: new Date(),
         updatedAt: new Date(),
-        signatureExpiresAt: null,
-      };
+      } as MultiSigSignature;
 
       mockTransactionRepo.findOne.mockResolvedValue(mockTx);
       mockSignatureRepo.findOne.mockResolvedValue(mockSignature);
@@ -349,13 +481,168 @@ describe('MultiSigWalletService', () => {
         expect.any(Object),
       );
     });
+
+    it('should throw NotFoundException when transaction does not exist', async () => {
+      // Requirements: 4.6
+      const approveDto: ApproveTransactionDto = {
+        multiSigTransactionId: 'nonexistent-tx',
+        signerAddress: 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R',
+      };
+
+      mockTransactionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.approveTransaction(approveDto, testUserId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException when signature record does not exist for signer', async () => {
+      // Requirements: 4.4
+      const transactionId = 'tx-123';
+      const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
+
+      const mockTx = {
+        id: transactionId,
+        multiSigWalletId: 'wallet-123',
+        status: MultiSigTransactionStatus.PENDING,
+        approvalsReceived: 0,
+        threshold: 2,
+      } as MultiSigTransaction;
+
+      mockTransactionRepo.findOne.mockResolvedValue(mockTx);
+      mockSignatureRepo.findOne.mockResolvedValue(null);
+
+      const approveDto: ApproveTransactionDto = {
+        multiSigTransactionId: transactionId,
+        signerAddress,
+      };
+
+      await expect(service.approveTransaction(approveDto, testUserId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException when signature is already SIGNED (double-approve)', async () => {
+      // Requirements: 4.5
+      const transactionId = 'tx-123';
+      const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
+
+      const mockTx = {
+        id: transactionId,
+        multiSigWalletId: 'wallet-123',
+        status: MultiSigTransactionStatus.PENDING,
+        approvalsReceived: 1,
+        threshold: 2,
+      } as MultiSigTransaction;
+
+      const alreadySignedSignature = {
+        id: 'sig-123',
+        multiSigTransactionId: transactionId,
+        signerAddress,
+        status: SignatureStatus.SIGNED,
+        signedAt: new Date(),
+      } as MultiSigSignature;
+
+      mockTransactionRepo.findOne.mockResolvedValue(mockTx);
+      mockSignatureRepo.findOne.mockResolvedValue(alreadySignedSignature);
+
+      const approveDto: ApproveTransactionDto = {
+        multiSigTransactionId: transactionId,
+        signerAddress,
+      };
+
+      await expect(service.approveTransaction(approveDto, testUserId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('updateThreshold', () => {
+    const walletId = 'wallet-123';
+
+    const mockWallet = {
+      id: walletId,
+      organizationId: testOrgId,
+      walletAddress: testWalletAddress,
+      name: 'Test Wallet',
+      threshold: 2,
+      totalSigners: 3,
+      status: MultiSigWalletStatus.ACTIVE,
+      totalTransactions: 0,
+      approvedTransactions: 0,
+      totalAmountApproved: 0,
+      createdBy: testUserId,
+      lastModifiedBy: testUserId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActivityAt: new Date(),
+    } as MultiSigWallet;
+
+    it('should update threshold to 1 (minimum) and emit multisig.threshold.updated', async () => {
+      const updateDto: UpdateThresholdDto = {
+        multiSigWalletId: walletId,
+        threshold: 1,
+      };
+
+      const updatedWallet = { ...mockWallet, threshold: 1 } as MultiSigWallet;
+
+      mockWalletRepo.findOne.mockResolvedValue({ ...mockWallet });
+      mockWalletRepo.save.mockResolvedValue(updatedWallet);
+
+      const result = await service.updateThreshold(updateDto, testUserId);
+
+      expect(result.threshold).toBe(1);
+      expect(mockWalletRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ threshold: 1 }),
+      );
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('multisig.threshold.updated', {
+        walletId,
+        newThreshold: 1,
+      });
+    });
+
+    it('should update threshold to totalSigners (maximum) and emit multisig.threshold.updated', async () => {
+      const updateDto: UpdateThresholdDto = {
+        multiSigWalletId: walletId,
+        threshold: 3, // equals totalSigners
+      };
+
+      const updatedWallet = { ...mockWallet, threshold: 3 } as MultiSigWallet;
+
+      mockWalletRepo.findOne.mockResolvedValue({ ...mockWallet });
+      mockWalletRepo.save.mockResolvedValue(updatedWallet);
+
+      const result = await service.updateThreshold(updateDto, testUserId);
+
+      expect(result.threshold).toBe(3);
+      expect(mockWalletRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ threshold: 3 }),
+      );
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('multisig.threshold.updated', {
+        walletId,
+        newThreshold: 3,
+      });
+    });
+
+    it('should throw NotFoundException when wallet does not exist', async () => {
+      const updateDto: UpdateThresholdDto = {
+        multiSigWalletId: walletId,
+        threshold: 2,
+      };
+
+      mockWalletRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.updateThreshold(updateDto, testUserId)).rejects.toThrow(
+        'Multi-sig wallet not found',
+      );
+    });
   });
 
   describe('getWalletStats', () => {
     it('should retrieve wallet statistics', async () => {
       const walletId = 'wallet-123';
 
-      const mockWallet: MultiSigWallet = {
+      const mockWallet = {
         id: walletId,
         organizationId: testOrgId,
         walletAddress: testWalletAddress,
@@ -371,7 +658,7 @@ describe('MultiSigWalletService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         lastActivityAt: new Date(),
-      };
+      } as MultiSigWallet;
 
       mockWalletRepo.findOne.mockResolvedValue(mockWallet);
       mockTransactionRepo.count
@@ -386,6 +673,268 @@ describe('MultiSigWalletService', () => {
       expect(stats.completedTransactions).toBe(8);
       expect(stats.pendingTransactions).toBe(1);
       expect(stats.rejectedTransactions).toBe(1);
+    });
+
+    it('should throw NotFoundException when wallet does not exist', async () => {
+      // Requirements: 6.5
+      mockWalletRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getWalletStats('nonexistent-wallet')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('rejectTransaction', () => {
+    const transactionId = 'tx-reject-123';
+    const signerAddress = 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R';
+    const rejectionReason = 'Amount too high';
+
+    const rejectDto: RejectTransactionDto = {
+      multiSigTransactionId: transactionId,
+      signerAddress,
+      rejectionReason,
+    };
+
+    const mockPendingTx = {
+      id: transactionId,
+      multiSigWalletId: 'wallet-123',
+      transactionType: MultiSigTransactionType.PAYOUT,
+      status: MultiSigTransactionStatus.PENDING,
+      destinationAddress: 'GBZXN7PIRZNT4Z5TZHTG2793CFAND3P5PMXEVII27KSKNM7TOTF7YLT2',
+      amount: 1000,
+      asset: 'XLM',
+      approvalsReceived: 0,
+      rejectionsReceived: 0,
+      threshold: 2,
+      initiatedBy: testUserId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      description: 'Test payout',
+      lastModifiedBy: testUserId,
+    } as MultiSigTransaction;
+
+    const mockPendingSignature = {
+      id: 'sig-reject-123',
+      multiSigTransactionId: transactionId,
+      signerAddress,
+      signerName: 'Signer 1',
+      status: SignatureStatus.PENDING,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as MultiSigSignature;
+
+    const mockSigner = {
+      id: 'signer-123',
+      multiSigWalletId: 'wallet-123',
+      signerAddress,
+      signerName: 'Signer 1',
+      role: SignerRole.APPROVER,
+      status: SignerStatus.ACTIVE,
+      approvalCount: 0,
+      rejectionCount: 0,
+      addedBy: testUserId,
+      addedAt: new Date(),
+      updatedAt: new Date(),
+    } as MultiSigSigner;
+
+    it('should reject a pending transaction, set failureReason, and emit multisig.transaction.rejected', async () => {
+      // Requirements: 5.1, 5.8
+      const rejectedTx = {
+        ...mockPendingTx,
+        status: MultiSigTransactionStatus.REJECTED,
+        rejectionsReceived: 1,
+        failureReason: `Rejected by ${signerAddress}: ${rejectionReason}`,
+      } as MultiSigTransaction;
+
+      mockTransactionRepo.findOne.mockResolvedValue({ ...mockPendingTx });
+      mockSignatureRepo.findOne.mockResolvedValue({ ...mockPendingSignature });
+      mockSignatureRepo.save.mockResolvedValue({
+        ...mockPendingSignature,
+        status: SignatureStatus.REJECTED,
+        rejectionReason,
+        rejectedAt: new Date(),
+      });
+      mockTransactionRepo.save.mockResolvedValue(rejectedTx);
+      mockSignerRepo.findOne.mockResolvedValue({ ...mockSigner });
+      mockSignerRepo.save.mockResolvedValue({ ...mockSigner, rejectionCount: 1, lastRejectionAt: new Date() });
+
+      const result = await service.rejectTransaction(rejectDto, testUserId);
+
+      expect(result.status).toBe(MultiSigTransactionStatus.REJECTED);
+      expect(result.failureReason).toContain(rejectionReason);
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('multisig.transaction.rejected', {
+        transactionId,
+        signer: signerAddress,
+        reason: rejectionReason,
+      });
+    });
+
+    it('should throw NotFoundException when transaction does not exist', async () => {
+      // Requirements: 5.6
+      mockTransactionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.rejectTransaction(rejectDto, testUserId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when signature record does not exist for signer', async () => {
+      // Requirements: 5.4
+      mockTransactionRepo.findOne.mockResolvedValue({ ...mockPendingTx });
+      mockSignatureRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.rejectTransaction(rejectDto, testUserId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when signature is already REJECTED (double-reject)', async () => {
+      // Requirements: 5.5
+      const alreadyRejectedSignature = {
+        ...mockPendingSignature,
+        status: SignatureStatus.REJECTED,
+        rejectedAt: new Date(),
+      } as MultiSigSignature;
+
+      mockTransactionRepo.findOne.mockResolvedValue({ ...mockPendingTx });
+      mockSignatureRepo.findOne.mockResolvedValue(alreadyRejectedSignature);
+
+      await expect(service.rejectTransaction(rejectDto, testUserId)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getWalletDetails', () => {
+    it('should throw NotFoundException when wallet does not exist', async () => {
+      // Requirements: 6.2
+      mockWalletRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getWalletDetails('nonexistent-wallet')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getTransactionSignatures', () => {
+    it('should return all signature records for a transaction', async () => {
+      // Requirements: 6.4
+      const transactionId = 'tx-sigs-123';
+      const mockSignatures = [
+        {
+          id: 'sig-1',
+          multiSigTransactionId: transactionId,
+          signerAddress: 'GCZST3XVCDTUJ76ZAV2HA72KYRF5QSGN4BXDGWV6MWVR5DXWPQSWVF5R',
+          status: SignatureStatus.SIGNED,
+          createdAt: new Date(),
+        } as MultiSigSignature,
+        {
+          id: 'sig-2',
+          multiSigTransactionId: transactionId,
+          signerAddress: 'GBZXN7PIRZNT4Z5TZHTG2793CFAND3P5PMXEVII27KSKNM7TOTF7YLT2',
+          status: SignatureStatus.PENDING,
+          createdAt: new Date(),
+        } as MultiSigSignature,
+        {
+          id: 'sig-3',
+          multiSigTransactionId: transactionId,
+          signerAddress: 'GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH3IEQBOHAVSQ37YR',
+          status: SignatureStatus.REJECTED,
+          createdAt: new Date(),
+        } as MultiSigSignature,
+      ];
+
+      mockSignatureRepo.find.mockResolvedValue(mockSignatures);
+
+      const result = await service.getTransactionSignatures(transactionId);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(mockSignatures);
+      expect(mockSignatureRepo.find).toHaveBeenCalledWith({
+        where: { multiSigTransactionId: transactionId },
+        order: { createdAt: 'ASC' },
+      });
+    });
+  });
+
+  describe('createTransaction', () => {
+    const createDto: CreateMultiSigTransactionDto = {
+      multiSigWalletId: 'wallet-123',
+      destinationAddress: 'GBZXN7PIRZNT4Z5TZHTG2793CFAND3P5PMXEVII27KSKNM7TOTF7YLT2',
+      amount: 500,
+      asset: 'XLM',
+      description: 'Test payout',
+    };
+
+    it('should throw BadRequestException when wallet status is INACTIVE', async () => {
+      // Requirements: 3.1
+      const inactiveWallet = {
+        id: 'wallet-123',
+        status: MultiSigWalletStatus.INACTIVE,
+        threshold: 2,
+        totalSigners: 3,
+      } as MultiSigWallet;
+
+      mockWalletRepo.findOne.mockResolvedValue(inactiveWallet);
+
+      await expect(service.createTransaction(createDto, testUserId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when wallet status is SUSPENDED', async () => {
+      // Requirements: 3.2
+      const suspendedWallet = {
+        id: 'wallet-123',
+        status: MultiSigWalletStatus.SUSPENDED,
+        threshold: 2,
+        totalSigners: 3,
+      } as MultiSigWallet;
+
+      mockWalletRepo.findOne.mockResolvedValue(suspendedWallet);
+
+      await expect(service.createTransaction(createDto, testUserId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw NotFoundException when wallet does not exist', async () => {
+      // Requirements: 3.3
+      mockWalletRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.createTransaction(createDto, testUserId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should emit multisig.transaction.created with correct walletId, amount, and threshold', async () => {
+      // Requirements: 3.7
+      const activeWallet = {
+        id: 'wallet-123',
+        status: MultiSigWalletStatus.ACTIVE,
+        threshold: 2,
+        totalSigners: 3,
+        totalTransactions: 5,
+        lastActivityAt: new Date(),
+      } as MultiSigWallet;
+
+      const savedTx = {
+        id: 'tx-new-123',
+        multiSigWalletId: 'wallet-123',
+        amount: 500,
+        threshold: 2,
+        status: MultiSigTransactionStatus.PENDING,
+      } as MultiSigTransaction;
+
+      mockWalletRepo.findOne.mockResolvedValue(activeWallet);
+      mockTransactionRepo.create.mockReturnValue(savedTx);
+      mockTransactionRepo.save.mockResolvedValue(savedTx);
+      mockSignerRepo.find.mockResolvedValue([]);
+      mockWalletRepo.save.mockResolvedValue({ ...activeWallet, totalTransactions: 6 });
+
+      await service.createTransaction(createDto, testUserId);
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('multisig.transaction.created', {
+        transactionId: 'tx-new-123',
+        walletId: 'wallet-123',
+        amount: 500,
+        threshold: 2,
+      });
     });
   });
 });


### PR DESCRIPTION
# PR: Multisig Edge Case Testing

## Summary

Extends the existing Jest unit test suite to achieve full coverage of `MultiSigWalletService` and `MultiSigPayoutService`. Adds property-based tests using `fast-check` for invariants that must hold across all valid input combinations.

## Changes

### New Files
- `BackEnd/test/stellar/multisig-payout.service.spec.ts` — full test suite for `MultiSigPayoutService`

### Modified Files
- `BackEnd/test/stellar/multisig-wallet.service.spec.ts` — extended with edge case coverage
- `BackEnd/package.json` / `package-lock.json` — added `fast-check` dev dependency

## Test Coverage Added

### MultiSigWalletService

| Area | Tests Added |
|---|---|
| `removeSigner` | Happy path: status = REMOVED, removedAt set, event emitted |
| `addSigner` | Re-add previously removed signer succeeds |
| `updateThreshold` | threshold = 1 (min), threshold = totalSigners (max), not-found |
| `createTransaction` | INACTIVE wallet, SUSPENDED wallet, not-found, event emission |
| `approveTransaction` | Transaction not found, signature not found, double-approve |
| `rejectTransaction` | Happy path, transaction not found, signature not found, double-reject |
| `getWalletDetails` | Not-found |
| `getTransactionSignatures` | Happy path returning N signatures |
| `getWalletStats` | Not-found |

### MultiSigPayoutService

| Area | Tests Added |
|---|---|
| `createPayoutEscrow` | Happy path, payout not found, non-PENDING payout (PBT) |
| `processApprovedPayout` | Happy path, transaction not found, non-APPROVED status (PBT) |
| `handleRejectedPayout` | Happy path, transaction not found |
| `getPayoutApprovalDashboard` | Happy path, not-found, pending count invariant (PBT) |

### Property-Based Tests (fast-check)

| Property | Description |
|---|---|
| Property 12 | Dashboard `pendingCount` always matches actual pending transaction count |
| Property 13 | Any non-PENDING payout status rejects escrow creation with `BadRequestException` |
| Property 14 | Any non-APPROVED transaction status rejects payout processing with `BadRequestException` |

## Test Results

```
Test Suites: 2 passed, 2 passed
Tests:       37 passed, 37 total
```

Close #334

## Requirements Covered

- Req 1.1, 1.4, 1.7 — Signer lifecycle
- Req 2.1, 2.3, 2.4, 2.5 — Threshold updates
- Req 3.1, 3.2, 3.3, 3.7 — Transaction creation
- Req 4.4, 4.5, 4.6 — Approval failure modes
- Req 5.1, 5.4, 5.5, 5.6, 5.8 — Rejection scenarios
- Req 6.2, 6.4, 6.5 — Query operations
- Req 7.1–7.8 — Payout service coverage
