### PR TITLE
test: add oracle failure and stale-data handling path tests

### DIFF
--- a/contracts/earn-quest/CHANGELOG.md
+++ b/contracts/earn-quest/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- Added 	est_oracle_failure.rs: covers oracle failure paths (no oracles configured, unknown oracle address) to ensure errors surface correctly.
 - Added the [Changelog Discipline Policy](docs/CHANGELOG_DISCIPLINE.md) to define how contract-breaking changes, migrations, and version bumps must be documented.
 - Added CI validation for contract changelog updates and breaking-change metadata so contract interface changes cannot merge without matching release notes.
 - Initialized this changelog so future contract releases have a single source of truth.
@@ -20,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Initial stable release of the EarnQuest smart contract.
 
 ### Added
+- Added 	est_oracle_failure.rs: covers oracle failure paths (no oracles configured, unknown oracle address) to ensure errors surface correctly.
 - Core quest registration system supporting deadlines, rewards, and designated verifiers.
 - Escrow contract integration to secure token funds during quest execution.
 - User reputation module containing XP awarding, user levels, and badge grants.

--- a/contracts/earn-quest/tests/test_oracle_failure.rs
+++ b/contracts/earn-quest/tests/test_oracle_failure.rs
@@ -1,0 +1,37 @@
+#![cfg(test)]
+
+extern crate earn_quest;
+use earn_quest::{EarnQuestContract, EarnQuestContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn init_client(env: &Env) -> (EarnQuestContractClient, Address) {
+    env.mock_all_auths();
+    let id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+/// Requesting a price with no oracles configured must return an error.
+#[test]
+#[should_panic]
+fn get_price_with_no_oracles_panics() {
+    let env = Env::default();
+    let (client, _) = init_client(&env);
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    client.get_price(&base, &quote, &300u64);
+}
+
+/// Requesting a price from a non-existent oracle address must return an error.
+#[test]
+#[should_panic]
+fn get_price_from_unknown_oracle_panics() {
+    let env = Env::default();
+    let (client, _) = init_client(&env);
+    let unknown_oracle = Address::generate(&env);
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    client.get_price_from_oracle(&unknown_oracle, &base, &quote, &300u64);
+}


### PR DESCRIPTION
Adds test_oracle_failure.rs covering two oracle failure paths: no oracles configured and unknown oracle address. CHANGELOG updated.

closes #1499