### PR TITLE
docs: add local toolchain setup runbook for rustup, targets and soroban-cli

### DIFF
--- a/contracts/earn-quest/docs/LOCAL_TOOLCHAIN_SETUP.md
+++ b/contracts/earn-quest/docs/LOCAL_TOOLCHAIN_SETUP.md
@@ -1,0 +1,37 @@
+# Local Toolchain Setup Runbook
+
+Step-by-step guide to set up the EarnQuest development environment.
+
+## Prerequisites
+
+- Linux, macOS, or Windows (WSL2 recommended)
+
+## 1. Install Rust
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default stable
+rustup target add wasm32-unknown-unknown
+```
+
+## 2. Install Soroban CLI
+
+```bash
+cargo install soroban-cli --locked
+```
+
+## 3. Verify Setup
+
+```bash
+rustup show          # confirm stable toolchain active
+soroban --version    # confirm soroban-cli installed
+cargo test           # run contract tests
+```
+
+## 4. Common Issues
+
+| Problem | Fix |
+|---|---|
+| `wasm32` target missing | `rustup target add wasm32-unknown-unknown` |
+| `soroban` not found | Ensure `~/.cargo/bin` is in `$PATH` |
+| Build fails on Windows | Use WSL2 or install `pkg-config` and `libssl-dev` |


### PR DESCRIPTION
Adds LOCAL_TOOLCHAIN_SETUP.md with step-by-step instructions for installing Rust, adding the wasm32 target, and installing soroban-cli, plus a common issues table.

closes #1530