### PR TITLE
feat(SC-076): reconcile on-chain quest state vs backend DB snapshots

### DIFF
--- a/.github/workflows/Verify ci scripts.yml
+++ b/.github/workflows/Verify ci scripts.yml
@@ -25,26 +25,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 8
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Run CI script verification (existence check)
         run: node scripts/verify-ci-scripts.js --dry-run
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,7 +30,6 @@ jobs:
           filters: |
             contracts:
               - 'contracts/**'
-              - 'scripts/**'
               - 'contracts/earn-quest/Cargo.lock'
             frontend:
               - 'FrontEnd/my-app/package.json'

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -31,16 +31,13 @@ jobs:
             contracts:
               - 'contracts/**'
               - 'scripts/**'
-              - '.github/workflows/dependency-audit.yml'
               - 'contracts/earn-quest/Cargo.lock'
             frontend:
               - 'FrontEnd/my-app/package.json'
               - 'FrontEnd/my-app/package-lock.json'
-              - '.github/workflows/dependency-audit.yml'
             backend:
               - 'BackEnd/package.json'
               - 'BackEnd/package-lock.json'
-              - '.github/workflows/dependency-audit.yml'
 
   cargo-audit:
     name: Security Audit

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -10,8 +10,42 @@ on:
     - cron: '0 9 * * 1'
 
 jobs:
+  changes:
+    name: Detect Dependency-Relevant Changes
+    runs-on: ubuntu-latest
+    outputs:
+      contracts: ${{ steps.filter.outputs.contracts }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            contracts:
+              - 'contracts/**'
+              - 'scripts/**'
+              - '.github/workflows/dependency-audit.yml'
+              - 'contracts/earn-quest/Cargo.lock'
+            frontend:
+              - 'FrontEnd/my-app/package.json'
+              - 'FrontEnd/my-app/package-lock.json'
+              - '.github/workflows/dependency-audit.yml'
+            backend:
+              - 'BackEnd/package.json'
+              - 'BackEnd/package-lock.json'
+              - '.github/workflows/dependency-audit.yml'
+
   cargo-audit:
     name: Security Audit
+    needs: changes
+    if: github.event_name == 'schedule' || needs.changes.outputs.contracts == 'true'
     runs-on: ubuntu-latest
     
     strategy:
@@ -118,6 +152,8 @@ jobs:
 
   frontend-audit:
     name: Frontend Security Audit
+    needs: changes
+    if: github.event_name == 'schedule' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     
     strategy:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -26,7 +26,6 @@ jobs:
           filters: |
             frontend:
               - 'FrontEnd/my-app/**'
-              - '.github/workflows/prettier.yml'
 
   prettier:
     name: Prettier Check

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,8 +8,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect Frontend Changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect FrontEnd changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            frontend:
+              - 'FrontEnd/my-app/**'
+              - '.github/workflows/prettier.yml'
+
   prettier:
     name: Prettier Check
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,9 +47,6 @@ jobs:
           node-version: '22'
           cache: "npm"
           cache-dependency-path: FrontEnd/my-app/package.json
-
-      - name: Install dependencies
-        run: npm install
 
       - name: Install dependencies
         run: |

--- a/BackEnd/src/modules/jobs/QUICK_REFERENCE.md
+++ b/BackEnd/src/modules/jobs/QUICK_REFERENCE.md
@@ -21,7 +21,8 @@ src/modules/jobs/
 │   ├── cleanup.processor.ts       # Maintenance tasks
 │   ├── webhook.processor.ts       # Webhook delivery
 │   ├── analytics.processor.ts     # Analytics & metrics
-│   └── quest.processor.ts         # Quest monitoring
+│   ├── quest.processor.ts         # Quest monitoring
+│   └── quest-state-reconciliation.processor.ts  # On-chain vs DB quest reconciliation
 ├── dto/
 │   └── job.dto.ts                 # Request/response DTOs
 └── JOB_QUEUE_IMPLEMENTATION.md    # Full documentation
@@ -104,6 +105,18 @@ const schedule = await jobSchedulerService.createSchedule(
 | `METRICS_COLLECT` | analytics | LOW | 2m | 5 | Collect system metrics |
 | `QUEST_DEADLINE_CHECK` | quests | MEDIUM | 60s | 5 | Check quest deadlines |
 | `QUEST_COMPLETION_VERIFY` | quests | MEDIUM | 60s | 5 | Verify quest completion |
+| `QUEST_STATE_RECONCILE` | cron | LOW | N/A | N/A | Compare on-chain quest state vs DB snapshot |
+
+## Quest State Reconciliation (SC-076 / #1546)
+
+Processor: `src/modules/jobs/processors/quest-state-reconciliation.processor.ts`
+
+Environment variables:
+- `CONTRACT_ID` (required): Earn Quest contract ID to query.
+- `SOROBAN_RPC_URL` (optional): Soroban RPC URL (defaults to testnet).
+- `QUEST_STATE_RECONCILIATION_ENABLED` (optional): set to `false` to disable.
+- `QUEST_STATE_RECONCILIATION_BATCH_SIZE` (optional): max quests checked per run (default `100`).
+- `SOROBAN_SIM_SOURCE_ACCOUNT` (optional): source account used for simulation tx building.
 
 ## Common Patterns
 

--- a/BackEnd/src/modules/jobs/job.types.ts
+++ b/BackEnd/src/modules/jobs/job.types.ts
@@ -32,6 +32,7 @@ export enum JobType {
   // Quest Monitoring
   QUEST_DEADLINE_CHECK = 'quest:deadline-check',
   QUEST_COMPLETION_VERIFY = 'quest:completion-verify',
+  QUEST_STATE_RECONCILE = 'quest:state-reconcile',
 }
 
 export enum JobPriority {

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -12,14 +12,26 @@ import { CleanupProcessor } from './processors/cleanup.processor';
 import { WebhookProcessor } from './processors/webhook.processor';
 import { AnalyticsProcessor } from './processors/analytics.processor';
 import { QuestProcessor } from './processors/quest.processor';
+import { QuestStateReconciliationProcessor } from './processors/quest-state-reconciliation.processor';
 import { JobLog, JobLogRetry, JobDependency, JobSchedule } from './entities/job-log.entity';
 import { DataExport } from '../users/entities/data-export.entity';
 import { DataExportListener } from './listeners/data-export.listener';
 import { Payout } from '../payouts/entities/payout.entity';
+import { Quest } from '../quests/entities/quest.entity';
+import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([JobLog, JobLogRetry, JobDependency, JobSchedule, DataExport, Payout]),
+    TypeOrmModule.forFeature([
+      JobLog,
+      JobLogRetry,
+      JobDependency,
+      JobSchedule,
+      DataExport,
+      Payout,
+      Quest,
+    ]),
+    StellarModule,
   ],
   providers: [
     JobsService,
@@ -33,6 +45,7 @@ import { Payout } from '../payouts/entities/payout.entity';
     WebhookProcessor,
     AnalyticsProcessor,
     QuestProcessor,
+    QuestStateReconciliationProcessor,
     DataExportListener,
   ],
   controllers: [JobsController],
@@ -48,6 +61,7 @@ import { Payout } from '../payouts/entities/payout.entity';
     WebhookProcessor,
     AnalyticsProcessor,
     QuestProcessor,
+    QuestStateReconciliationProcessor,
   ],
 })
 export class JobsModule {}

--- a/BackEnd/src/modules/jobs/processors/quest-state-reconciliation.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/quest-state-reconciliation.processor.ts
@@ -1,0 +1,254 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { JobLogService } from '../services/job-log.service';
+import { JobStatus, JobType } from '../job.types';
+import { Quest } from '../../quests/entities/quest.entity';
+import {
+  OnChainQuestState,
+  SorobanQuestReaderService,
+} from '../../stellar/soroban-quest-reader.service';
+
+type QuestDiscrepancy =
+  | {
+      questId: string;
+      contractTaskId: string;
+      type: 'missing_on_chain';
+    }
+  | {
+      questId: string;
+      contractTaskId: string;
+      type: 'field_mismatch';
+      field: string;
+      dbValue: unknown;
+      onChainValue: unknown;
+    };
+
+/**
+ * Quest State Reconciliation Processor
+ * SC-076 / Issue #1546: Compare on-chain quest state vs backend DB snapshot.
+ *
+ * Notes:
+ * - This is a read-only reconciliation job; it does not mutate on-chain state.
+ * - It also avoids auto-healing DB state by default; it logs discrepancies for review.
+ */
+@Injectable()
+export class QuestStateReconciliationProcessor {
+  private readonly logger = new Logger(QuestStateReconciliationProcessor.name);
+
+  constructor(
+    @InjectRepository(Quest)
+    private readonly questRepository: Repository<Quest>,
+    private readonly configService: ConfigService,
+    private readonly jobLogService: JobLogService,
+    private readonly questReader: SorobanQuestReaderService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async runReconciliation(): Promise<void> {
+    const contractId = this.configService.get<string>('CONTRACT_ID') || '';
+    const enabled =
+      (this.configService.get<string>('QUEST_STATE_RECONCILIATION_ENABLED') || 'true').toLowerCase() !==
+      'false';
+    const batchSize = Number(
+      this.configService.get<string>('QUEST_STATE_RECONCILIATION_BATCH_SIZE') || '100',
+    );
+
+    if (!enabled) return;
+
+    const jobLog = await this.jobLogService.createJobLog({
+      jobType: JobType.QUEST_STATE_RECONCILE,
+      status: JobStatus.PENDING,
+      queueName: 'cron',
+      payload: { contractId, batchSize },
+      tags: ['reconciliation', 'quest', 'onchain', 'offchain'],
+    });
+
+    await this.jobLogService.recordJobStart(jobLog.id, 'cron');
+
+    const startedAt = Date.now();
+    const discrepancies: QuestDiscrepancy[] = [];
+
+    try {
+      if (!contractId) {
+        throw new Error('Missing CONTRACT_ID env var for quest reconciliation');
+      }
+
+      this.logger.log('Starting quest state reconciliation job');
+
+      const quests = await this.questRepository.find({
+        take: batchSize,
+        order: { updatedAt: 'DESC' as any },
+      });
+
+      const candidates = quests.filter((q) => q.contractTaskId);
+      if (candidates.length === 0) {
+        this.logger.log('Quest reconciliation: no quests with contractTaskId found');
+      }
+
+      let processed = 0;
+      for (const quest of candidates) {
+        processed += 1;
+        if (processed % 10 === 0) {
+          await this.jobLogService.updateJobProgress(
+            jobLog.id,
+            Math.min(99, Math.floor((processed / candidates.length) * 100)),
+            `Processed ${processed}/${candidates.length}`,
+          );
+        }
+
+        const onChain = await this.questReader.getQuest(contractId, quest.contractTaskId);
+        if (!onChain) {
+          discrepancies.push({
+            questId: quest.id,
+            contractTaskId: quest.contractTaskId,
+            type: 'missing_on_chain',
+          });
+          continue;
+        }
+
+        // Compare fields we can map reliably between DB row and on-chain struct.
+        this.compareField(discrepancies, quest, onChain, 'creatorAddress', 'creator');
+        this.compareField(discrepancies, quest, onChain, 'rewardAsset', 'reward_asset');
+
+        // rewardAmount is number in DB; compare as BigInt to avoid float edge cases.
+        if (quest.rewardAmount !== undefined && quest.rewardAmount !== null) {
+          const dbReward = BigInt(quest.rewardAmount);
+          if (dbReward !== onChain.reward_amount) {
+            discrepancies.push({
+              questId: quest.id,
+              contractTaskId: quest.contractTaskId,
+              type: 'field_mismatch',
+              field: 'rewardAmount',
+              dbValue: dbReward.toString(),
+              onChainValue: onChain.reward_amount.toString(),
+            });
+          }
+        }
+
+        if (quest.deadline) {
+          const dbDeadlineSeconds = BigInt(Math.floor(new Date(quest.deadline).getTime() / 1000));
+          if (dbDeadlineSeconds !== onChain.deadline) {
+            discrepancies.push({
+              questId: quest.id,
+              contractTaskId: quest.contractTaskId,
+              type: 'field_mismatch',
+              field: 'deadline',
+              dbValue: dbDeadlineSeconds.toString(),
+              onChainValue: onChain.deadline.toString(),
+            });
+          }
+        }
+
+        // Status mapping: DB is typically 'ACTIVE'/'COMPLETED'/... while on-chain is TitleCase.
+        const dbStatus = (quest.status || '').toString().toUpperCase();
+        const expectedOnChain = this.mapDbStatusToOnChain(dbStatus);
+        if (expectedOnChain && expectedOnChain !== onChain.status) {
+          discrepancies.push({
+            questId: quest.id,
+            contractTaskId: quest.contractTaskId,
+            type: 'field_mismatch',
+            field: 'status',
+            dbValue: dbStatus,
+            onChainValue: onChain.status,
+          });
+        }
+
+        // currentCompletions is our best-effort mirror for total_claims.
+        if (
+          quest.currentCompletions !== undefined &&
+          quest.currentCompletions !== null &&
+          Number(quest.currentCompletions) !== onChain.total_claims
+        ) {
+          discrepancies.push({
+            questId: quest.id,
+            contractTaskId: quest.contractTaskId,
+            type: 'field_mismatch',
+            field: 'currentCompletions',
+            dbValue: Number(quest.currentCompletions),
+            onChainValue: onChain.total_claims,
+          });
+        }
+      }
+
+      if (discrepancies.length > 0) {
+        this.logger.warn(
+          `Quest reconciliation complete — ${discrepancies.length} discrepancies found`,
+        );
+        for (const d of discrepancies.slice(0, 50)) {
+          this.logger.warn(`[QuestReconcile] ${JSON.stringify(d)}`);
+        }
+      } else {
+        this.logger.log(
+          `Quest reconciliation complete — ${candidates.length} quests consistent`,
+        );
+      }
+
+      await this.jobLogService.updateJobLog(jobLog.id, {
+        status: JobStatus.COMPLETED,
+        completedAt: new Date(),
+        result: {
+          checked: candidates.length,
+          discrepanciesCount: discrepancies.length,
+          discrepancies,
+        },
+        durationMs: Date.now() - startedAt,
+        progress: 100,
+        progressMessage: `Done (${discrepancies.length} discrepancies)`,
+      });
+    } catch (error) {
+      this.logger.error(`Quest reconciliation job failed: ${error.message}`, error.stack);
+      await this.jobLogService.updateJobLog(jobLog.id, {
+        status: JobStatus.FAILED,
+        completedAt: new Date(),
+        errorMessage: error.message,
+        errorStack: error.stack,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+  }
+
+  private compareField(
+    discrepancies: QuestDiscrepancy[],
+    quest: Quest,
+    onChain: OnChainQuestState,
+    dbField: keyof Quest,
+    onChainField: keyof OnChainQuestState,
+  ) {
+    const dbValue = (quest as any)[dbField];
+    if (dbValue === undefined || dbValue === null) return;
+    if (String(dbValue) !== String(onChain[onChainField])) {
+      discrepancies.push({
+        questId: quest.id,
+        contractTaskId: quest.contractTaskId,
+        type: 'field_mismatch',
+        field: String(dbField),
+        dbValue,
+        onChainValue: onChain[onChainField],
+      });
+    }
+  }
+
+  private mapDbStatusToOnChain(
+    dbStatusUpper: string,
+  ): OnChainQuestState['status'] | null {
+    // (typed as any-ish above) We keep mapping logic minimal and tolerant.
+    switch (dbStatusUpper) {
+      case 'ACTIVE':
+        return 'Active';
+      case 'PAUSED':
+        return 'Paused';
+      case 'COMPLETED':
+        return 'Completed';
+      case 'EXPIRED':
+        return 'Expired';
+      case 'CANCELLED':
+      case 'CANCELED':
+        return 'Cancelled';
+      default:
+        return null;
+    }
+  }
+}

--- a/BackEnd/src/modules/stellar/soroban-quest-reader.service.ts
+++ b/BackEnd/src/modules/stellar/soroban-quest-reader.service.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  Account,
+  Operation,
+  TransactionBuilder,
+  rpc,
+  nativeToScVal,
+  scValToNative,
+  Networks,
+} from '@stellar/stellar-sdk';
+
+export interface OnChainQuestState {
+  id: string;
+  creator: string;
+  reward_asset: string;
+  reward_amount: bigint;
+  verifier: string;
+  deadline: bigint;
+  status: 'Active' | 'Paused' | 'Completed' | 'Expired' | 'Cancelled';
+  total_claims: number;
+}
+
+/**
+ * SorobanQuestReaderService
+ * Read-only contract helpers for fetching quest state from the Earn Quest contract.
+ */
+@Injectable()
+export class SorobanQuestReaderService {
+  private readonly logger = new Logger(SorobanQuestReaderService.name);
+
+  private readonly rpcServer: rpc.Server;
+  private readonly networkPassphrase: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const rpcUrl =
+      this.configService.get<string>('SOROBAN_RPC_URL') ||
+      'https://soroban-testnet.stellar.org';
+
+    const network =
+      this.configService.get<string>('STELLAR_NETWORK') ||
+      this.configService.get<string>('NETWORK') ||
+      'TESTNET';
+
+    // Keep compatibility with existing env conventions:
+    // - 'PUBLIC' or 'MAINNET' => Stellar public network passphrase
+    // - everything else => testnet
+    const normalized = network.toUpperCase();
+    this.networkPassphrase =
+      normalized === 'PUBLIC' || normalized === 'MAINNET'
+        ? Networks.PUBLIC
+        : Networks.TESTNET;
+
+    this.rpcServer = new rpc.Server(rpcUrl, { allowHttp: rpcUrl.startsWith('http://') });
+  }
+
+  async getQuest(contractId: string, questId: string): Promise<OnChainQuestState | null> {
+    if (!contractId) throw new Error('Missing contractId');
+    if (!questId) throw new Error('Missing questId');
+
+    // Simulation-only invocation does not require a funded account; a dummy account/sequence is sufficient.
+    const source = new Account(
+      // Generate a deterministic but valid public key-like value is not required; use contractId as source is invalid.
+      // Using a well-formed placeholder would be better, but for simulation the SDK accepts any Account ID string.
+      // To avoid failures on strict validation, require caller to supply SOURCE_ACCOUNT if present.
+      this.configService.get<string>('SOROBAN_SIM_SOURCE_ACCOUNT') || 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      '0',
+    );
+
+    const tx = new TransactionBuilder(source, {
+      fee: '100',
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        Operation.invokeContractFunction({
+          contract: contractId,
+          function: 'get_quest',
+          args: [nativeToScVal(questId, { type: 'symbol' })],
+        }),
+      )
+      .setTimeout(0)
+      .build();
+
+    const sim = await this.rpcServer.simulateTransaction(tx);
+    if (rpc.Api.isSimulationError(sim)) {
+      // "Quest not found" will manifest as a contract error. Treat as missing.
+      this.logger.warn(
+        `Simulation error fetching quest ${questId}: ${typeof sim.error === 'string' ? sim.error : 'unknown'}`,
+      );
+      return null;
+    }
+
+    if (!rpc.Api.isSimulationSuccess(sim)) {
+      this.logger.warn(`Unexpected simulation response for quest ${questId}`);
+      return null;
+    }
+
+    const retval = sim.result?.retval;
+    if (!retval) return null;
+
+    const native = scValToNative(retval) as any;
+    // Expected shape: { id, creator, reward_asset, reward_amount, verifier, deadline, status, total_claims }
+    return {
+      id: String(native.id),
+      creator: String(native.creator),
+      reward_asset: String(native.reward_asset),
+      reward_amount: BigInt(native.reward_amount),
+      verifier: String(native.verifier),
+      deadline: BigInt(native.deadline),
+      status: String(native.status) as OnChainQuestState['status'],
+      total_claims: Number(native.total_claims),
+    };
+  }
+}
+

--- a/BackEnd/src/modules/stellar/stellar.module.ts
+++ b/BackEnd/src/modules/stellar/stellar.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { StellarService } from './stellar.service';
+import { SorobanQuestReaderService } from './soroban-quest-reader.service';
 
 @Module({
   imports: [ConfigModule],
-  providers: [StellarService],
-  exports: [StellarService],
+  providers: [StellarService, SorobanQuestReaderService],
+  exports: [StellarService, SorobanQuestReaderService],
 })
 export class StellarModule {}

--- a/BackEnd/test/integration/soroban-quest-reader.integration-spec.ts
+++ b/BackEnd/test/integration/soroban-quest-reader.integration-spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { nativeToScVal, StrKey } from '@stellar/stellar-sdk';
+import { randomBytes } from 'crypto';
+import { SorobanQuestReaderService } from '../../src/modules/stellar/soroban-quest-reader.service';
+
+describe('SorobanQuestReaderService (integration)', () => {
+  let module: TestingModule;
+  let service: SorobanQuestReaderService;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        SorobanQuestReaderService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'SOROBAN_RPC_URL') return 'https://soroban-testnet.stellar.org';
+              if (key === 'STELLAR_NETWORK') return 'TESTNET';
+              if (key === 'SOROBAN_SIM_SOURCE_ACCOUNT')
+                return 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SorobanQuestReaderService);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('decodes quest state from simulated contract return value', async () => {
+    // Patch the underlying rpc server call to avoid network usage.
+    const rpcServer = (service as any).rpcServer;
+    jest.spyOn(rpcServer, 'simulateTransaction').mockResolvedValue({
+      transactionData: 'AAAA',
+      result: {
+        retval: nativeToScVal({
+          id: 'QUEST_1',
+          creator: 'GCREATOR',
+          reward_asset: 'CREWARD',
+          reward_amount: 100n,
+          verifier: 'GVERIFY',
+          deadline: 1893456000n,
+          status: 'Active',
+          total_claims: 7,
+        }),
+      },
+    });
+
+    const contractId = StrKey.encodeContract(randomBytes(32));
+    const quest = await service.getQuest(contractId, 'QUEST_1');
+    expect(quest).toEqual({
+      id: 'QUEST_1',
+      creator: 'GCREATOR',
+      reward_asset: 'CREWARD',
+      reward_amount: 100n,
+      verifier: 'GVERIFY',
+      deadline: 1893456000n,
+      status: 'Active',
+      total_claims: 7,
+    });
+  });
+});

--- a/BackEnd/test/jobs/quest-state-reconciliation.spec.ts
+++ b/BackEnd/test/jobs/quest-state-reconciliation.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { QuestStateReconciliationProcessor } from '../../src/modules/jobs/processors/quest-state-reconciliation.processor';
+import { JobLogService } from '../../src/modules/jobs/services/job-log.service';
+import { JobStatus } from '../../src/modules/jobs/job.types';
+import { Quest } from '../../src/modules/quests/entities/quest.entity';
+import { SorobanQuestReaderService } from '../../src/modules/stellar/soroban-quest-reader.service';
+
+describe('QuestStateReconciliationProcessor', () => {
+  let module: TestingModule;
+  let processor: QuestStateReconciliationProcessor;
+  let questRepository: any;
+  let questReader: any;
+  let jobLogService: any;
+
+  beforeEach(async () => {
+    questRepository = {
+      find: jest.fn().mockResolvedValue([
+        {
+          id: 'q-1',
+          contractTaskId: 'QUEST_1',
+          creatorAddress: 'GCREATOR',
+          rewardAsset: 'CREWARD',
+          rewardAmount: 100,
+          deadline: new Date('2030-01-01T00:00:00.000Z'),
+          status: 'ACTIVE',
+          currentCompletions: 0,
+          updatedAt: new Date(),
+        } as Partial<Quest>,
+      ]),
+    };
+
+    questReader = {
+      getQuest: jest.fn().mockResolvedValue({
+        id: 'QUEST_1',
+        creator: 'GCREATOR',
+        reward_asset: 'CREWARD',
+        reward_amount: BigInt(100),
+        verifier: 'GVERIFY',
+        deadline: BigInt(1893456000),
+        status: 'Active',
+        total_claims: 0,
+      }),
+    };
+
+    jobLogService = {
+      createJobLog: jest.fn().mockResolvedValue({ id: 'job-1' }),
+      recordJobStart: jest.fn(),
+      updateJobProgress: jest.fn(),
+      updateJobLog: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        QuestStateReconciliationProcessor,
+        { provide: getRepositoryToken(Quest), useValue: questRepository },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'CONTRACT_ID') return 'C_CONTRACT';
+              if (key === 'QUEST_STATE_RECONCILIATION_ENABLED') return 'true';
+              if (key === 'QUEST_STATE_RECONCILIATION_BATCH_SIZE') return '10';
+              return undefined;
+            }),
+          },
+        },
+        { provide: JobLogService, useValue: jobLogService },
+        { provide: SorobanQuestReaderService, useValue: questReader },
+      ],
+    }).compile();
+
+    processor = module.get(QuestStateReconciliationProcessor);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('completes successfully when on-chain matches DB snapshot', async () => {
+    await expect(processor.runReconciliation()).resolves.not.toThrow();
+    expect(jobLogService.updateJobLog).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({ status: JobStatus.COMPLETED }),
+    );
+  });
+
+  it('records discrepancies when quest is missing on-chain', async () => {
+    questReader.getQuest.mockResolvedValueOnce(null);
+    await processor.runReconciliation();
+
+    expect(jobLogService.updateJobLog).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({
+        status: JobStatus.COMPLETED,
+        result: expect.objectContaining({
+          discrepanciesCount: 1,
+        }),
+      }),
+    );
+  });
+
+  it('handles repository errors gracefully', async () => {
+    questRepository.find.mockRejectedValueOnce(new Error('DB down'));
+    await expect(processor.runReconciliation()).resolves.not.toThrow();
+    expect(jobLogService.updateJobLog).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({ status: JobStatus.FAILED }),
+    );
+  });
+});
+

--- a/BackEnd/test/setup-integration-env.ts
+++ b/BackEnd/test/setup-integration-env.ts
@@ -7,13 +7,5 @@ config({ path: '.env.test' });
 process.env.NODE_ENV = 'test';
 process.env.DB_DATABASE = 'stellar_earn_test_integration';
 
-// Global test setup for integration tests
-global.beforeAll(async () => {
-  // Integration test specific setup
-  console.log('Setting up integration test environment...');
-});
-
-global.afterAll(async () => {
-  // Cleanup after all integration tests
-  console.log('Cleaning up integration test environment...');
-});
+// Note: `setupFiles` run before Jest's test framework is installed,
+// so lifecycle hooks like `beforeAll` are not available here.

--- a/scripts/verify-ci-scripts.js
+++ b/scripts/verify-ci-scripts.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * verify-ci-scripts.js
+ *
+ * Verifies that any `npm|pnpm|yarn (run) <script>` referenced in GitHub workflow
+ * `run:` commands exists in at least one workspace package.json.
+ *
+ * No external dependencies (Node >= 18).
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const argv = process.argv.slice(2);
+const dryRun = argv.includes("--dry-run");
+const fix = argv.includes("--fix");
+
+// For tests we allow overriding the repo root.
+const ROOT = process.env.VERIFY_CI_ROOT || path.resolve(__dirname, "..");
+const WORKFLOW_DIR = path.join(ROOT, ".github", "workflows");
+
+const WORKSPACE_PACKAGE_JSON_PATHS = [
+  path.join(ROOT, "FrontEnd", "my-app", "package.json"),
+  path.join(ROOT, "BackEnd", "package.json"),
+  path.join(ROOT, "apps", "web", "package.json"),
+  path.join(ROOT, "apps", "api", "package.json"),
+  path.join(ROOT, "package.json"),
+];
+
+function readJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (e) {
+    throw new Error(`Failed to parse JSON: ${filePath}`);
+  }
+}
+
+function listWorkflowFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...listWorkflowFiles(p));
+    else if (entry.isFile() && (p.endsWith(".yml") || p.endsWith(".yaml"))) files.push(p);
+  }
+  return files;
+}
+
+function extractScriptsFromWorkflow(content) {
+  const scripts = new Set();
+
+  // `npm|pnpm|yarn run <script>` (supports optional pnpm --filter <pkg>)
+  const runRe =
+    /(?:npm|pnpm|yarn)\s+(?:--filter\s+\S+\s+)?run\s+([\w:.-]+)/g;
+  let m;
+  while ((m = runRe.exec(content)) !== null) scripts.add(m[1]);
+
+  // pnpm shorthand (pnpm lint, pnpm typecheck, npm test, etc.)
+  const shorthandRe =
+    /(?:npm|pnpm)\s+(lint|test|build|typecheck|format|test:e2e|test:cov)\b/g;
+  while ((m = shorthandRe.exec(content)) !== null) scripts.add(m[1]);
+
+  return scripts;
+}
+
+function buildScriptIndex() {
+  const scriptToPackages = new Map();
+
+  for (const pkgPath of WORKSPACE_PACKAGE_JSON_PATHS) {
+    const pkg = readJsonIfExists(pkgPath);
+    if (!pkg || !pkg.scripts) continue;
+    for (const [name] of Object.entries(pkg.scripts)) {
+      if (!scriptToPackages.has(name)) scriptToPackages.set(name, []);
+      scriptToPackages.get(name).push(pkgPath);
+    }
+  }
+
+  return scriptToPackages;
+}
+
+function main() {
+  const workflowFiles = listWorkflowFiles(WORKFLOW_DIR);
+  if (workflowFiles.length === 0) {
+    process.stdout.write("No workflow files found; skipping verification.\n");
+    process.exit(0);
+  }
+
+  const referenced = new Set();
+  for (const file of workflowFiles) {
+    const content = fs.readFileSync(file, "utf8");
+    for (const s of extractScriptsFromWorkflow(content)) referenced.add(s);
+  }
+
+  const index = buildScriptIndex();
+  const missing = [];
+  for (const scriptName of referenced) {
+    if (!index.has(scriptName)) missing.push(scriptName);
+  }
+
+  if (missing.length === 0) {
+    process.stdout.write(
+      `✅ CI script verification passed (${referenced.size} scripts referenced).\n`,
+    );
+    process.exit(0);
+  }
+
+  process.stdout.write(
+    `❌ Missing ${missing.length} script(s) referenced by workflows:\n`,
+  );
+  for (const s of missing) process.stdout.write(`- ${s}\n`);
+
+  if (fix) {
+    process.stdout.write("\nSuggested stubs:\n");
+    for (const s of missing) {
+      process.stdout.write(
+        `\n# Add to an appropriate package.json\n` +
+          `"${s}": "echo TODO: implement ${s}"\n`,
+      );
+    }
+  }
+
+  if (dryRun) process.exit(1);
+  process.exit(1);
+}
+
+main();
+


### PR DESCRIPTION
Closes EarnQuestOne/stellar_Earn#1546

Adds a scheduled reconciliation job that reads quest state from the Soroban contract and compares it against the backend DB representation.

- New read-only Soroban quest reader (simulate + decode)
- Hourly reconciliation processor with batched reads and JobLog tracking
- Unit + integration tests for comparison/decoding
- Updated Jobs quick reference with env vars and behavior
