### PR TITLE
feat: add poison message handling strategy and quarantine storage [BE-108]

### DIFF
--- a/BackEnd/src/events/entities/poison-message.entity.ts
+++ b/BackEnd/src/events/entities/poison-message.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum PoisonMessageStatus {
+  QUARANTINED = 'quarantined',
+  RETRYING = 'retrying',
+  RESOLVED = 'resolved',
+  DISCARDED = 'discarded',
+}
+
+@Entity('poison_messages')
+export class PoisonMessage {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  eventName: string;
+
+  @Column({ type: 'jsonb' })
+  payload: any;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: any;
+
+  @Column({ type: 'text' })
+  lastError: string;
+
+  @Column({ default: 0 })
+  retryCount: number;
+
+  @Column({ default: 5 })
+  maxRetries: number;
+
+  @Column({
+    type: 'enum',
+    enum: PoisonMessageStatus,
+    default: PoisonMessageStatus.QUARANTINED,
+  })
+  @Index()
+  status: PoisonMessageStatus;
+
+  @Column({ type: 'jsonb', nullable: true })
+  errorHistory: Array<{ error: string; attemptedAt: string }>;
+
+  @Column({ nullable: true })
+  resolvedAt?: Date;
+
+  @CreateDateColumn()
+  @Index()
+  quarantinedAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/BackEnd/src/events/events.module.ts
+++ b/BackEnd/src/events/events.module.ts
@@ -4,12 +4,15 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { EventsService } from './events.service';
 import { AuditLogService } from './services/audit-log.service';
 import { RetryService } from './services/retry.service';
+import { PoisonMessageService } from './services/poison-message.service';
 import { EventStoreService } from './event-store/event-store.service';
 import { EventStore } from './entities/event-store.entity';
+import { PoisonMessage } from './entities/poison-message.entity';
 import { QuestEventsHandler } from './handlers/quest-events.handler';
 import { SubmissionEventsHandler } from './handlers/submission-events.handler';
 import { UserEventsHandler } from './handlers/user-events.handler';
 import { DeadLetterHandler } from './handlers/dead-letter.handler';
+import { PoisonMessageHandler } from './handlers/poison-message.handler';
 import { EventAuditListener } from './listeners/event-audit.listener';
 import { EventPersistenceListener } from './listeners/event-persistence.listener';
 import { DeadLetterQueueListener } from './listeners/dead-letter-queue.listener';
@@ -30,18 +33,20 @@ import { PayoutListener } from './listeners/payout.listener';
       verboseMemoryLeak: true,
       ignoreErrors: false,
     }),
-    TypeOrmModule.forFeature([EventStore]),
+    TypeOrmModule.forFeature([EventStore, PoisonMessage]),
   ],
   providers: [
     EventsService,
     EventStoreService,
     AuditLogService,
     RetryService,
+    PoisonMessageService,
     // Event Handlers
     QuestEventsHandler,
     SubmissionEventsHandler,
     UserEventsHandler,
     DeadLetterHandler,
+    PoisonMessageHandler,
     // Event Listeners
     EventAuditListener,
     EventPersistenceListener,
@@ -51,6 +56,6 @@ import { PayoutListener } from './listeners/payout.listener';
     SubmissionListener,
     PayoutListener,
   ],
-  exports: [EventsService, EventStoreService],
+  exports: [EventsService, EventStoreService, PoisonMessageService],
 })
 export class EventsModule {}

--- a/BackEnd/src/events/handlers/poison-message.handler.ts
+++ b/BackEnd/src/events/handlers/poison-message.handler.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { PoisonMessageService } from '../services/poison-message.service';
+
+@Injectable()
+export class PoisonMessageHandler {
+  private readonly logger = new Logger(PoisonMessageHandler.name);
+
+  constructor(private readonly poisonMessageService: PoisonMessageService) {}
+
+  @OnEvent('event.failed', { async: true })
+  async handleFailedEvent(payload: {
+    eventName?: string;
+    type?: string;
+    eventId?: string;
+    payload?: any;
+    data?: any;
+    error: string;
+    metadata?: any;
+  }): Promise<void> {
+    const eventName = payload.eventName || payload.type || 'unknown';
+    const eventPayload = payload.payload || payload.data;
+
+    this.logger.warn(`Handling poison message for event: ${eventName}`);
+
+    await this.poisonMessageService.quarantine(
+      eventName,
+      eventPayload,
+      payload.error,
+      payload.metadata,
+    );
+  }
+}

--- a/BackEnd/src/events/services/poison-message.service.ts
+++ b/BackEnd/src/events/services/poison-message.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PoisonMessage, PoisonMessageStatus } from '../entities/poison-message.entity';
+
+@Injectable()
+export class PoisonMessageService {
+  private readonly logger = new Logger(PoisonMessageService.name);
+
+  constructor(
+    @InjectRepository(PoisonMessage)
+    private readonly poisonMessageRepository: Repository<PoisonMessage>,
+  ) {}
+
+  async quarantine(
+    eventName: string,
+    payload: any,
+    error: string,
+    metadata?: any,
+    maxRetries = 5,
+  ): Promise<PoisonMessage> {
+    const existing = await this.poisonMessageRepository.findOne({
+      where: { eventName, status: PoisonMessageStatus.QUARANTINED },
+    });
+
+    if (existing) {
+      return this.recordRetryFailure(existing, error);
+    }
+
+    const message = this.poisonMessageRepository.create({
+      eventName,
+      payload,
+      metadata,
+      lastError: error,
+      maxRetries,
+      errorHistory: [{ error, attemptedAt: new Date().toISOString() }],
+    });
+
+    const saved = await this.poisonMessageRepository.save(message);
+    this.logger.warn(`Quarantined poison message: ${eventName} (id: ${saved.id})`);
+    return saved;
+  }
+
+  private async recordRetryFailure(message: PoisonMessage, error: string): Promise<PoisonMessage> {
+    const history = message.errorHistory || [];
+    history.push({ error, attemptedAt: new Date().toISOString() });
+
+    message.retryCount += 1;
+    message.lastError = error;
+    message.errorHistory = history;
+
+    if (message.retryCount >= message.maxRetries) {
+      message.status = PoisonMessageStatus.DISCARDED;
+      this.logger.error(
+        `Poison message ${message.id} (${message.eventName}) discarded after ${message.retryCount} retries`,
+      );
+    }
+
+    return this.poisonMessageRepository.save(message);
+  }
+
+  async getQuarantined(): Promise<PoisonMessage[]> {
+    return this.poisonMessageRepository.find({
+      where: { status: PoisonMessageStatus.QUARANTINED },
+      order: { quarantinedAt: 'ASC' },
+    });
+  }
+
+  async markResolved(id: string): Promise<void> {
+    await this.poisonMessageRepository.update(id, {
+      status: PoisonMessageStatus.RESOLVED,
+      resolvedAt: new Date(),
+    });
+    this.logger.log(`Poison message ${id} marked as resolved`);
+  }
+
+  async markRetrying(id: string): Promise<void> {
+    await this.poisonMessageRepository.update(id, {
+      status: PoisonMessageStatus.RETRYING,
+    });
+  }
+
+  async resetToQuarantined(id: string): Promise<void> {
+    await this.poisonMessageRepository.update(id, {
+      status: PoisonMessageStatus.QUARANTINED,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implements a poison message handling strategy with quarantine storage for failed events in the event system.

## Changes

- BackEnd/src/events/entities/poison-message.entity.ts - New PoisonMessage entity with status tracking (quarantined, etrying, esolved, discarded), retry count, error history, and timestamps
- BackEnd/src/events/services/poison-message.service.ts - PoisonMessageService to quarantine failed events, track retry attempts, auto-discard after max retries, and mark messages as resolved
- BackEnd/src/events/handlers/poison-message.handler.ts - PoisonMessageHandler listens on event.failed and routes to quarantine storage
- BackEnd/src/events/events.module.ts - Registers the new entity, service, and handler; exports PoisonMessageService

## Behaviour

1. When an event fails, PoisonMessageHandler catches the event.failed emission
2. The event payload is quarantined via PoisonMessageService.quarantine()
3. Repeated failures on the same event increment etryCount and append to errorHistory
4. Once etryCount >= maxRetries (default 5), the message is automatically marked discarded
5. Operators can query quarantined messages and mark them esolved after manual intervention

closes #1135