### PR TITLE
Add flaky-test quarantine policy

### DIFF
--- a/BackEnd/E2E_FLAKINESS_FIX.md
+++ b/BackEnd/E2E_FLAKINESS_FIX.md
@@ -660,6 +660,21 @@ In your CI/CD pipeline:
     fi
 ```
 
+### Flaky-Test Quarantine Policy
+
+Use the `flaky-test-quarantine` label for tests that fail intermittently and need temporary removal from the release gate.
+
+**Remediation SLA**
+- Triage within 1 business day after the label is applied.
+- Assign an owner and remediation plan within 1 business day.
+- Land a fix, test stabilization change, or explicit follow-up update within 3 business days.
+- Remove the quarantine label after the test passes cleanly for 5 consecutive CI runs.
+
+**Quarantine rules**
+- Only quarantine tests with a documented failure pattern and reproduction notes.
+- Keep `continue-on-error: true` limited to the quarantined test job or matrix entry.
+- Re-run quarantined tests on every CI pass until the label is removed.
+
 ## Checklist for Stable E2E Tests
 
 - [ ] All tests use `waitForAppReady()` in `beforeAll`


### PR DESCRIPTION
## Linked Issue

Closes #1166

## Description

Adds a flaky-test quarantine policy and remediation SLA to the backend E2E flakiness guide.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Security fix
- [ ] Refactor (no functional change)
- [x] Documentation update
- [ ] Tests only
- [ ] Configuration / DevOps change

## Test Evidence

- Not run (docs only)

## Final Pre-Merge Checklist

- [x] Branch is up to date with main / master
- [x] No hardcoded secrets or environment-specific values in source code
- [x] Self-review completed