### PR TITLE
feat(pwa): add service worker versioning and caching strategies

### DIFF
--- a/FrontEnd/my-app/app/layout.tsx
+++ b/FrontEnd/my-app/app/layout.tsx
@@ -15,6 +15,7 @@ import { A11yAnnouncerProvider } from '@/components/a11y/A11yAnnouncer';
 import PerformanceMonitor from '@/components/ui/PerformanceMonitor';
 import { AppErrorBoundary } from '@/components/error/ErrorBoundary';
 import { EnvValidator } from '@/components/providers/EnvValidator';
+import { SWRegister } from '@/components/SWRegister';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -51,26 +52,10 @@ export default function RootLayout({
     })();
   `;
 
-  const swRegistrationScript = `
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function() {
-        navigator.serviceWorker.register('/sw.js').then(
-          function(registration) {
-            console.log('Service Worker registration successful with scope: ', registration.scope);
-          },
-          function(err) {
-            console.log('Service Worker registration failed: ', err);
-          }
-        );
-      });
-    }
-  `;
-
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-        <script dangerouslySetInnerHTML={{ __html: swRegistrationScript }} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"
@@ -90,6 +75,7 @@ export default function RootLayout({
                     <ToastProvider>
                       <AppErrorBoundary>
                         <SkipToContent />
+                        <SWRegister />
                         {children}
                         <PerformanceMonitor />
                         <ConsentBanner />

--- a/FrontEnd/my-app/components/SWRegister.tsx
+++ b/FrontEnd/my-app/components/SWRegister.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export const SWRegister = () => {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .then((registration) =>
+          console.log(
+            'Service Worker registered with scope:',
+            registration.scope
+          )
+        )
+        .catch((error) =>
+          console.error('Service Worker registration failed:', error)
+        );
+    }
+  }, []);
+
+  return null; // This component does not render anything
+};

--- a/FrontEnd/my-app/public/sw.js
+++ b/FrontEnd/my-app/public/sw.js
@@ -1,33 +1,81 @@
-const CACHE_NAME = 'stellar-earn-cache-v1';
-const ASSETS_TO_CACHE = [
-    '/',
-    '/favicon.ico',
+const SW_VERSION = 'v1.0.0'; // Update this version string to invalidate caches
+const CACHE_PREFIX = 'stellar-earn';
+
+// Cache names
+const STATIC_CACHE = `${CACHE_PREFIX}-static-${SW_VERSION}`;
+const DYNAMIC_CACHE = `${CACHE_PREFIX}-dynamic-${SW_VERSION}`;
+
+// Essential static assets to cache on install
+const STATIC_ASSETS = [
+  '/',
+  '/manifest.json',
+  '/favicon.ico',
 ];
 
+// Install Event - Cache initial static assets
 self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open(CACHE_NAME).then((cache) => {
-            return cache.addAll(ASSETS_TO_CACHE);
-        })
-    );
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => {
+      console.log(`[Service Worker] Caching Static Assets (Version: ${SW_VERSION})`);
+      return cache.addAll(STATIC_ASSETS);
+    })
+  );
 });
 
-self.addEventListener('fetch', (event) => {
-    event.respondWith(
-        caches.match(event.request).then((response) => {
-            return response || fetch(event.request).then((fetchResponse) => {
-                // Don't cache if not a successful response or not a GET request
-                if (!fetchResponse || fetchResponse.status !== 200 || fetchResponse.type !== 'basic' || event.request.method !== 'GET') {
-                    return fetchResponse;
-                }
-
-                const responseToCache = fetchResponse.clone();
-                caches.open(CACHE_NAME).then((cache) => {
-                    cache.put(event.request, responseToCache);
-                });
-
-                return fetchResponse;
-            });
+// Activate Event - Clean up old caches (Versioning Strategy)
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          // Only delete caches that belong to this app but don't match the current version
+          if (
+            cacheName.startsWith(CACHE_PREFIX) &&
+            cacheName !== STATIC_CACHE &&
+            cacheName !== DYNAMIC_CACHE
+          ) {
+            console.log(`[Service Worker] Clearing old cache: ${cacheName}`);
+            return caches.delete(cacheName);
+          }
         })
+      );
+    }).then(() => self.clients.claim())
+  );
+});
+
+// Fetch Event - Cache Strategies
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests and unsupported protocols (like chrome-extension://)
+  if (request.method !== 'GET' || !url.protocol.startsWith('http')) {
+    return;
+  }
+
+  // Strategy 1: Network First (for HTML pages and API requests)
+  if (request.headers.get('accept').includes('text/html') || url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(request)
+        .then((networkResponse) => {
+          const responseClone = networkResponse.clone();
+          caches.open(DYNAMIC_CACHE).then((cache) => cache.put(request, responseClone));
+          return networkResponse;
+        })
+        .catch(() => caches.match(request)) // Fallback to cache if offline
     );
+    return;
+  }
+
+  // Strategy 2: Cache First with Network Fallback (for static assets: JS, CSS, Images)
+  event.respondWith(
+    caches.match(request).then((cachedResponse) => {
+      return cachedResponse || fetch(request).then((networkResponse) => {
+        const responseClone = networkResponse.clone();
+        caches.open(DYNAMIC_CACHE).then((cache) => cache.put(request, responseClone));
+        return networkResponse;
+      });
+    })
+  );
 });


### PR DESCRIPTION
## Linked Issue

Closes #291
Closes #24

---

## Description

**What changed?**
- Created `sw.js` with caching strategies in the `public` directory.
- Added `SWRegister.tsx` client component for safe registration.
- Injected `<SWRegister />` into the root `layout.tsx`.

**Why was it changed?**
To resolve PWA cache invalidation issues by introducing a service worker versioning strategy.

**How was it implemented?**
- Bound cache names to a `SW_VERSION` string (`v1.0.0`) in `sw.js`. 
- Implemented a "Network First" strategy for HTML/API requests and a "Cache First" strategy for static assets. 
- Registered the service worker via a React `useEffect` hook to prevent hydration mismatches.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Security fix
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Tests only
- [ ] Configuration / DevOps change

---

## Test Evidence

### Unit Tests

- [ ] New unit tests added for changed logic
- [x] All existing unit tests pass (`npm run test`)
- [x] Coverage does not regress (`npm run test:cov`)

**Test output / screenshot:**

```text
Service Worker registered with scope: http://localhost:3000/
[Service Worker] Caching Static Assets (Version: v1.0.0)
