### PR TITLE
feat: add frontend TypeScript type check workflow

### DIFF
--- a/.github/workflows/frontend-typecheck.yml
+++ b/.github/workflows/frontend-typecheck.yml
@@ -1,0 +1,31 @@
+name: Frontend Type Check
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'FrontEnd/**'
+      - '.github/workflows/frontend-typecheck.yml'
+
+jobs:
+  typecheck:
+    name: TypeScript Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: FrontEnd/my-app
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: FrontEnd/my-app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit

--- a/FrontEnd/my-app/package.json
+++ b/FrontEnd/my-app/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION
Adds a dedicated GitHub Actions workflow that runs tsc --noEmit on every PR 
targeting main/master, catching type errors before merge.

Changes
- .github/workflows/frontend-typecheck.yml — new workflow, runs on PRs that 
touch FrontEnd/
- FrontEnd/my-app/package.json — adds "typecheck": "tsc --noEmit" script for 
local use

Testing
Run locally with:
bash
cd FrontEnd/my-app && npm run typecheck


Close #302
