### PR TITLE
feat: add cache hit-rate target and alert threshold [BE-123]

### DIFF
--- a/BackEnd/src/modules/cache/cache-analytics.service.ts
+++ b/BackEnd/src/modules/cache/cache-analytics.service.ts
@@ -1,8 +1,23 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+export interface CacheHitRateAlert {
+  triggered: boolean;
+  currentRate: number;
+  targetRate: number;
+  alertThreshold: number;
+  message: string;
+}
+
 @Injectable()
 export class CacheAnalyticsService {
   private readonly logger = new Logger(CacheAnalyticsService.name);
+
+  /** Minimum acceptable hit-rate (0–1). Alert fires below this value. */
+  static readonly HIT_RATE_TARGET = 0.8;
+
+  /** Alert threshold: fires when hit-rate drops this far below the target. */
+  static readonly HIT_RATE_ALERT_THRESHOLD = 0.7;
+
   private analytics = {
     hits: 0,
     misses: 0,
@@ -17,11 +32,13 @@ export class CacheAnalyticsService {
   recordHit(): void {
     this.analytics.hits++;
     this.analytics.operations.get++;
+    this.checkHitRateAlert();
   }
 
   recordMiss(): void {
     this.analytics.misses++;
     this.analytics.operations.get++;
+    this.checkHitRateAlert();
   }
 
   recordSet(): void {
@@ -37,20 +54,54 @@ export class CacheAnalyticsService {
   }
 
   getAnalytics() {
-    return this.analytics;
+    return {
+      ...this.analytics,
+      hitRate: this.getHitRate(),
+      hitRateTarget: CacheAnalyticsService.HIT_RATE_TARGET,
+      alertThreshold: CacheAnalyticsService.HIT_RATE_ALERT_THRESHOLD,
+    };
+  }
+
+  /** Returns the current hit-rate as a value between 0 and 1. */
+  getHitRate(): number {
+    const total = this.analytics.hits + this.analytics.misses;
+    if (total === 0) return 1;
+    return this.analytics.hits / total;
+  }
+
+  /** Returns alert status against the configured target and threshold. */
+  getHitRateAlert(): CacheHitRateAlert {
+    const currentRate = this.getHitRate();
+    const triggered = currentRate < CacheAnalyticsService.HIT_RATE_ALERT_THRESHOLD;
+    return {
+      triggered,
+      currentRate,
+      targetRate: CacheAnalyticsService.HIT_RATE_TARGET,
+      alertThreshold: CacheAnalyticsService.HIT_RATE_ALERT_THRESHOLD,
+      message: triggered
+        ? `Cache hit-rate ${(currentRate * 100).toFixed(1)}% is below alert threshold ${(CacheAnalyticsService.HIT_RATE_ALERT_THRESHOLD * 100).toFixed(1)}% (target: ${(CacheAnalyticsService.HIT_RATE_TARGET * 100).toFixed(1)}%)`
+        : `Cache hit-rate ${(currentRate * 100).toFixed(1)}% is within acceptable range`,
+    };
   }
 
   resetAnalytics(): void {
     this.analytics = {
       hits: 0,
       misses: 0,
-      operations: {
-        get: 0,
-        set: 0,
-        del: 0,
-      },
+      operations: { get: 0, set: 0, del: 0 },
       errors: 0,
     };
     this.logger.log('Cache analytics have been reset');
+  }
+
+  private checkHitRateAlert(): void {
+    // Only evaluate after a minimum sample size to avoid noise
+    const total = this.analytics.hits + this.analytics.misses;
+    if (total < 10) return;
+
+    const alert = this.getHitRateAlert();
+    if (alert.triggered) {
+      this.logger.warn(`[CACHE ALERT] ${alert.message}`);
+    }
   }
 }

--- a/BackEnd/src/modules/cache/cache.controller.ts
+++ b/BackEnd/src/modules/cache/cache.controller.ts
@@ -1,19 +1,33 @@
 import { Controller, Get, Delete, UseGuards, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CacheService } from './cache.service';
+import { CacheAnalyticsService } from './cache-analytics.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('Cache')
 @Controller('cache')
 @UseGuards(JwtAuthGuard)
 export class CacheController {
-  constructor(private cacheService: CacheService) {}
+  constructor(
+    private cacheService: CacheService,
+    private cacheAnalyticsService: CacheAnalyticsService,
+  ) {}
 
   @Get('stats')
   @ApiOperation({ summary: 'Get cache statistics' })
   @ApiResponse({ status: 200, description: 'Cache statistics retrieved' })
   async getStats(@Query('key') key?: string) {
     return this.cacheService.getStats(key);
+  }
+
+  @Get('hit-rate')
+  @ApiOperation({ summary: 'Get cache hit-rate, target, and alert status' })
+  @ApiResponse({ status: 200, description: 'Cache hit-rate metrics' })
+  getHitRate() {
+    return {
+      ...this.cacheAnalyticsService.getAnalytics(),
+      alert: this.cacheAnalyticsService.getHitRateAlert(),
+    };
   }
 
   @Delete('clear')


### PR DESCRIPTION
## Summary

Adds a cache hit-rate target and alert threshold to CacheAnalyticsService, with a new GET /cache/hit-rate endpoint that exposes the current rate, target, threshold, and alert status.

## Changes

### BackEnd/src/modules/cache/cache-analytics.service.ts
- HIT_RATE_TARGET = 0.8 (80%) - the desired minimum hit-rate
- HIT_RATE_ALERT_THRESHOLD = 0.7 (70%) - fires a warning log when hit-rate drops below this
- getHitRate() - returns current hit-rate (0-1)
- getHitRateAlert() - returns { triggered, currentRate, targetRate, alertThreshold, message }
- checkHitRateAlert() - called on every ecordHit/ecordMiss after ?10 samples; logs a WARN when threshold is breached
- getAnalytics() - now includes hitRate, hitRateTarget, lertThreshold

### BackEnd/src/modules/cache/cache.controller.ts
- New GET /cache/hit-rate endpoint returning full analytics + alert object
- Injects CacheAnalyticsService directly (was previously only accessible via CacheService)

closes #1150