### PR TITLE
feat: add session expired flow when token refresh fails

### DIFF
--- a/FrontEnd/my-app/components/auth/SessionManager.test.tsx
+++ b/FrontEnd/my-app/components/auth/SessionManager.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SessionManager } from './SessionManager';
+
+const mockLogout = vi.fn();
+const mockRefreshProfile = vi.fn();
+const mockSetWalletModalOpen = vi.fn();
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    refreshProfile: mockRefreshProfile,
+    logout: mockLogout,
+    user: { stellarAddress: 'GABCD...', username: 'testuser' },
+  }),
+}));
+
+vi.mock('../../lib/store', () => ({
+  useStore: (selector: any) => {
+    const state = { setWalletModalOpen: mockSetWalletModalOpen };
+    return selector(state);
+  },
+}));
+
+describe('SessionManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing by default', () => {
+    const { container } = render(<SessionManager />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows session-expired modal when session-expired event is dispatched', async () => {
+    render(<SessionManager />);
+
+    window.dispatchEvent(
+      new CustomEvent('session-expired', {
+        detail: { reason: 'token_refresh_failed' },
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Session Expired')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText('Your session has expired. Please sign in again to continue.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /connect wallet/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /dismiss/i })
+    ).toBeInTheDocument();
+  });
+
+  it('calls logout and opens wallet modal when Connect Wallet is clicked', async () => {
+    render(<SessionManager />);
+
+    window.dispatchEvent(
+      new CustomEvent('session-expired', {
+        detail: { reason: 'token_refresh_failed' },
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Session Expired')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+      expect(mockSetWalletModalOpen).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('calls logout when Dismiss button is clicked', async () => {
+    render(<SessionManager />);
+
+    window.dispatchEvent(
+      new CustomEvent('session-expired', {
+        detail: { reason: 'token_refresh_failed' },
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Session Expired')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes event listener on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(<SessionManager />);
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith(
+      'session-expired',
+      expect.any(Function)
+    );
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/FrontEnd/my-app/components/auth/SessionManager.tsx
+++ b/FrontEnd/my-app/components/auth/SessionManager.tsx
@@ -1,20 +1,25 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { apiClient } from '../../lib/api/client';
+import { useStore } from '../../lib/store';
 import { motion, AnimatePresence } from 'framer-motion';
-import { AlertTriangle, RefreshCw, LogOut } from 'lucide-react';
+import { AlertTriangle, RefreshCw, LogOut, Wallet } from 'lucide-react';
+
+const SESSION_EXPIRED_EVENT = 'session-expired';
 
 /**
  * SessionManager handles:
  * 1. Auto-refreshing tokens before they expire (via /auth/profile calls)
  * 2. Monitoring authentication status
- * 3. Showing session timeout warnings
+ * 3. Showing session expired/timeout modals
  */
 export function SessionManager() {
-  const { isAuthenticated, refreshProfile, logout, user } = useAuth();
+  const { isAuthenticated, refreshProfile, logout } = useAuth();
+  const setWalletModalOpen = useStore((s) => s.setWalletModalOpen);
   const [showWarning, setShowWarning] = useState(false);
+  const [isSessionExpired, setIsSessionExpired] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const refreshInterval = useRef<NodeJS.Timeout | null>(null);
@@ -25,11 +30,30 @@ export function SessionManager() {
   const REFRESH_BEFORE_EXPIRY = 60 * 1000; // 1 minute before access token expiry
   const DEFAULT_ACCESS_TOKEN_LIFETIME = 15 * 60 * 1000; // 15 minutes
 
+  const handleSessionExpired = useCallback(() => {
+    setIsSessionExpired(true);
+    setShowWarning(true);
+    if (refreshInterval.current) {
+      clearInterval(refreshInterval.current);
+      refreshInterval.current = null;
+    }
+    if (warningTimeout.current) {
+      clearTimeout(warningTimeout.current);
+      warningTimeout.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
+    return () => {
+      window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
+    };
+  }, [handleSessionExpired]);
+
   useEffect(() => {
     const setupTimers = () => {
       if (!isAuthenticated) return;
 
-      // Clear existing timers
       if (refreshInterval.current) clearInterval(refreshInterval.current);
       if (warningTimeout.current) clearTimeout(warningTimeout.current);
 
@@ -56,6 +80,19 @@ export function SessionManager() {
     };
   }, [isAuthenticated, refreshProfile]);
 
+  const handleReconnect = useCallback(async () => {
+    await logout();
+    setShowWarning(false);
+    setIsSessionExpired(false);
+    setWalletModalOpen(true);
+  }, [logout, setWalletModalOpen]);
+
+  const handleLogout = useCallback(async () => {
+    await logout();
+    setShowWarning(false);
+    setIsSessionExpired(false);
+  }, [logout]);
+
   return (
     <>
       <AnimatePresence>
@@ -73,7 +110,44 @@ export function SessionManager() {
           </motion.div>
         )}
 
-        {showWarning && (
+        {showWarning && isSessionExpired && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            className="fixed inset-0 z-[110] flex items-center justify-center bg-black/40 backdrop-blur-sm"
+          >
+            <div className="w-[90vw] max-w-sm rounded-2xl border border-zinc-200 bg-white p-6 shadow-2xl dark:border-[#2A3338] dark:bg-[#161E22]">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-500/10 text-red-500">
+                <AlertTriangle className="h-6 w-6" />
+              </div>
+              <h3 className="mb-2 text-lg font-bold text-zinc-900 dark:text-white">
+                Session Expired
+              </h3>
+              <p className="mb-6 text-sm text-zinc-500 dark:text-[#92A5A8]">
+                Your session has expired. Please sign in again to continue.
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={handleLogout}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-zinc-200 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-[#2A3338] dark:hover:bg-white/5"
+                >
+                  <LogOut className="h-4 w-4" />
+                  Dismiss
+                </button>
+                <button
+                  onClick={handleReconnect}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-[#33C5E0] py-2 text-sm font-bold text-black hover:bg-[#33C5E0]/90"
+                >
+                  <Wallet className="h-4 w-4" />
+                  Connect Wallet
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+
+        {showWarning && !isSessionExpired && (
           <motion.div
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
@@ -93,7 +167,7 @@ export function SessionManager() {
               </p>
               <div className="flex gap-3">
                 <button
-                  onClick={logout}
+                  onClick={handleLogout}
                   className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-zinc-200 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-[#2A3338] dark:hover:bg-white/5"
                 >
                   <LogOut className="h-4 w-4" />

--- a/FrontEnd/my-app/docs/auth-session-expired.md
+++ b/FrontEnd/my-app/docs/auth-session-expired.md
@@ -1,0 +1,72 @@
+# Session Expired UX Flow
+
+When the JWT refresh token expires or becomes invalid, API requests return 401. The Axios interceptor attempts a transparent refresh, but when that also fails, the user needs clear feedback and a path to re-authenticate.
+
+---
+
+## Architecture
+
+```
+Axios interceptor (401 response → refresh fails)
+  ├── clearTokens()                    ← removes stale tokens from localStorage
+  ├── dispatchEvent('session-expired') ← bridges HTTP layer → React tree
+  └── Promise.reject(refreshError)     ← callers still handle errors normally
+
+SessionManager (listens for 'session-expired' event on window)
+  ├── shows modal: "Session Expired"
+  ├── "Connect Wallet" → logout() + open wallet connection modal
+  └── "Dismiss" → logout()
+```
+
+The HTTP interceptor lives outside React, so a DOM `CustomEvent` (`session-expired`) is used to bridge into the component tree. The `SessionManager` component, already mounted globally in the root layout, listens for this event and shows a modal.
+
+---
+
+## Flow
+
+1. A 401 response is received by the Axios response interceptor
+2. The interceptor tries `POST /auth/refresh` with the stored refresh token
+3. If refresh succeeds → queued requests are retried with the new token
+4. If refresh fails:
+   - `tokenManager.clearTokens()` removes both tokens from `localStorage`
+   - `window.dispatchEvent(new CustomEvent('session-expired', ...))` fires
+   - The failed request is rejected (callers handle normally)
+5. `SessionManager` receives the event and shows a modal:
+   - **"Session Expired"** title with explanation text
+   - **"Connect Wallet"** button → calls `logout()` then opens `WalletConnectionModal`
+   - **"Dismiss"** button → calls `logout()` without opening the wallet modal
+
+---
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `lib/api/client.ts` | Axios instance, token manager, response interceptor — refresh failure handling at lines 266-273 |
+| `components/auth/SessionManager.tsx` | Event listener + session-expired modal UI |
+| `components/auth/SessionManager.test.tsx` | Unit tests for the session-expired flow |
+| `lib/api/client.test.ts` | Unit tests for interceptor refresh-failure behavior (token clearing + event dispatch) |
+| `tests/e2e/auth.spec.ts` | E2E test for the session-expired modal appearance |
+
+---
+
+## Event Contract
+
+```typescript
+// Dispatched by client.ts when token refresh fails
+window.dispatchEvent(
+  new CustomEvent('session-expired', {
+    detail: { reason: 'token_refresh_failed' },
+  })
+);
+```
+
+Any component can listen for this event on `window` if needed.
+
+---
+
+## Design Decisions
+
+- **CustomEvent pattern** (not Zustand/Context): The Axios interceptor runs outside the React tree; dispatching a DOM event is the cleanest bridge.
+- **Tokens cleared in the interceptor**: Prevents stale tokens from being used in subsequent requests before React re-renders.
+- **Separate `isSessionExpired` state**: Distinguishes this modal from the proactive "Session Expiring" warning modal (which shares the same component but has different copy and buttons).

--- a/FrontEnd/my-app/lib/api/client.test.ts
+++ b/FrontEnd/my-app/lib/api/client.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { tokenManager } from './client';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { tokenManager, apiClient } from './client';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/tests/mocks/server';
+
+const REFRESH_TOKEN_KEY = 'stellar_earn_refresh_token';
+const ACCESS_TOKEN_KEY = 'stellar_earn_access_token';
+
+function setValidTokens() {
+  window.localStorage.setItem(ACCESS_TOKEN_KEY, 'header.payload.signature');
+  window.localStorage.setItem(REFRESH_TOKEN_KEY, 'header.payload.signature');
+}
 
 describe('tokenManager', () => {
-  const ACCESS_TOKEN_KEY = 'stellar_earn_access_token';
-
   beforeEach(() => {
     window.localStorage.clear();
     vi.restoreAllMocks();
@@ -32,5 +40,66 @@ describe('tokenManager', () => {
     });
     const result = tokenManager.getAccessToken();
     expect(result).toBeNull();
+  });
+});
+
+describe('response interceptor - refresh failure', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('clears tokens when refresh fails after a 401 response', async () => {
+    setValidTokens();
+
+    server.use(
+      http.get('http://localhost:3000/api/v1/auth/profile', () => {
+        return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+      }),
+      http.post('http://localhost:3000/api/v1/auth/refresh', () => {
+        return HttpResponse.json({ message: 'Refresh failed' }, { status: 401 });
+      })
+    );
+
+    try {
+      await apiClient.get('/auth/profile');
+    } catch {
+      // expected
+    }
+
+    expect(tokenManager.getAccessToken()).toBeNull();
+    expect(tokenManager.getRefreshToken()).toBeNull();
+  });
+
+  it('dispatches session-expired event when refresh fails', async () => {
+    setValidTokens();
+
+    const eventSpy = vi.fn();
+    window.addEventListener('session-expired', eventSpy);
+
+    server.use(
+      http.get('http://localhost:3000/api/v1/auth/profile', () => {
+        return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+      }),
+      http.post('http://localhost:3000/api/v1/auth/refresh', () => {
+        return HttpResponse.json({ message: 'Refresh failed' }, { status: 401 });
+      })
+    );
+
+    try {
+      await apiClient.get('/auth/profile');
+    } catch {
+      // expected
+    }
+
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+    const event = eventSpy.mock.calls[0][0] as CustomEvent;
+    expect(event.detail).toEqual({ reason: 'token_refresh_failed' });
+
+    window.removeEventListener('session-expired', eventSpy);
   });
 });

--- a/FrontEnd/my-app/lib/api/client.ts
+++ b/FrontEnd/my-app/lib/api/client.ts
@@ -264,6 +264,14 @@ apiClient.interceptors.response.use(
         processQueue(null, 'refreshed');
         return apiClient(originalRequest);
       } catch (refreshError) {
+        tokenManager.clearTokens();
+        if (isClient()) {
+          window.dispatchEvent(
+            new CustomEvent('session-expired', {
+              detail: { reason: 'token_refresh_failed' },
+            })
+          );
+        }
         processQueue(refreshError, null);
         return Promise.reject(refreshError);
       } finally {

--- a/FrontEnd/my-app/tests/e2e/auth.spec.ts
+++ b/FrontEnd/my-app/tests/e2e/auth.spec.ts
@@ -2,6 +2,13 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Authentication Flow', () => {
   test.beforeEach(async ({ page }) => {
+    // Suppress analytics banner
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'stellar_earn_analytics_consent',
+        JSON.stringify({ status: 'denied', version: '1' })
+      );
+    });
     await page.goto('/');
   });
 
@@ -21,5 +28,45 @@ test.describe('Authentication Flow', () => {
 
   test('should logout correctly', async () => {
     // Placeholder for logout coverage once wallet mocking is available.
+  });
+});
+
+test.describe('Session Expired Flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'stellar_earn_analytics_consent',
+        JSON.stringify({ status: 'denied', version: '1' })
+      );
+    });
+  });
+
+  test('should show session expired modal when session-expired event is dispatched', async ({ page }) => {
+    // Inject stale tokens to simulate an authenticated session
+    await page.addInitScript(() => {
+      localStorage.setItem('stellar_earn_access_token', 'expired.header.sig');
+      localStorage.setItem('stellar_earn_refresh_token', 'expired.header.sig');
+    });
+
+    await page.goto('/');
+
+    // Dispatch the session-expired event as the interceptor would
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('session-expired', {
+          detail: { reason: 'token_refresh_failed' },
+        })
+      );
+    });
+
+    // Verify the session expired modal appears
+    await expect(page.getByText('Session Expired')).toBeVisible();
+    await expect(
+      page.getByText('Your session has expired. Please sign in again to continue.')
+    ).toBeVisible();
+
+    // Verify action buttons are present
+    await expect(page.getByRole('button', { name: /connect wallet/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /dismiss/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #885

Changes made:
- lib/api/client.ts: On refresh failure: clearTokens() + dispatch session-expired event
- components/auth/SessionManager.tsx: Listen for event, show "Session Expired" modal with Connect Wallet / Dismiss
- lib/api/client.test.ts: 2 tests: tokens cleared + event dispatched
- components/auth/SessionManager.test.tsx: New file, 5 tests for modal flow
- tests/e2e/auth.spec.ts: E2E test for session-expired modal
- docs/auth-session-expired.md: New file, architecture & flow documentation