### PR TITLE
Add stale-while-revalidate cache for quest listings

### DIFF
--- a/FrontEnd/my-app/components/homepage/FeaturedQuests.test.tsx
+++ b/FrontEnd/my-app/components/homepage/FeaturedQuests.test.tsx
@@ -87,7 +87,12 @@ describe('FeaturedQuests - Error Boundary and Timeout Integration', () => {
 
     await waitFor(() => {
       // Verify second call is made with 60000ms custom timeout
-      expect(mockGetQuests).toHaveBeenLastCalledWith(expect.any(Object), expect.any(Object), 60000);
+      expect(mockGetQuests).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        60000,
+        expect.objectContaining({ onRevalidate: expect.any(Function) })
+      );
     });
   });
 

--- a/FrontEnd/my-app/components/homepage/FeaturedQuests.tsx
+++ b/FrontEnd/my-app/components/homepage/FeaturedQuests.tsx
@@ -49,7 +49,12 @@ function FeaturedQuestsContent() {
     setError(null);
 
     try {
-      const res = await getQuests(TAB_PARAMS[activeFilter], cancelRef.current, customTimeout);
+      const res = await getQuests(TAB_PARAMS[activeFilter], cancelRef.current, customTimeout, {
+        onRevalidate: (fresh) => {
+          const freshItems = (fresh as any).data ?? (fresh as any).quests ?? [];
+          setQuests(freshItems);
+        },
+      });
       const items = (res as any).data ?? (res as any).quests ?? [];
       setQuests(items);
       setRetryCount(0); // Reset retry count on success

--- a/FrontEnd/my-app/docs/FE-042-SWR-QUEST-CACHE.md
+++ b/FrontEnd/my-app/docs/FE-042-SWR-QUEST-CACHE.md
@@ -1,0 +1,12 @@
+# FE-042 Quest Listing Cache
+
+Quest listings use a stale-while-revalidate cache in `lib/api/quests.ts`.
+
+- Fresh window: 3 minutes.
+- Stale window: 10 additional minutes.
+- Fresh entries return without a network request.
+- Stale entries return immediately and trigger a background refresh.
+- Components can pass `onRevalidate` to receive fresh data after the background request completes.
+- Expired entries outside the stale window block on a fresh network request.
+
+Quest create/update/delete operations continue to invalidate quest caches through the shared cache manager.

--- a/FrontEnd/my-app/lib/api/quests.test.ts
+++ b/FrontEnd/my-app/lib/api/quests.test.ts
@@ -1,9 +1,44 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { getQuests, getQuestById } from './quests';
+import { cacheManager } from '@/lib/utils/cache';
+import { server } from '@/tests/mocks/server';
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+
+function questListResponse(version: number) {
+  return {
+    data: [
+      {
+        id: `quest-${version}`,
+        title: `Test Quest ${version}`,
+        description: 'This is a test quest',
+        rewardAmount: 100,
+        rewardAsset: 'XLM',
+        status: 'active',
+      },
+    ],
+    meta: {
+      total: 1,
+      page: 1,
+      limit: 10,
+      hasMore: false,
+    },
+  };
+}
+
+beforeEach(() => {
+  cacheManager.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('Quests API Integration Tests', () => {
   it('should fetch quests successfully with mock data', async () => {
-    const response = await getQuests();
+    const response = (await getQuests()) as any;
 
     expect(response).toBeDefined();
     expect(response.data).toHaveLength(1);
@@ -13,12 +48,80 @@ describe('Quests API Integration Tests', () => {
   });
 
   it('should fetch a single quest by ID successfully', async () => {
-    const response = await getQuestById('quest-123');
+    const response = (await getQuestById('quest-123')) as any;
 
     expect(response).toBeDefined();
     expect(response.data).toBeDefined();
     expect(response.data.id).toBe('quest-123');
     expect(response.data.title).toBe('Test Quest quest-123');
     expect(response.data.rewardAmount).toBe(50);
+  });
+
+  it('should reuse fresh cached quest listings without another request', async () => {
+    let requestCount = 0;
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/quests`, () => {
+        requestCount += 1;
+        return HttpResponse.json(questListResponse(requestCount));
+      })
+    );
+
+    const first = (await getQuests({ limit: 10 })) as any;
+    const second = (await getQuests({ limit: 10 })) as any;
+
+    expect(requestCount).toBe(1);
+    expect(first.data[0].id).toBe('quest-1');
+    expect(second.data[0].id).toBe('quest-1');
+  });
+
+  it('should return stale quest listings while revalidating in the background', async () => {
+    let now = 0;
+    let requestCount = 0;
+    const onRevalidate = vi.fn();
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/quests`, () => {
+        requestCount += 1;
+        return HttpResponse.json(questListResponse(requestCount));
+      })
+    );
+
+    const fresh = (await getQuests()) as any;
+    now = 3 * 60 * 1000 + 1;
+    const stale = (await getQuests(undefined, undefined, undefined, {
+      onRevalidate,
+    })) as any;
+
+    expect(stale.data[0].id).toBe(fresh.data[0].id);
+    expect(stale.data[0].id).toBe('quest-1');
+
+    await vi.waitFor(() => {
+      expect(requestCount).toBe(2);
+      expect(onRevalidate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: [expect.objectContaining({ id: 'quest-2' })],
+        })
+      );
+    });
+  });
+
+  it('should refetch quest listings after the stale window expires', async () => {
+    let now = 0;
+    let requestCount = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/quests`, () => {
+        requestCount += 1;
+        return HttpResponse.json(questListResponse(requestCount));
+      })
+    );
+
+    const first = (await getQuests()) as any;
+    now = 13 * 60 * 1000 + 1;
+    const second = (await getQuests()) as any;
+
+    expect(requestCount).toBe(2);
+    expect(first.data[0].id).toBe('quest-1');
+    expect(second.data[0].id).toBe('quest-2');
   });
 });

--- a/FrontEnd/my-app/lib/api/quests.ts
+++ b/FrontEnd/my-app/lib/api/quests.ts
@@ -27,6 +27,13 @@ import type {
   QuestQueryParams,
 } from '@/lib/types/api.types';
 
+const QUEST_LIST_TTL_MS = 3 * 60 * 1000;
+const QUEST_LIST_STALE_TTL_MS = 10 * 60 * 1000;
+
+type QuestListCacheOptions = {
+  onRevalidate?: (data: PaginatedQuestsResponse) => void;
+};
+
 // Re-export legacy types for backward compatibility with existing hooks
 export type {
   QuestFilters,
@@ -47,12 +54,13 @@ export type {
 export async function getQuests(
   filters?: QuestQueryParams,
   cancelToken?: CancelToken,
-  timeout?: number
+  timeout?: number,
+  cacheOptions?: QuestListCacheOptions
 ): Promise<PaginatedQuestsResponse> {
   const params = buildQuestParams(filters);
   const cacheKey = `${generateQuestsCacheKey(params)}${timeout ? `:t-${timeout}` : ''}`;
 
-  return cacheManager.get(
+  return cacheManager.getStaleWhileRevalidate(
     cacheKey,
     () =>
       withRetry(() =>
@@ -62,7 +70,11 @@ export async function getQuests(
           timeout,
         })
       ),
-    3 * 60 * 1000 // 3 minutes TTL
+    {
+      ttl: QUEST_LIST_TTL_MS,
+      staleTtl: QUEST_LIST_STALE_TTL_MS,
+      onRevalidate: cacheOptions?.onRevalidate,
+    }
   );
 }
 

--- a/FrontEnd/my-app/lib/utils/cache.ts
+++ b/FrontEnd/my-app/lib/utils/cache.ts
@@ -2,6 +2,13 @@ type CacheEntry<T> = {
   data: T;
   timestamp: number;
   expiresAt: number;
+  staleUntil?: number;
+};
+
+type StaleWhileRevalidateOptions<T> = {
+  ttl?: number;
+  staleTtl?: number;
+  onRevalidate?: (data: T) => void;
 };
 
 class CacheManager {
@@ -33,6 +40,80 @@ class CacheManager {
           data,
           timestamp: now,
           expiresAt: now + (ttl || this.defaultTTL),
+        });
+        this.pendingRequests.delete(key);
+        return data;
+      })
+      .catch((error) => {
+        this.pendingRequests.delete(key);
+        throw error;
+      });
+
+    this.pendingRequests.set(key, promise);
+    return promise;
+  }
+
+  async getStaleWhileRevalidate<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    options: StaleWhileRevalidateOptions<T> = {}
+  ): Promise<T> {
+    const ttl = options.ttl ?? this.defaultTTL;
+    const staleTtl = options.staleTtl ?? ttl;
+    const now = Date.now();
+    const entry = this.cache.get(key) as CacheEntry<T> | undefined;
+
+    if (entry && entry.expiresAt > now) {
+      return entry.data;
+    }
+
+    if (entry && (entry.staleUntil ?? 0) > now) {
+      this.revalidate(key, fetcher, ttl, staleTtl, options.onRevalidate);
+      return entry.data;
+    }
+
+    if (this.pendingRequests.has(key)) {
+      return this.pendingRequests.get(key);
+    }
+
+    return this.fetchAndCache(key, fetcher, ttl, staleTtl);
+  }
+
+  private revalidate<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    ttl: number,
+    staleTtl: number,
+    onRevalidate?: (data: T) => void
+  ): void {
+    if (this.pendingRequests.has(key)) return;
+
+    const promise = this.fetchAndCache(key, fetcher, ttl, staleTtl)
+      .then((data) => {
+        onRevalidate?.(data);
+        return data;
+      })
+      .catch(() => {
+        return this.cache.get(key)?.data;
+      });
+
+    this.pendingRequests.set(key, promise);
+  }
+
+  private async fetchAndCache<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    ttl: number,
+    staleTtl?: number
+  ): Promise<T> {
+    const promise = fetcher()
+      .then((data) => {
+        const now = Date.now();
+        this.cache.set(key, {
+          data,
+          timestamp: now,
+          expiresAt: now + ttl,
+          staleUntil: now + ttl + (staleTtl ?? 0),
         });
         this.pendingRequests.delete(key);
         return data;

--- a/FrontEnd/my-app/tests/mocks/handlers.ts
+++ b/FrontEnd/my-app/tests/mocks/handlers.ts
@@ -4,41 +4,46 @@ import { http, HttpResponse } from 'msw';
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001';
 
-export const handlers = [
-  // List quests
-  http.get(`${API_BASE_URL}/api/v1/quests`, ({ request }) => {
-    return HttpResponse.json({
-      data: [
-        {
-          id: 'quest-1',
-          title: 'Test Quest 1',
-          description: 'This is a test quest',
-          rewardAmount: 100,
-          rewardAsset: 'XLM',
-          status: 'active',
-        },
-      ],
-      meta: {
-        total: 1,
-        page: 1,
-        limit: 10,
-        hasMore: false,
-      },
-    });
-  }),
-
-  // Get single quest
-  http.get(`${API_BASE_URL}/api/v1/quests/:id`, ({ params }) => {
-    const { id } = params;
-    return HttpResponse.json({
-      data: {
-        id,
-        title: `Test Quest ${id}`,
-        description: 'Details for test quest',
-        rewardAmount: 50,
+const questListResolver = () =>
+  HttpResponse.json({
+    data: [
+      {
+        id: 'quest-1',
+        title: 'Test Quest 1',
+        description: 'This is a test quest',
+        rewardAmount: 100,
         rewardAsset: 'XLM',
         status: 'active',
       },
-    });
-  }),
+    ],
+    meta: {
+      total: 1,
+      page: 1,
+      limit: 10,
+      hasMore: false,
+    },
+  });
+
+const questDetailResolver = ({ params }: { params: { id?: string | readonly string[] } }) => {
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  return HttpResponse.json({
+    data: {
+      id,
+      title: `Test Quest ${id}`,
+      description: 'Details for test quest',
+      rewardAmount: 50,
+      rewardAsset: 'XLM',
+      status: 'active',
+    },
+  });
+};
+
+export const handlers = [
+  // List quests
+  http.get(`${API_BASE_URL}/api/v1/quests`, questListResolver),
+  http.get('/api/v1/quests', questListResolver),
+
+  // Get single quest
+  http.get(`${API_BASE_URL}/api/v1/quests/:id`, questDetailResolver),
+  http.get('/api/v1/quests/:id', questDetailResolver),
 ];


### PR DESCRIPTION
Summary
- Added a stale-while-revalidate cache path for quest listing requests.
- Updated FeaturedQuests to refresh from background revalidation without blocking stale data display.
- Added quest API coverage for fresh cache hits, stale responses, background refresh, and stale-window expiry.

Issue
- Closes #873

Changes
- Extended the shared cache manager with fresh/stale windows and background revalidation callbacks.
- Switched getQuests to use a 3-minute fresh window plus 10-minute stale revalidation window.
- Added documentation for FE-042 quest listing cache behavior.
- Updated MSW quest handlers to cover both absolute and relative API request URLs used by the client/tests.

Validation
- Passed: cd FrontEnd/my-app && npm run test -- lib/api/quests.test.ts
- Passed: cd FrontEnd/my-app && npm run test -- components/homepage/FeaturedQuests.test.tsx
- Failed: cd FrontEnd/my-app && npm run lint
- Failed: cd FrontEnd/my-app && npm run typecheck
- Failed: cd FrontEnd/my-app && npm run build

Notes
- Lint is blocked by existing repo configuration: eslint.config.mjs imports eslint-plugin-boundaries, but that package is not installed.
- Typecheck/build are blocked by existing unrelated errors, including missing exports from '@/lib/types/admin' and '@/lib/types/submission', a missing Sidebar reference in app/quests/page.tsx, and existing test matcher typings.
- npm install reports existing dependency audit and engine warnings under Node v23.1.0.