### PR TITLE
[BE-154] Add CI guard to fail on orphaned scripts without references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,21 @@ jobs:
 
       - name: Build WASM
         run: cargo build --release --target wasm32-unknown-unknown
+
+    orphaned-scripts-check:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Set up Node.js
+          uses: actions/setup-node@v4
+          with:
+            node-version: '18'
+
+        - name: Install dependencies (if any)
+          run: |
+            if [ -f package.json ]; then npm ci || true; fi
+
+        - name: Run orphaned-scripts detector
+          run: node scripts/check-orphaned-scripts.js

--- a/docs/orphaned-scripts.md
+++ b/docs/orphaned-scripts.md
@@ -1,0 +1,38 @@
+Orphaned Scripts Detector
+=========================
+
+Overview
+--------
+
+A small Node.js detector checks for scripts under `scripts/` and `BackEnd/scripts/` that have no references elsewhere in the repository. The detector is run in CI and will fail the build if orphaned scripts are found.
+
+Usage
+-----
+
+Run locally:
+
+```bash
+node scripts/check-orphaned-scripts.js
+```
+
+Run unit tests (requires Node >= 18):
+
+```bash
+npm test
+```
+
+CI
+--
+
+The CI job `orphaned-scripts-check` in `.github/workflows/ci.yml` checks the repository using the detector. If the detector finds orphaned scripts, the job exits non-zero and fails the pipeline.
+
+Allow-listing
+-------------
+
+If certain standalone scripts are intentionally unmanaged (maintenance helpers, one-off deploy scripts), update the CI job or the detector to include an allow-list. A future enhancement would be to support a `.orphaned-scripts-allowlist.json` file read by the detector.
+
+Notes for contributors
+----------------------
+
+- The detector exports functions for testing in `scripts/check-orphaned-scripts.js`.
+- Tests live in `tests/` and are runnable via `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "stellar-earn-ci-tools",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node tests/run-tests.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/check-orphaned-scripts.js
+++ b/scripts/check-orphaned-scripts.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const defaultScriptDirs = ['scripts', 'BackEnd/scripts'];
+const scriptExtensions = ['.sh', '.ps1', '.ts', '.js', '.bash'];
+const ignoreDirs = new Set(['.git', 'node_modules', 'build', 'dist', 'target']);
+
+function createContext(repoRoot = process.cwd(), scriptDirs = defaultScriptDirs) {
+  return { repoRoot, scriptDirs };
+}
+
+function isTextFile(file) {
+  const binExt = ['.png', '.jpg', '.jpeg', '.gif', '.pdf', '.wasm', '.zip', '.tar', '.gz'];
+  return !binExt.includes(path.extname(file).toLowerCase());
+}
+
+function walk(dir) {
+  let results = [];
+  const list = fs.readdirSync(dir, { withFileTypes: true });
+  for (const ent of list) {
+    const name = ent.name;
+    if (ignoreDirs.has(name)) continue;
+    const full = path.join(dir, name);
+    if (ent.isDirectory()) {
+      results = results.concat(walk(full));
+    } else {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function collectScriptFiles(ctx) {
+  const { repoRoot, scriptDirs } = ctx;
+  const found = [];
+  for (const d of scriptDirs) {
+    const fullDir = path.join(repoRoot, d);
+    if (!fs.existsSync(fullDir)) continue;
+    const files = walk(fullDir);
+    for (const f of files) {
+      if (scriptExtensions.includes(path.extname(f))) found.push(path.relative(repoRoot, f));
+    }
+  }
+  return found;
+}
+
+function fileContains(filePath, needle) {
+  try {
+    if (!isTextFile(filePath)) return false;
+    const content = fs.readFileSync(filePath, 'utf8');
+    return content.includes(needle);
+  } catch (e) {
+    return false;
+  }
+}
+
+function findReferences(scriptPath, ctx, allFiles) {
+  const { repoRoot } = ctx;
+  const basename = path.basename(scriptPath);
+  const candidates = [scriptPath, basename, scriptPath.replace(/\\\\/g, '/')];
+  const refs = [];
+  for (const f of allFiles) {
+    if (path.relative(repoRoot, f) === scriptPath) continue;
+    for (const c of candidates) {
+      if (fileContains(f, c)) {
+        refs.push({ file: path.relative(repoRoot, f), match: c });
+        break;
+      }
+    }
+  }
+  return refs;
+}
+
+function runDetector(ctx) {
+  const scripts = collectScriptFiles(ctx);
+  if (scripts.length === 0) {
+    console.log('No scripts found in', ctx.scriptDirs.join(', '));
+    return { ok: true, orphaned: [] };
+  }
+
+  const allFiles = walk(ctx.repoRoot).map(p => path.relative(ctx.repoRoot, p));
+  const textFiles = allFiles.filter(p => isTextFile(p));
+
+  const orphaned = [];
+  for (const s of scripts) {
+    const refs = findReferences(s, ctx, textFiles.map(p => path.join(ctx.repoRoot, p)).filter(Boolean));
+    if (refs.length === 0) orphaned.push(s);
+  }
+
+  if (orphaned.length > 0) {
+    return { ok: false, orphaned };
+  }
+
+  return { ok: true, orphaned: [] };
+}
+
+if (require.main === module) {
+  const ctx = createContext();
+  const res = runDetector(ctx);
+  if (!res.ok) {
+    console.error('\nFound orphaned scripts (no references found):');
+    for (const o of res.orphaned) console.error(' -', o);
+    console.error('\nFailing CI. If these scripts are intentionally standalone, update the CI guard to allow-list them or add references.');
+    process.exit(1);
+  }
+  console.log('✅ No orphaned scripts found');
+}
+
+module.exports = { createContext, collectScriptFiles, findReferences, runDetector, isTextFile, walk };

--- a/tests/check-orphaned-scripts.test.js
+++ b/tests/check-orphaned-scripts.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createContext, runDetector } = require('../scripts/check-orphaned-scripts');
+
+function mkdtemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'orphan-test-'));
+}
+
+function writeFile(root, rel, content) {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+  return full;
+}
+
+function testNoOrphans() {
+  const tmp = mkdtemp();
+  try {
+    writeFile(tmp, 'scripts/foo.sh', '#!/bin/sh\necho hi');
+    writeFile(tmp, 'README.md', 'This repo uses scripts/foo.sh in docs');
+    const ctx = createContext(tmp, ['scripts']);
+    const res = runDetector(ctx);
+    assert.strictEqual(res.ok, true, 'Expected no orphaned scripts');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function testHasOrphan() {
+  const tmp = mkdtemp();
+  try {
+    writeFile(tmp, 'scripts/orphan.sh', '#!/bin/sh\necho orphan');
+    writeFile(tmp, 'somefile.txt', 'no references here');
+    const ctx = createContext(tmp, ['scripts']);
+    const res = runDetector(ctx);
+    assert.strictEqual(res.ok, false, 'Expected orphaned scripts detected');
+    const normalized = res.orphaned.map(p => p.replace(/\\/g, '/'));
+    assert.ok(Array.isArray(res.orphaned) && normalized.includes('scripts/orphan.sh'));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function runAll() {
+  testNoOrphans();
+  testHasOrphan();
+}
+
+module.exports = { runAll };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,10 @@
+const { runAll } = require('./check-orphaned-scripts.test');
+
+try {
+  runAll();
+  console.log('All tests passed');
+  process.exit(0);
+} catch (e) {
+  console.error('Tests failed:', e && e.stack ? e.stack : e);
+  process.exit(1);
+}


### PR DESCRIPTION
Added a detector and CI job to fail builds when scripts under scripts or scripts have no references. This is to prevent the accumulation of stale/one-off scripts that increase maintenance and security risk; surface unreferenced scripts early in CI. 
Closed #1254

