### PR TITLE
feat: replace eager API client import with lazy loader

### DIFF
--- a/FrontEnd/my-app/lib/api/lazy-client.ts
+++ b/FrontEnd/my-app/lib/api/lazy-client.ts
@@ -1,0 +1,24 @@
+/**
+ * Lazy API client loader.
+ *
+ * Modules that do not need immediate network access should import the client
+ * via this helper instead of importing directly from `./client`. This defers
+ * the module evaluation and avoids eager initialisation on app startup.
+ *
+ * @example
+ *   const { apiClient } = await getLazyApiClient();
+ *   const data = await apiClient.get('/quests');
+ */
+export async function getLazyApiClient() {
+  const { apiClient } = await import('./client');
+  return { apiClient };
+}
+
+/**
+ * Lazy loader for the authenticated API client.
+ * Use in components or services that only need the client on user interaction.
+ */
+export async function getLazyAuthClient() {
+  const { authClient } = await import('./auth');
+  return { authClient };
+}


### PR DESCRIPTION
Adds lazy-client.ts with getLazyApiClient and getLazyAuthClient helpers so modules not requiring immediate network access defer client initialisation until first use.

closes #877