### PR TITLE
feat(SC-063): Add pre-commit hooks for cargo fmt, clippy, and fast tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# pre-commit hook: runs cargo fmt, clippy, and fast unit tests for staged contract changes.
+#
+# Install: run `make install-hooks` (or `just install-hooks`) from the repo root,
+#          or run `scripts/install-hooks.sh` directly.
+#
+# Skip:    SKIP_CONTRACT_HOOKS=1 git commit  (emergency escape hatch — use sparingly)
+
+set -euo pipefail
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()  { echo -e "${CYAN}[pre-commit]${RESET} $*"; }
+ok()    { echo -e "${GREEN}[pre-commit] ✓${RESET} $*"; }
+warn()  { echo -e "${YELLOW}[pre-commit] ⚠${RESET} $*"; }
+fail()  { echo -e "${RED}[pre-commit] ✗${RESET} $*" >&2; }
+header(){ echo -e "\n${BOLD}${CYAN}── $* ──${RESET}"; }
+
+# ── Escape hatch ──────────────────────────────────────────────────────────────
+if [[ "${SKIP_CONTRACT_HOOKS:-0}" == "1" ]]; then
+  warn "SKIP_CONTRACT_HOOKS=1 — skipping all contract pre-commit checks."
+  exit 0
+fi
+
+# ── Detect staged contract files ─────────────────────────────────────────────
+STAGED_CONTRACT_FILES=$(git diff --cached --name-only --diff-filter=ACMRT | \
+  grep -E '^contracts/earn-quest/.*\.(rs|toml)$' || true)
+
+if [[ -z "$STAGED_CONTRACT_FILES" ]]; then
+  # No contract files staged — nothing to check.
+  exit 0
+fi
+
+info "Staged contract file(s) detected:"
+echo "$STAGED_CONTRACT_FILES" | sed 's/^/  /'
+
+CONTRACT_DIR="$(git rev-parse --show-toplevel)/contracts/earn-quest"
+
+# ── Tool availability checks ─────────────────────────────────────────────────
+if ! command -v cargo &>/dev/null; then
+  fail "cargo not found. Install Rust from https://rustup.rs and re-run."
+  exit 1
+fi
+
+for component in rustfmt clippy; do
+  if ! rustup component list --installed 2>/dev/null | grep -q "^${component}-"; then
+    warn "${component} not installed — attempting install via rustup..."
+    rustup component add "$component" || {
+      fail "Could not install ${component}. Run: rustup component add ${component}"
+      exit 1
+    }
+  fi
+done
+
+# ── Run checks ────────────────────────────────────────────────────────────────
+cd "$CONTRACT_DIR"
+
+FAILED=0
+
+# 1. cargo fmt --check
+header "cargo fmt"
+info "Checking formatting..."
+if cargo fmt --all -- --check 2>&1; then
+  ok "cargo fmt passed."
+else
+  fail "Formatting issues found."
+  echo ""
+  echo -e "  Fix with: ${BOLD}cd contracts/earn-quest && cargo fmt --all${RESET}"
+  echo ""
+  FAILED=1
+fi
+
+# 2. cargo clippy
+header "cargo clippy"
+info "Running clippy linter..."
+if cargo clippy --all-targets --all-features -- -D warnings 2>&1; then
+  ok "cargo clippy passed."
+else
+  fail "Clippy reported warnings or errors."
+  echo ""
+  echo -e "  Fix with: ${BOLD}cd contracts/earn-quest && cargo clippy --all-targets --all-features -- -D warnings${RESET}"
+  echo ""
+  FAILED=1
+fi
+
+# 3. Fast tests (lib unit tests only — excludes the heavier integration test suite)
+header "cargo test --lib"
+info "Running fast unit tests..."
+if cargo test --lib 2>&1; then
+  ok "Fast tests passed."
+else
+  fail "One or more unit tests failed."
+  echo ""
+  echo -e "  Debug with: ${BOLD}cd contracts/earn-quest && cargo test --lib -- --nocapture${RESET}"
+  echo ""
+  FAILED=1
+fi
+
+# ── Result ────────────────────────────────────────────────────────────────────
+echo ""
+if [[ "$FAILED" -ne 0 ]]; then
+  fail "Pre-commit checks FAILED. Commit rejected."
+  echo ""
+  echo -e "  To bypass in an emergency: ${BOLD}SKIP_CONTRACT_HOOKS=1 git commit${RESET}"
+  echo ""
+  exit 1
+fi
+
+ok "All contract pre-commit checks passed."
+exit 0

--- a/contracts/earn-quest/Justfile
+++ b/contracts/earn-quest/Justfile
@@ -13,11 +13,33 @@ build:
 test:
     cargo test
 
+# Fast unit tests only — same subset the pre-commit hook runs
+test-fast:
+    cargo test --lib
+
 fmt:
     cargo fmt
 
 clippy:
     cargo clippy --all-targets --all-features -- -D warnings
+
+# Run fmt check + clippy + fast tests (mirrors the pre-commit hook locally)
+pre-commit-check:
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test --lib
+
+# Install pre-commit hooks into .git/hooks/
+install-hooks:
+    bash ../../scripts/install-hooks.sh
+
+# Verify hooks are installed
+check-hooks:
+    bash ../../scripts/install-hooks.sh --check
+
+# Remove project hooks from .git/hooks/
+remove-hooks:
+    bash ../../scripts/install-hooks.sh --remove
 
 deploy:
     if [ -z "$SOROBAN_SECRET_KEY" ]; then

--- a/contracts/earn-quest/Makefile
+++ b/contracts/earn-quest/Makefile
@@ -2,7 +2,7 @@ CRATE := earn-quest
 WASM := $(shell ls target/wasm32-unknown-unknown/release/*.wasm 2>/dev/null | head -n1)
 NETWORK ?= testnet
 
-.PHONY: help test test-verbose build fmt clippy deploy invoke-register license-check deny-check migration-dry-run migration-apply snapshots snapshots-clean snapshots-verify snapshots-restore snapshots-backup snapshots-stats snapshots-admin snapshots-quest snapshots-payout snapshots-security clean clean-all
+.PHONY: help test test-verbose test-fast build fmt clippy deploy invoke-register license-check deny-check migration-dry-run migration-apply snapshots snapshots-clean snapshots-verify snapshots-restore snapshots-backup snapshots-stats snapshots-admin snapshots-quest snapshots-payout snapshots-security clean clean-all install-hooks check-hooks remove-hooks
 
 # Default target
 help:
@@ -13,10 +13,16 @@ help:
 	@echo "  make build               - Build the contract for wasm32"
 	@echo "  make test                - Run all tests"
 	@echo "  make test-verbose        - Run tests with verbose output"
+	@echo "  make test-fast           - Run fast unit tests only (same as pre-commit hook)"
 	@echo "  make fmt                 - Format code with cargo fmt"
 	@echo "  make clippy              - Run linter (clippy)"
 	@echo "  make license-check       - Run cargo-deny license checks"
 	@echo "  make deny-check          - Run cargo-deny advisory and license checks"
+	@echo ""
+	@echo "Git Hooks:"
+	@echo "  make install-hooks       - Install pre-commit hooks into .git/hooks/"
+	@echo "  make check-hooks         - Verify hooks are installed"
+	@echo "  make remove-hooks        - Uninstall project hooks"
 	@echo ""
 	@echo "Stellar / Soroban Deployment & Interaction:"
 	@echo "  make deploy              - Deploy the compiled WASM to the network"
@@ -62,10 +68,31 @@ fmt:
 	@echo "Formatting code..."
 	cargo fmt
 
+# Run fast unit tests only (lib crate, no integration tests — matches pre-commit hook)
+test-fast:
+	@echo "Running fast unit tests..."
+	cargo test --lib
+
 # Run code compliance checks
 clippy:
 	@echo "Running clippy linter..."
 	cargo clippy --all-targets --all-features -- -D warnings
+
+# ── Git hooks ─────────────────────────────────────────────────────────────────
+
+# Install pre-commit hooks into .git/hooks/
+install-hooks:
+	@echo "Installing git hooks..."
+	@bash ../../scripts/install-hooks.sh
+	@echo "Done. Hooks will run automatically on 'git commit'."
+
+# Verify hooks are installed
+check-hooks:
+	@bash ../../scripts/install-hooks.sh --check
+
+# Remove project hooks from .git/hooks/
+remove-hooks:
+	@bash ../../scripts/install-hooks.sh --remove
 
 # Deploy contract to Stellar network
 deploy:

--- a/contracts/earn-quest/README.md
+++ b/contracts/earn-quest/README.md
@@ -25,10 +25,44 @@ cargo build
 cargo build --target wasm32-unknown-unknown --release
 ```
 
+### Development Setup (Git Hooks)
+
+After cloning, install the pre-commit hooks so `cargo fmt`, `clippy`, and fast unit
+tests run automatically before every commit to contract files:
+
+```bash
+# From the repo root
+bash scripts/install-hooks.sh
+
+# Or from this directory via Make / just
+make install-hooks
+just install-hooks
+```
+
+The hook only fires when `.rs` or `.toml` files inside `contracts/earn-quest/` are
+staged — other commits are unaffected.
+
+To run the same checks manually at any time:
+
+```bash
+make pre-commit-check        # via Make
+just pre-commit-check        # via just
+```
+
+To bypass the hook in an emergency:
+
+```bash
+SKIP_CONTRACT_HOOKS=1 git commit -m "..."
+```
+
 ### Test
 ```bash
 # Run all tests
 cargo test
+
+# Run fast unit tests only (same subset the pre-commit hook uses)
+cargo test --lib
+make test-fast
 
 # Run with output
 cargo test -- --nocapture

--- a/contracts/earn-quest/clippy.toml
+++ b/contracts/earn-quest/clippy.toml
@@ -1,0 +1,15 @@
+# Clippy configuration for the earn-quest Soroban contract.
+# See: https://doc.rust-lang.org/clippy/configuration.html
+
+# Treat integer arithmetic as inherently risky in contract code.
+# Prefer explicit checked_*, saturating_*, or wrapping_* variants.
+arithmetic-side-effects-allowed = []
+
+# Minimum complexity before a function is flagged as too complex.
+cognitive-complexity-threshold = 30
+
+# Maximum number of lines allowed in a function body before clippy warns.
+too-many-lines-threshold = 100
+
+# Maximum number of arguments for a function before clippy warns.
+too-many-arguments-threshold = 8

--- a/contracts/earn-quest/rustfmt.toml
+++ b/contracts/earn-quest/rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Default"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Installs the project's git hooks from .githooks/ into .git/hooks/.
+#
+# Usage:
+#   bash scripts/install-hooks.sh          # install all hooks
+#   bash scripts/install-hooks.sh --check  # verify hooks are installed
+#   bash scripts/install-hooks.sh --remove # uninstall project hooks
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info() { echo -e "${CYAN}[install-hooks]${RESET} $*"; }
+ok()   { echo -e "${GREEN}[install-hooks] ✓${RESET} $*"; }
+warn() { echo -e "${YELLOW}[install-hooks] ⚠${RESET} $*"; }
+fail() { echo -e "${RED}[install-hooks] ✗${RESET} $*" >&2; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS_SRC="$REPO_ROOT/.githooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+if [[ ! -d "$HOOKS_SRC" ]]; then
+  fail "No .githooks/ directory found at $HOOKS_SRC"
+  exit 1
+fi
+
+if [[ ! -d "$HOOKS_DST" ]]; then
+  fail ".git/hooks/ directory not found — are you inside a git repository?"
+  exit 1
+fi
+
+# ── --check: verify hooks are installed ───────────────────────────────────────
+if [[ "${1:-}" == "--check" ]]; then
+  ALL_OK=1
+  for src in "$HOOKS_SRC"/*; do
+    name="$(basename "$src")"
+    dst="$HOOKS_DST/$name"
+    if [[ -x "$dst" ]]; then
+      ok "$name is installed."
+    else
+      warn "$name is NOT installed. Run: bash scripts/install-hooks.sh"
+      ALL_OK=0
+    fi
+  done
+  exit $((1 - ALL_OK))
+fi
+
+# ── --remove: uninstall project hooks ─────────────────────────────────────────
+if [[ "${1:-}" == "--remove" ]]; then
+  for src in "$HOOKS_SRC"/*; do
+    name="$(basename "$src")"
+    dst="$HOOKS_DST/$name"
+    if [[ -f "$dst" ]]; then
+      rm "$dst"
+      ok "Removed $name."
+    fi
+  done
+  exit 0
+fi
+
+# ── Default: install hooks ─────────────────────────────────────────────────────
+INSTALLED=0
+for src in "$HOOKS_SRC"/*; do
+  name="$(basename "$src")"
+  dst="$HOOKS_DST/$name"
+
+  # Back up any existing hook that we didn't install
+  if [[ -f "$dst" ]] && ! diff -q "$src" "$dst" &>/dev/null; then
+    backup="${dst}.bak.$(date +%s)"
+    warn "$name already exists — backing up to $(basename "$backup")"
+    cp "$dst" "$backup"
+  fi
+
+  cp "$src" "$dst"
+  chmod +x "$dst"
+  ok "Installed $name"
+  INSTALLED=$((INSTALLED + 1))
+done
+
+echo ""
+if [[ "$INSTALLED" -eq 0 ]]; then
+  warn "No hook files found in .githooks/ — nothing installed."
+else
+  ok "Installed $INSTALLED hook(s). They will run automatically on 'git commit'."
+  echo ""
+  echo -e "  To skip in an emergency: ${BOLD}SKIP_CONTRACT_HOOKS=1 git commit${RESET}"
+  echo -e "  To uninstall:            ${BOLD}bash scripts/install-hooks.sh --remove${RESET}"
+fi


### PR DESCRIPTION
Closes #1533 

## Summary

- Adds a `pre-commit` git hook that runs `cargo fmt --check`, `cargo clippy -D warnings`, and `cargo test --lib` whenever `.rs` or `.toml` files inside `contracts/earn-quest/` are staged
- Adds `scripts/install-hooks.sh` — a portable installer with `--check` and `--remove` flags
- Adds `rustfmt.toml` and `clippy.toml` to codify formatter and linter configuration that was previously only implied by CI commands
- Extends `Makefile` and `Justfile` with `install-hooks`, `check-hooks`, `remove-hooks`, `test-fast`, and `pre-commit-check` targets
- Documents the setup flow in `contracts/earn-quest/README.md`

## How It Works

The hook is stored in `.githooks/pre-commit` (tracked in git, not `.git/hooks/`). Developers install it once:

```bash
bash scripts/install-hooks.sh
# or
make install-hooks        # from contracts/earn-quest/
just install-hooks
```

On every `git commit` that stages contract files, the hook runs three checks in sequence:

| Step | Command | On failure |
|------|---------|------------|
| 1 | `cargo fmt --all -- --check` | Shows fix command, rejects commit |
| 2 | `cargo clippy --all-targets --all-features -- -D warnings` | Shows fix command, rejects commit |
| 3 | `cargo test --lib` (fast unit tests only) | Shows debug command, rejects commit |

Commits that touch no files under `contracts/earn-quest/` skip all checks entirely.

**Emergency bypass:** `SKIP_CONTRACT_HOOKS=1 git commit -m "..."`

## Why `cargo test --lib` (not `cargo test`)?

The full integration test suite involves snapshot regeneration and takes longer. `--lib` runs only the unit tests inside the crate's `src/` tree — fast enough for a pre-commit check while still catching regressions in core logic. Full integration tests continue to run in CI.

## Files Changed

| File | Change |
|------|--------|
| `.githooks/pre-commit` | New — the hook script |
| `scripts/install-hooks.sh` | New — installer with install / --check / --remove modes |
| `contracts/earn-quest/rustfmt.toml` | New — edition 2021, max_width 100, import grouping |
| `contracts/earn-quest/clippy.toml` | New — complexity and arg-count thresholds |
| `contracts/earn-quest/Makefile` | New targets: `test-fast`, `install-hooks`, `check-hooks`, `remove-hooks`; updated help text |
| `contracts/earn-quest/Justfile` | New recipes: `test-fast`, `pre-commit-check`, `install-hooks`, `check-hooks`, `remove-hooks` |
| `contracts/earn-quest/README.md` | New "Development Setup (Git Hooks)" section |

## Test Plan

- [ ] Clone the repo fresh and run `bash scripts/install-hooks.sh` — verify `.git/hooks/pre-commit` is created and executable
- [ ] Run `make check-hooks` / `just check-hooks` — should report hook installed
- [ ] Stage a `.rs` file with a formatting issue and attempt `git commit` — hook should reject with a clear message pointing to `cargo fmt --all`
- [ ] Stage a `.rs` file that triggers a clippy warning — hook should reject with clippy output
- [ ] Stage a frontend-only file — hook should exit silently (no Rust checks run)
- [ ] Run `SKIP_CONTRACT_HOOKS=1 git commit` — hook should print a skip warning and allow the commit
- [ ] Run `make remove-hooks` — hook file removed from `.git/hooks/`
- [ ] Run `make test-fast` — only lib tests run, no integration tests