### PR TITLE
#899 [FE-068] Add frontend changelog policy for breaking type/model c…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -123,6 +123,24 @@ Closes #<!-- issue number -->
 
 ---
 
+---
+
+## Breaking Type / Model Changes (Frontend — FE-068)
+
+> Required if your PR modifies any file under `FrontEnd/my-app/lib/types/**`,
+> `FrontEnd/my-app/lib/api/**`, `FrontEnd/my-app/lib/schemas/**`,
+> `FrontEnd/my-app/lib/validation/**`, or `FrontEnd/my-app/context/walletTypes.ts`.
+>
+> Full policy: [`FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md`](../FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md)
+
+- [ ] My PR touches **none** of the watched type/model paths — not applicable.
+- [ ] I classified my change as: ☐ `breaking-types` ☐ `breaking-runtime` ☐ `added` ☐ `changed` ☐ `deprecated` ☐ `removed` ☐ `fixed` ☐ `security`
+- [ ] I added a bullet to `## [Unreleased]` in [`FrontEnd/my-app/CHANGELOG.md`](../FrontEnd/my-app/CHANGELOG.md) **OR** a new file in [`FrontEnd/my-app/.changeset/`](../FrontEnd/my-app/.changeset/README.md).
+- [ ] If breaking, my entry includes a before/after `Migration:` code block.
+- [ ] `cd FrontEnd/my-app && npm run changelog:check` passes locally.
+- [ ] If I am asserting this change is non-breaking despite touching a watched file, I added the `changelog-skip` label or `[changelog-skip]` to the PR title.
+
+
 ## Final Pre-Merge Checklist
 
 - [ ] Branch is up to date with `main` / `master`

--- a/.github/workflows/frontend-changelog.yml
+++ b/.github/workflows/frontend-changelog.yml
@@ -1,0 +1,50 @@
+name: Frontend Changelog
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'FrontEnd/my-app/lib/types/**'
+      - 'FrontEnd/my-app/lib/api/**'
+      - 'FrontEnd/my-app/lib/schemas/**'
+      - 'FrontEnd/my-app/lib/validation/**'
+      - 'FrontEnd/my-app/context/walletTypes.ts'
+      - 'FrontEnd/my-app/CHANGELOG.md'
+      - 'FrontEnd/my-app/.changeset/**'
+      - 'FrontEnd/my-app/scripts/check-changelog.mjs'
+      - '.github/workflows/frontend-changelog.yml'
+
+jobs:
+  changelog-policy:
+    name: Verify CHANGELOG / changeset entry (FE-068)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR with full history
+        uses: actions/checkout@v4
+        with:
+          # Needed so `git merge-base` can resolve the PR base.
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Detect 'changelog-skip' label
+        id: skip
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -q '"changelog-skip"'; then
+            echo "CHANGELOG_SKIP=1" >> "$GITHUB_ENV"
+            echo "Skip label present — guard will pass."
+          else
+            echo "CHANGELOG_SKIP=0" >> "$GITHUB_ENV"
+          fi
+
+      - name: Run changelog guard
+        working-directory: FrontEnd/my-app
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          CHANGELOG_BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: node scripts/check-changelog.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -466,3 +466,29 @@ Use this checklist when reviewing any PR targeting the NestJS backend:
 ---
 
 *For questions, open a GitHub Discussion or ping a maintainer in the PR comments.*
+
+---
+
+## 10. Frontend Changelog Policy (FE-068)
+
+The frontend (`FrontEnd/my-app/`) maintains a Keep-a-Changelog-style
+[`CHANGELOG.md`](FrontEnd/my-app/CHANGELOG.md) so that every breaking
+TypeScript type, interface, enum, Zod schema, or API model change is
+announced and migratable.
+
+**Read the full policy:**
+[`FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md`](FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md)
+
+In short:
+
+1. If your PR modifies any file under
+   `FrontEnd/my-app/lib/types/**`, `lib/api/**`, `lib/schemas/**`,
+   `lib/validation/**`, or `context/walletTypes.ts`, you must either
+   update [`CHANGELOG.md`](FrontEnd/my-app/CHANGELOG.md) or add a file in
+   [`FrontEnd/my-app/.changeset/`](FrontEnd/my-app/.changeset/README.md).
+2. For breaking changes the entry **must** include a before/after
+   `Migration:` code block.
+3. CI runs `npm run changelog:check` via the
+   [`frontend-changelog`](.github/workflows/frontend-changelog.yml) workflow.
+4. To bypass for a verified non-breaking change, add the
+   `changelog-skip` label or `[changelog-skip]` token to the PR title.

--- a/FrontEnd/my-app/.changeset/README.md
+++ b/FrontEnd/my-app/.changeset/README.md
@@ -1,0 +1,31 @@
+# Changesets (Frontend)
+
+This folder collects per-PR change notes that the release script aggregates
+into the top-level [`CHANGELOG.md`](../CHANGELOG.md).
+
+## When to add a file here
+
+You **must** add a file here (or edit `CHANGELOG.md` directly) when your PR
+modifies any of the watched paths listed in
+[`docs/TYPE_CHANGES_POLICY.md §3`](../docs/TYPE_CHANGES_POLICY.md#3-which-files-are-watched).
+
+## How to add a file
+
+1. Copy [`TEMPLATE.md`](./TEMPLATE.md) to a new file in this directory.
+2. Name it `YYYY-MM-DD-<short-kebab-slug>.md`
+   (e.g. `2026-05-27-rename-questsstatus-paused.md`).
+   3. Fill in the frontmatter and body.
+   4. Commit it as part of your PR.
+
+   ## How they get released
+
+   A maintainer running the release process (see
+   [`docs/TYPE_CHANGES_POLICY.md §6`](../docs/TYPE_CHANGES_POLICY.md#6-release-process-maintainer-only))
+   moves every file in this folder into the next release block in
+   `CHANGELOG.md` and deletes the consumed files.
+
+   ## Skipping
+
+   For a strictly non-breaking PR that the CI guard flagged, do **not** add a
+   dummy file. Instead, add the label `changelog-skip` to the PR or put
+   `[changelog-skip]` in the PR title / commit message.

--- a/FrontEnd/my-app/.changeset/TEMPLATE.md
+++ b/FrontEnd/my-app/.changeset/TEMPLATE.md
@@ -1,0 +1,28 @@
+---
+# One of: breaking-types | breaking-runtime | added | changed | deprecated | removed | fixed | security
+type: breaking-types
+
+# Link the PR or issue number(s) this changeset belongs to.
+pr: 0
+
+# List every exported symbol affected, using `path → Name` format.
+symbols:
+  - lib/types/quest.ts → QuestStatus
+  ---
+
+  <!--
+    Write a one-paragraph human summary of the change here. Be specific:
+      who does this affect, and why was it done?
+      -->
+
+      A short summary of what changed and why.
+
+      ### Migration
+
+      ```ts
+      // before
+      quest.status === QuestStatus.PAUSED;
+
+      // after
+      quest.status === QuestStatus.ON_HOLD;
+      ```

--- a/FrontEnd/my-app/.prettierignore
+++ b/FrontEnd/my-app/.prettierignore
@@ -9,3 +9,8 @@ next-env.d.ts
 coverage
 playwright-report
 test-results
+
+# FE-068 — keep author-controlled formatting in changelog & policy artefacts.
+CHANGELOG.md
+.changeset/
+docs/TYPE_CHANGES_POLICY.md

--- a/FrontEnd/my-app/CHANGELOG.md
+++ b/FrontEnd/my-app/CHANGELOG.md
@@ -1,0 +1,131 @@
+# Frontend Changelog
+
+All notable changes to the **StellarEarn Frontend** (`FrontEnd/my-app`) are
+documented in this file.
+
+The format is based on
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **鈿狅笍 Breaking type / model changes MUST be recorded here.**
+> See
+> [`docs/TYPE_CHANGES_POLICY.md`](./docs/TYPE_CHANGES_POLICY.md)
+> for the full policy, definitions, and examples. PRs that modify files under
+> `lib/types/**`, `lib/api/**`, `lib/schemas/**` or `lib/validation/**` are
+> automatically checked by the
+> [`Frontend Changelog`](../../.github/workflows/frontend-changelog.yml)
+> workflow.
+
+---
+
+## Section Legend
+
+Each release block uses the following ordered sections (omit empty ones):
+
+| Section                         | Use for                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **馃挜 Breaking 鈥� Types/Models**  | Any incompatible change to a TypeScript type, interface, enum, Zod schema, or API response shape |
+| **馃挜 Breaking 鈥� Runtime/API**   | Any incompatible runtime behaviour, route, prop, or env-var change                               |
+| **鉁� Added**                    | New features, types, hooks, or models (additive only)                                            |
+| **馃洜 Changed**                  | Backwards-compatible changes to existing behaviour                                               |
+| **鉀� Deprecated**               | Soon-to-be-removed types or APIs                                                                 |
+| **馃棏 Removed**                  | Previously-deprecated types or APIs that are now gone                                            |
+| **馃悰 Fixed**                    | Bug fixes                                                                                        |
+| **馃敀 Security**                 | Vulnerability fixes                                                                              |
+
+Every **馃挜 Breaking 鈥� Types/Models** entry must include:
+
+1. The fully-qualified symbol (e.g. `lib/types/quest.ts 鈫� QuestStatus`).
+2. A one-line summary of the change.
+3. A **Migration** sub-bullet showing the before 鈫� after code.
+4. The PR or issue number (e.g. `(#068)`).
+
+---
+
+## [Unreleased]
+
+### 馃挜 Breaking 鈥� Types/Models
+
+_None yet._
+
+### 鉁� Added
+
+- **Frontend changelog policy** for breaking type / model changes
+  ([FE-068](https://github.com/Kappa16/stellar_Earn/issues/068)).
+    - New canonical `FrontEnd/my-app/CHANGELOG.md` (this file).
+      - New policy document at
+          [`docs/TYPE_CHANGES_POLICY.md`](./docs/TYPE_CHANGES_POLICY.md).
+            - New lightweight changeset workflow under
+                [`.changeset/`](./.changeset/README.md).
+                  - New CI guard
+                      [`scripts/check-changelog.mjs`](./scripts/check-changelog.mjs) wired into
+                          `npm run changelog:check` and the
+                              [`frontend-changelog.yml`](../../.github/workflows/frontend-changelog.yml)
+                                  workflow.
+
+                                  ### 馃洜 Changed
+
+                                  - Updated root [`CONTRIBUTING.md`](../../CONTRIBUTING.md) and the
+                                    [PR template](../../.github/pull_request_template.md) with a "Breaking
+                                      Type/Model Changes" checklist that links to this changelog.
+
+                                      ### 鉀� Deprecated
+
+                                      _None yet._
+
+                                      ### 馃棏 Removed
+
+                                      _None yet._
+
+                                      ### 馃悰 Fixed
+
+                                      _None yet._
+
+                                      ### 馃敀 Security
+
+                                      _None yet._
+
+                                      ---
+
+                                      ## Worked Example 鈥� How to Document a Breaking Type Change
+
+                                      > The following block is **illustrative only** 鈥� keep it at the bottom of the
+                                      > file forever as a template for new contributors.
+
+                                      ```markdown
+                                      ## [1.2.0] 鈥� 2026-06-15
+
+                                      ### 馃挜 Breaking 鈥� Types/Models
+
+                                      - **`lib/types/quest.ts 鈫� QuestStatus`** 鈥� renamed `PAUSED` to `ON_HOLD` to
+                                        match the new contract event name. (#412)
+
+                                          **Migration:**
+
+                                            ```ts
+                                              // before
+                                                import { QuestStatus } from '@/lib/types';
+                                                  if (quest.status === QuestStatus.PAUSED) { 鈥� }
+
+                                                    // after
+                                                      import { QuestStatus } from '@/lib/types';
+                                                        if (quest.status === QuestStatus.ON_HOLD) { 鈥� }
+                                                          ```
+
+                                                          - **`lib/types/api.types.ts 鈫� PaginationMeta`** 鈥� `cursor` is now required
+                                                            (was optional). All consumers must pass a cursor when paginating. (#418)
+
+                                                              **Migration:**
+
+                                                                ```ts
+                                                                  // before
+                                                                    const meta: PaginationMeta = { page: 1, limit: 20, total: 0, totalPages: 0, hasMore: false };
+
+                                                                      // after
+                                                                        const meta: PaginationMeta = { page: 1, limit: 20, total: 0, totalPages: 0, hasMore: false, cursor: '' };
+                                                                          ```
+                                                                          ```
+
+                                                                          ---
+
+                                                                          [Unreleased]: https://github.com/Kappa16/stellar_Earn/compare/HEAD

--- a/FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md
+++ b/FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md
@@ -1,0 +1,183 @@
+# Frontend Changelog Policy — Breaking Type & Model Changes
+
+**Status:** Active
+**Owner:** Frontend maintainers
+**Applies to:** Everything under `FrontEnd/my-app/`
+**Related:**
+[`CHANGELOG.md`](../CHANGELOG.md) ·
+[`.changeset/`](../.changeset/README.md) ·
+[`scripts/check-changelog.mjs`](../scripts/check-changelog.mjs) ·
+[`frontend-changelog.yml`](../../../.github/workflows/frontend-changelog.yml)
+
+---
+
+## 1. Why This Policy Exists
+
+The StellarEarn frontend is the single TypeScript consumer of:
+
+- Backend REST/Swagger contracts (`lib/api/*`, `lib/types/api.types.ts`)
+- Smart-contract event/model shapes (`lib/types/quest.ts`, `lib/types/reputation.ts`, …)
+- Internal domain models (`lib/types/*.ts`, `lib/schemas/*.ts`, `lib/validation/*.ts`)
+
+A silent change to any of these can:
+
+- Break dependent packages (e.g. the `subgraph/` resolvers, future mobile app).
+- Silently change runtime behaviour after a deploy.
+- Hide regressions until the next release.
+
+**This policy guarantees that every breaking type/model change is announced,
+versioned, and migratable.**
+
+---
+
+## 2. What Counts as a "Breaking Type/Model Change"
+
+A change is **breaking** if any external consumer (another file, another
+package, another contributor's open branch) could plausibly fail to compile or
+behave incorrectly after the change.
+
+### 2.1 Always breaking ⛔
+
+| Change                                                                                                | Example                                                          |
+| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Renaming an exported `type`, `interface`, `enum`, `class`, or `const`-as-enum                         | `QuestStatus.PAUSED` → `QuestStatus.ON_HOLD`                     |
+| Removing an exported symbol                                                                           | `export type QuestFilters` deleted                               |
+| Removing or renaming a member of an exported type/interface/enum                                      | `Quest.rewardAmount` → `Quest.amount`                            |
+| Changing the **TS type** of a member (incl. widening `string` → `string \| null`)                     | `id: string` → `id: string \| null`                              |
+| Turning an **optional** member into **required**                                                      | `cursor?: string` → `cursor: string`                             |
+| Changing a literal-union member                                                                       | `'beginner' \| 'intermediate'` → `'easy' \| 'medium'`            |
+| Changing the **runtime** value of a `const`-as-enum without changing the type name                   | `QuestDifficulty.EASY = 'beginner'` → `'EASY'`                   |
+| Changing a Zod schema in a way that rejects previously-valid input                                   | `z.string()` → `z.string().uuid()`                               |
+| Changing the **HTTP shape** assumed by a function in `lib/api/*`                                      | `/quests` now returns `{ items, meta }` instead of `{ data }`    |
+| Changing the **arguments** of a public hook (`lib/hooks/*`) or store action (`lib/store/slices/*`)    | `useQuests(filters)` → `useQuests(filters, options)` (positional) |
+
+### 2.2 Not breaking ✅ (but still log under **Added** / **Changed**)
+
+| Change                                                          | Why it's safe                                  |
+| --------------------------------------------------------------- | ---------------------------------------------- |
+| Adding a new optional member                                    | Existing code still type-checks                |
+| Adding a new exported type / hook                               | Purely additive                                |
+| Adding a new union member to a type that is **only produced**, never consumed exhaustively in a `switch` | No exhaustive checks break |
+| Internal-only refactor (no `export` change)                     | No external surface                            |
+| Loosening a Zod schema (e.g. removing `.min(1)`)                | Previously-valid input is still valid          |
+
+> When in doubt, **treat the change as breaking**. The cost of an extra
+> CHANGELOG entry is near zero; the cost of a silent break is high.
+
+---
+
+## 3. Which Files Are Watched
+
+The CI guard (`scripts/check-changelog.mjs`) treats edits to **any** of the
+following as a potentially breaking change and requires either a `CHANGELOG.md`
+update or a `.changeset/*.md` file in the same PR:
+
+```
+FrontEnd/my-app/lib/types/**
+FrontEnd/my-app/lib/api/**
+FrontEnd/my-app/lib/schemas/**
+FrontEnd/my-app/lib/validation/**
+FrontEnd/my-app/context/walletTypes.ts
+```
+
+To opt-out for a strictly non-breaking change, add the label
+`changelog-skip` to the PR **or** include the literal token
+`[changelog-skip]` in the PR title or commit message.
+
+---
+
+## 4. The Two Ways to Record a Change
+
+### 4.1 Direct `CHANGELOG.md` edit (recommended for solo PRs)
+
+Add a bullet to the `## [Unreleased]` section of
+[`CHANGELOG.md`](../CHANGELOG.md), under the correct heading
+(💥 / ✨ / 🛠 / ⛔ / 🗑 / 🐛 / 🔒).
+
+For a breaking type/model change you **must** include:
+
+1. The fully-qualified symbol (file path → exported name).
+2. A one-line summary.
+3. A `Migration:` code block with **before** / **after**.
+4. The issue or PR number.
+
+### 4.2 Changeset file (recommended when multiple PRs target the same release)
+
+Create one markdown file in `.changeset/`, named
+`YYYY-MM-DD-<short-slug>.md` (kebab-case), with the frontmatter shown in
+[`.changeset/TEMPLATE.md`](../.changeset/TEMPLATE.md):
+
+```markdown
+---
+pr: 068
+type: breaking-types     # one of: breaking-types | breaking-runtime | added | changed | deprecated | removed | fixed | security
+symbols:
+  - lib/types/quest.ts → QuestStatus
+  ---
+
+  Renamed `QuestStatus.PAUSED` to `QuestStatus.ON_HOLD` to align with the
+  contract event name.
+
+  ### Migration
+
+  ```ts
+  // before
+  quest.status === QuestStatus.PAUSED;
+  // after
+  quest.status === QuestStatus.ON_HOLD;
+  ```
+  ```
+
+  A release script (run manually by a maintainer) collapses all `.changeset/*.md`
+  files into the next release block in `CHANGELOG.md` and deletes them.
+
+  ---
+
+  ## 5. Review Checklist (copy into every PR that touches watched files)
+
+  ```markdown
+  ### Breaking Type/Model Changes — FE-068
+
+  - [ ] I read [`docs/TYPE_CHANGES_POLICY.md`](FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md).
+  - [ ] I classified my change as: ☐ breaking-types ☐ breaking-runtime ☐ additive ☐ no-op
+  - [ ] If breaking: I added a `💥 Breaking — Types/Models` bullet in `CHANGELOG.md` **OR** a `.changeset/*.md` file.
+  - [ ] My entry includes a before/after `Migration:` block.
+  - [ ] My entry references this PR / issue number.
+  - [ ] I ran `npm run changelog:check` locally and it passed.
+  ```
+
+  ---
+
+  ## 6. Release Process (maintainer-only)
+
+  1. `cd FrontEnd/my-app`
+  2. `npm run changelog:check` (must pass).
+  3. Decide the next version per SemVer:
+     - **MAJOR** if there is _any_ `💥 Breaking` entry in `## [Unreleased]`.
+        - **MINOR** for additive (`✨ Added`) changes only.
+           - **PATCH** for `🐛 Fixed`, `🔒 Security`, or `🛠 Changed`-only releases.
+           4. Rename `## [Unreleased]` → `## [X.Y.Z] — YYYY-MM-DD` and re-create a fresh
+              empty `## [Unreleased]` block at the top.
+              5. Move every `.changeset/*.md` body into the new release block, then delete
+                 the consumed `.changeset/*.md` files.
+                 6. Bump `version` in `FrontEnd/my-app/package.json`.
+                 7. Tag the commit `frontend-vX.Y.Z` and push.
+
+                 ---
+
+                 ## 7. FAQ
+
+                 **Q: I only renamed a private (non-exported) type. Do I need to log it?**
+                 A: No. The policy only covers _exported_ surface area.
+
+                 **Q: I added a new optional field to `Quest`. Breaking?**
+                 A: No — log it under `✨ Added`.
+
+                 **Q: The backend already changed its API; I'm just catching up the FE types.**
+                 A: Still log it under `💥 Breaking — Types/Models` with a migration note. The
+                 FE changelog is the source of truth for FE consumers regardless of who caused
+                 the upstream change.
+
+                 **Q: My PR fails the changelog check but my change really is non-breaking.**
+                 A: Add `[changelog-skip]` to the PR title **or** apply the `changelog-skip`
+                 label. The script will pass and the reviewer will verify your claim.

--- a/FrontEnd/my-app/package.json
+++ b/FrontEnd/my-app/package.json
@@ -12,7 +12,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "changelog:check": "node scripts/check-changelog.mjs",
+    "changelog:check:staged": "node scripts/check-changelog.mjs --staged"
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^1.9.5",

--- a/FrontEnd/my-app/scripts/check-changelog.mjs
+++ b/FrontEnd/my-app/scripts/check-changelog.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * FE-068 — Frontend changelog policy enforcement.
+ *
+ * Verifies that any PR which modifies a "watched" type/model file also
+ * either:
+ *   1. modifies `FrontEnd/my-app/CHANGELOG.md`, OR
+ *   2. adds a new file under `FrontEnd/my-app/.changeset/` (excluding
+ *      README.md and TEMPLATE.md), OR
+ *   3. opts out via `[changelog-skip]` in the PR title or any commit
+ *      message in the range, or the `changelog-skip` label (handled by
+ *      the GitHub Actions workflow).
+ *
+ * Usage:
+ *   node scripts/check-changelog.mjs                # compare HEAD vs merge-base with origin/main
+ *   node scripts/check-changelog.mjs --base <ref>   # explicit base ref
+ *   node scripts/check-changelog.mjs --staged       # check staged files only (pre-commit)
+ *
+ * Exit codes:
+ *   0 — OK (no watched files changed, OR a changelog entry was added, OR skipped)
+ *   1 — Violation (watched file changed without changelog/changeset)
+ *   2 — Tool error (git unavailable, etc.)
+ *
+ * No third-party dependencies. Node ≥ 18.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..', '..'); // /…/stellar_Earn
+const feRoot = resolve(__dirname, '..'); // /…/stellar_Earn/FrontEnd/my-app
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const opt = (name, fallback) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const STAGED_ONLY = flag('--staged');
+const BASE_REF = opt('--base', process.env.CHANGELOG_BASE_REF || '');
+const QUIET = flag('--quiet');
+
+// ---------------------------------------------------------------------------
+// Watched paths (POSIX-style, relative to repo root)
+// ---------------------------------------------------------------------------
+const WATCHED = [
+  /^FrontEnd\/my-app\/lib\/types\//,
+  /^FrontEnd\/my-app\/lib\/api\//,
+  /^FrontEnd\/my-app\/lib\/schemas\//,
+  /^FrontEnd\/my-app\/lib\/validation\//,
+  /^FrontEnd\/my-app\/context\/walletTypes\.ts$/,
+];
+
+const CHANGELOG_PATH = /^FrontEnd\/my-app\/CHANGELOG\.md$/;
+const CHANGESET_FILE = /^FrontEnd\/my-app\/\.changeset\/(?!README\.md$|TEMPLATE\.md$).+\.md$/;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function sh(cmd, opts = {}) {
+  return execSync(cmd, { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'], ...opts })
+    .toString()
+    .trim();
+}
+
+function log(...a) {
+  if (!QUIET) console.log('[changelog-check]', ...a);
+}
+function warn(...a) {
+  console.warn('[changelog-check] ⚠', ...a);
+}
+function fail(msg) {
+  console.error(`\n❌ [changelog-check] ${msg}\n`);
+  process.exit(1);
+}
+
+function getChangedFiles() {
+  if (STAGED_ONLY) {
+    return sh('git diff --name-only --cached').split('\n').filter(Boolean);
+  }
+
+  // Resolve the base ref.
+  let base = BASE_REF;
+  if (!base) {
+    // Try common defaults in order.
+    const candidates = [
+      'origin/main',
+      'origin/master',
+      'upstream/main',
+      'upstream/master',
+      'main',
+      'master',
+    ];
+    for (const c of candidates) {
+      try {
+        sh(`git rev-parse --verify --quiet ${c}^{commit}`);
+        base = c;
+        break;
+      } catch {
+        /* keep trying */
+      }
+    }
+  }
+
+  if (!base) {
+    warn(
+      'No base ref found (tried origin/main, origin/master, main, master). ' +
+        'Falling back to HEAD~1.',
+    );
+    base = 'HEAD~1';
+  }
+
+  let mergeBase;
+  try {
+    mergeBase = sh(`git merge-base ${base} HEAD`);
+  } catch {
+    mergeBase = base;
+  }
+
+  log(`Comparing HEAD against ${base} (merge-base ${mergeBase.slice(0, 8)})`);
+  return sh(`git diff --name-only ${mergeBase}...HEAD`)
+    .split('\n')
+    .filter(Boolean);
+}
+
+function isSkipRequested(changedFiles) {
+  // 1. Env var (set by the GH workflow when the `changelog-skip` label is present).
+  if (process.env.CHANGELOG_SKIP === '1' || process.env.CHANGELOG_SKIP === 'true') {
+    return 'env CHANGELOG_SKIP=1';
+  }
+  // 2. PR title / commit messages.
+  const needles = [/\[changelog-skip\]/i, /\[skip changelog\]/i];
+  const prTitle = process.env.PR_TITLE || '';
+  if (needles.some((r) => r.test(prTitle))) return `PR title contains skip token`;
+
+  try {
+    const msgs = sh('git log -50 --pretty=%B');
+    if (needles.some((r) => r.test(msgs))) return 'commit message contains skip token';
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function main() {
+  // Sanity checks
+  if (!existsSync(resolve(feRoot, 'CHANGELOG.md'))) {
+    fail(
+      `CHANGELOG.md is missing at ${resolve(feRoot, 'CHANGELOG.md')}. ` +
+        'See docs/TYPE_CHANGES_POLICY.md.',
+    );
+  }
+  if (!existsSync(resolve(feRoot, '.changeset'))) {
+    fail(
+      `.changeset/ directory is missing at ${resolve(feRoot, '.changeset')}. ` +
+        'See docs/TYPE_CHANGES_POLICY.md.',
+    );
+  }
+
+  let changed;
+  try {
+    changed = getChangedFiles();
+  } catch (e) {
+    console.error('[changelog-check] git failed:', e.message);
+    process.exit(2);
+  }
+
+  if (changed.length === 0) {
+    log('No file changes detected — nothing to verify. ✅');
+    process.exit(0);
+  }
+
+  const watchedHits = changed.filter((f) => WATCHED.some((r) => r.test(f)));
+  if (watchedHits.length === 0) {
+    log(`No watched type/model files changed (${changed.length} files diffed). ✅`);
+    process.exit(0);
+  }
+
+  log(`Watched files modified (${watchedHits.length}):`);
+  watchedHits.forEach((f) => log('  •', f));
+
+  const skipReason = isSkipRequested(changed);
+  if (skipReason) {
+    log(`Skip token detected (${skipReason}) — bypassing changelog requirement. ⚠ ✅`);
+    process.exit(0);
+  }
+
+  const changelogTouched = changed.some((f) => CHANGELOG_PATH.test(f));
+  const changesetAdded = changed.some((f) => CHANGESET_FILE.test(f));
+
+  if (changelogTouched) {
+    log('CHANGELOG.md was updated in this diff. ✅');
+    process.exit(0);
+  }
+  if (changesetAdded) {
+    log('A .changeset/*.md file was added in this diff. ✅');
+    process.exit(0);
+  }
+
+  // Hard fail with an instructive message.
+  const watchedList = watchedHits.map((f) => `  • ${f}`).join('\n');
+  fail(
+    `This PR modifies watched frontend type/model files but does NOT update
+${'   '}FrontEnd/my-app/CHANGELOG.md and does NOT add a .changeset/*.md entry.
+
+Watched files changed:
+${watchedList}
+
+Resolve in one of these ways:
+
+  1. Add a bullet under "## [Unreleased]" in
+     FrontEnd/my-app/CHANGELOG.md (preferred for single-PR work).
+  2. Create a new file in FrontEnd/my-app/.changeset/ based on
+     FrontEnd/my-app/.changeset/TEMPLATE.md (preferred when several PRs
+     target the same release).
+  3. If the change is truly non-breaking, add the "changelog-skip" label
+     to the PR or include "[changelog-skip]" in the PR title /
+     commit message.
+
+Full policy: FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md`,
+  );
+}
+
+// Defensive: list .changeset for friendly error messages
+try {
+  readdirSync(resolve(feRoot, '.changeset'));
+} catch {
+  /* the existsSync check above handles this */
+}
+
+main();


### PR DESCRIPTION
[FE-068] Add frontend changelog policy for breaking type/model changes FIXED

Key Findings

Issue FE-068 identified the absence of a frontend changelog policy for breaking type and model changes in the Kappa16/stellar_Earn monorepo. The repository contains multiple packages, including a Next.js and TypeScript frontend with a large shared public type surface used across the application and related services. Before the fix, the project lacked a CHANGELOG.md, a formal type-change policy, a changeset workflow, and CI validation for frontend type-breaking updates. Existing CI already enforced linting, type checking, formatting, and dependency auditing, which made changelog enforcement a natural addition.

Fix Features

The solution introduced a complete frontend changelog and type-change management system. A canonical CHANGELOG.md using the Keep a Changelog format was added with a dedicated breaking changes section and FE-068 already documented. A detailed TYPE_CHANGES_POLICY.md now defines breaking type changes, watched paths, contributor responsibilities, and release procedures. Lightweight changeset support was added without external dependencies, alongside a zero-dependency Node.js guard script that detects watched file changes and enforces changelog updates during pull requests. A new GitHub Actions workflow runs the validation automatically and supports changelog skip controls. Additional updates included new npm scripts for changelog checks, pull request template checklists, CONTRIBUTING.md guidance, and Prettier exclusions for changelog-related markdown files.

CLOSE #899 