### PR TITLE
feat(jobs): add graceful worker shutdown with in-flight drain

### DIFF
--- a/BackEnd/src/modules/jobs/jobs.service.ts
+++ b/BackEnd/src/modules/jobs/jobs.service.ts
@@ -42,8 +42,65 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleDestroy() {
-    await Promise.all(Object.values(this.queues).map((q) => q.close()));
-    await Promise.all(this.workers.map((w) => w.close()));
+    this.logger.log('Initiating graceful shutdown of background workers and queues...');
+
+    const timeoutMs = parseInt(process.env.WORKER_SHUTDOWN_TIMEOUT_MS || '10000', 10);
+
+    // 1. Pause all workers to stop fetching new jobs
+    if (this.workers.length > 0) {
+      this.logger.log(`Pausing ${this.workers.length} workers...`);
+      await Promise.all(
+        this.workers.map(async (worker) => {
+          try {
+            await worker.pause(true);
+            this.logger.log(`Worker for queue ${worker.name} paused.`);
+          } catch (error) {
+            this.logger.error(`Error pausing worker for queue ${worker.name}: ${error.message}`);
+          }
+        }),
+      );
+
+      // 2. Close/drain workers with timeout
+      this.logger.log(`Closing and draining workers (timeout: ${timeoutMs}ms)...`);
+      await Promise.all(
+        this.workers.map(async (worker) => {
+          try {
+            const closePromise = worker.close();
+            const timeoutPromise = new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error(`Drain timeout of ${timeoutMs}ms exceeded`)), timeoutMs)
+            );
+            await Promise.race([closePromise, timeoutPromise]);
+            this.logger.log(`Worker for queue ${worker.name} closed successfully.`);
+          } catch (error) {
+            this.logger.warn(`Failed to drain worker for queue ${worker.name} gracefully: ${error.message}. Force closing...`);
+            try {
+              await worker.close(true);
+              this.logger.log(`Worker for queue ${worker.name} force closed.`);
+            } catch (forceError) {
+              this.logger.error(`Error force closing worker for queue ${worker.name}: ${forceError.message}`);
+            }
+          }
+        }),
+      );
+    }
+
+    // 3. Once workers are completely closed, safely close the queues
+    const queueNames = Object.keys(this.queues);
+    if (queueNames.length > 0) {
+      this.logger.log(`Closing ${queueNames.length} queues...`);
+      await Promise.all(
+        Object.entries(this.queues).map(async ([name, queue]) => {
+          try {
+            await queue.close();
+            this.logger.log(`Queue ${name} closed successfully.`);
+          } catch (error) {
+            this.logger.error(`Error closing queue ${name}: ${error.message}`);
+          }
+        }),
+      );
+    }
+
+    this.logger.log('Graceful shutdown completed.');
   }
 
   getQueue(name: string) {

--- a/BackEnd/test/jobs/jobs.service.spec.ts
+++ b/BackEnd/test/jobs/jobs.service.spec.ts
@@ -15,4 +15,56 @@ describe('JobsService (unit)', () => {
   it('addJob should throw when queue not found', async () => {
     await expect(service.addJob('nope', {})).rejects.toThrow();
   });
+
+  describe('onModuleDestroy', () => {
+    it('should pause workers, close workers, and then close queues sequentially', async () => {
+      const callOrder: string[] = [];
+      const mockWorker = {
+        name: 'test-worker',
+        pause: jest.fn().mockImplementation(async () => {
+          callOrder.push('worker.pause');
+        }),
+        close: jest.fn().mockImplementation(async () => {
+          callOrder.push('worker.close');
+        }),
+      };
+      const mockQueue = {
+        close: jest.fn().mockImplementation(async () => {
+          callOrder.push('queue.close');
+        }),
+      };
+
+      service['workers'] = [mockWorker as any];
+      service['queues'] = { 'test-queue': mockQueue as any };
+
+      await service.onModuleDestroy();
+
+      expect(mockWorker.pause).toHaveBeenCalledWith(true);
+      expect(mockWorker.close).toHaveBeenCalled();
+      expect(mockQueue.close).toHaveBeenCalled();
+      expect(callOrder).toEqual(['worker.pause', 'worker.close', 'queue.close']);
+    });
+
+    it('should force close worker on drain timeout', async () => {
+      process.env.WORKER_SHUTDOWN_TIMEOUT_MS = '10';
+      let timer: NodeJS.Timeout | undefined = undefined;
+      const mockWorker = {
+        name: 'slow-worker',
+        pause: jest.fn().mockResolvedValue(undefined),
+        close: jest.fn().mockImplementation(() => new Promise((resolve) => {
+          timer = setTimeout(resolve, 50);
+        })),
+      };
+
+      service['workers'] = [mockWorker as any];
+      service['queues'] = {};
+
+      await service.onModuleDestroy();
+
+      // Should have been force closed (i.e. called close with true)
+      expect(mockWorker.close).toHaveBeenCalledWith(true);
+      clearTimeout(timer);
+      delete process.env.WORKER_SHUTDOWN_TIMEOUT_MS;
+    });
+  });
 });


### PR DESCRIPTION
##Summary

Implements graceful shutdown handling for BullMQ workers to prevent interrupted in-flight jobs and Redis connection errors during NestJS shutdown.

## Changes
Paused workers before shutdown to stop fetching new jobs
Added graceful worker drain and close sequencing
Added configurable WORKER_SHUTDOWN_TIMEOUT_MS timeout handling
Ensured queues close only after worker shutdown completes
Added shutdown lifecycle logging for observability
Added unit tests covering shutdown order and timeout behavior

## Validation
```bash
npx jest
# all tests passing
```

Closes #1134