### PR TITLE
test: add double-claim prevention test under concurrent attempts

### DIFF
--- a/contracts/earn-quest/CHANGELOG.md
+++ b/contracts/earn-quest/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- Added 	est_double_claim.rs: verifies that a second claim on the same submission is rejected, preventing double-claim under concurrent attempts.
 - Added the [Changelog Discipline Policy](docs/CHANGELOG_DISCIPLINE.md) to define how contract-breaking changes, migrations, and version bumps must be documented.
 - Added CI validation for contract changelog updates and breaking-change metadata so contract interface changes cannot merge without matching release notes.
 - Initialized this changelog so future contract releases have a single source of truth.
@@ -20,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Initial stable release of the EarnQuest smart contract.
 
 ### Added
+- Added 	est_double_claim.rs: verifies that a second claim on the same submission is rejected, preventing double-claim under concurrent attempts.
 - Core quest registration system supporting deadlines, rewards, and designated verifiers.
 - Escrow contract integration to secure token funds during quest execution.
 - User reputation module containing XP awarding, user levels, and badge grants.

--- a/contracts/earn-quest/tests/test_double_claim.rs
+++ b/contracts/earn-quest/tests/test_double_claim.rs
@@ -1,0 +1,42 @@
+#![cfg(test)]
+
+extern crate earn_quest;
+use earn_quest::{EarnQuestContract, EarnQuestContractClient};
+use soroban_sdk::{
+    symbol_short,
+    testutils::Address as _,
+    token::{StellarAssetClient, TokenClient},
+    Address, BytesN, Env,
+};
+
+fn setup(env: &Env) -> (Address, EarnQuestContractClient, Address, Address, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let token_obj = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token_obj.address();
+    StellarAssetClient::new(env, &token).mint(&contract_id, &1000);
+    client.initialize(&admin);
+    let creator = Address::generate(env);
+    let verifier = Address::generate(env);
+    let submitter = Address::generate(env);
+    let quest_id = symbol_short!("Q_DC");
+    client.register_quest(&quest_id, &creator, &token, &100i128, &verifier, &(env.ledger().timestamp() + 10000));
+    client.deposit_escrow(&quest_id, &creator, &token, &500i128);
+    let proof: BytesN<32> = BytesN::from_array(env, &[1u8; 32]);
+    client.submit_proof(&quest_id, &submitter, &proof);
+    client.approve_submission(&quest_id, &submitter, &verifier);
+    (contract_id, client, token, creator, verifier, submitter)
+}
+
+/// Claiming twice for the same submission must fail on the second attempt.
+#[test]
+#[should_panic]
+fn double_claim_is_rejected() {
+    let env = Env::default();
+    let (_id, client, _token, _creator, _verifier, submitter) = setup(&env);
+    let quest_id = symbol_short!("Q_DC");
+    client.claim_reward(&quest_id, &submitter, &100i128);
+    client.claim_reward(&quest_id, &submitter, &100i128); // must panic
+}


### PR DESCRIPTION
Adds test_double_claim.rs verifying that a second claim on the same approved submission panics, preventing double-claim under concurrent attempts. CHANGELOG updated.

closes #1500