### PR TITLE
feat: ws auth guard, room manager, message entity, distributed lock service

### DIFF
--- a/BackEnd/src/modules/jobs/distributed-lock.service.ts
+++ b/BackEnd/src/modules/jobs/distributed-lock.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+
+// In-memory implementation for development / single-instance deployments.
+// Replace the Map with a Redis-backed store (e.g. SET key value PX ttlMs NX)
+// for true distributed locking across multiple instances.
+
+interface LockEntry {
+  expiresAt: number;
+}
+
+@Injectable()
+export class DistributedLockService {
+  private readonly locks = new Map<string, LockEntry>();
+
+  /**
+   * Try to acquire a lock for `key` that expires after `ttlMs` milliseconds.
+   * Returns true when the lock was successfully acquired, false if already held.
+   */
+  async acquireLock(key: string, ttlMs: number): Promise<boolean> {
+    const now = Date.now();
+    const existing = this.locks.get(key);
+
+    if (existing && existing.expiresAt > now) {
+      // Lock is still held by another holder.
+      return false;
+    }
+
+    this.locks.set(key, { expiresAt: now + ttlMs });
+    return true;
+  }
+
+  /**
+   * Release the lock for `key`. Safe to call even if the lock has already expired.
+   */
+  releaseLock(key: string): void {
+    this.locks.delete(key);
+  }
+}

--- a/BackEnd/src/modules/websocket/entities/chat-message.entity.ts
+++ b/BackEnd/src/modules/websocket/entities/chat-message.entity.ts
@@ -1,0 +1,24 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity('chat_messages')
+export class ChatMessage {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  room: string;
+
+  @Column()
+  senderId: string;
+
+  @Column({ type: 'text' })
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/BackEnd/src/modules/websocket/room-manager.service.ts
+++ b/BackEnd/src/modules/websocket/room-manager.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { Server } from 'socket.io';
+
+@Injectable()
+export class RoomManagerService {
+  /**
+   * Add a socket client to a named room.
+   */
+  joinRoom(server: Server, clientId: string, room: string): void {
+    const socket = server.sockets.sockets.get(clientId);
+    if (socket) {
+      socket.join(room);
+    }
+  }
+
+  /**
+   * Remove a socket client from a named room.
+   */
+  leaveRoom(server: Server, clientId: string, room: string): void {
+    const socket = server.sockets.sockets.get(clientId);
+    if (socket) {
+      socket.leave(room);
+    }
+  }
+
+  /**
+   * Emit an event with `data` to every socket currently in `room`.
+   */
+  broadcastToRoom(
+    server: Server,
+    room: string,
+    event: string,
+    data: unknown,
+  ): void {
+    server.to(room).emit(event, data);
+  }
+}

--- a/BackEnd/src/modules/websocket/ws-jwt.guard.ts
+++ b/BackEnd/src/modules/websocket/ws-jwt.guard.ts
@@ -1,0 +1,43 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Socket } from 'socket.io';
+import { WsException } from '@nestjs/websockets';
+
+@Injectable()
+export class WsJwtGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const client: Socket = context.switchToWs().getClient<Socket>();
+
+    const token = this.extractToken(client);
+
+    if (!token) {
+      client.disconnect();
+      throw new WsException('Missing authentication token');
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      // Attach decoded user to client so handlers can read it via client.data.user.
+      client.data.user = payload;
+      return true;
+    } catch {
+      client.disconnect();
+      throw new WsException('Invalid or expired token');
+    }
+  }
+
+  private extractToken(client: Socket): string | undefined {
+    // Check Authorization header first, then query param as fallback.
+    const authHeader =
+      client.handshake.headers['authorization'] ||
+      client.handshake.headers['Authorization'];
+
+    if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+      return authHeader.slice(7);
+    }
+
+    return client.handshake.query['token'] as string | undefined;
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces four backend features covering WebSocket security, room management, message persistence, and distributed job coordination.

- **DistributedLockService** – An `@Injectable()` service with `acquireLock(key, ttlMs)` and `releaseLock(key)`. Uses an in-memory `Map` for now; a comment marks where Redis `SET NX PX` should replace it for multi-instance deployments. closes #328
- **WsJwtGuard** – A `CanActivate` guard for Socket.IO that reads a JWT from the `Authorization` header or `token` query param, verifies it with `JwtService`, and sets `client.data.user`. Invalid or missing tokens disconnect the client immediately. closes #329
- **RoomManagerService** – An `@Injectable()` service with `joinRoom`, `leaveRoom`, and `broadcastToRoom` helpers that wrap Socket.IO's native room API, keeping gateway code clean. closes #330
- **ChatMessage entity** – A TypeORM `@Entity('chat_messages')` with `id` (uuid PK), `room`, `senderId`, `content` (text), and `createdAt` (auto-timestamp), providing the persistence layer for WebSocket messages. closes #331

## Files changed

- `BackEnd/src/modules/jobs/distributed-lock.service.ts` (issue #328)
- `BackEnd/src/modules/websocket/ws-jwt.guard.ts` (issue #329)
- `BackEnd/src/modules/websocket/room-manager.service.ts` (issue #330)
- `BackEnd/src/modules/websocket/entities/chat-message.entity.ts` (issue #331)