### PR TITLE
docs(backend): add reliability roadmap and backend CI workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,257 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "BackEnd/**"
+      - ".github/workflows/backend-ci.yml"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "BackEnd/**"
+      - ".github/workflows/backend-ci.yml"
+
+jobs:
+  build-and-lint:
+    name: Build, Lint & Format
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: BackEnd
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-backend-npm-${{ hashFiles('BackEnd/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript compilation
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npx prettier --check "src/**/*.ts" "test/**/*.ts"
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: build-and-lint
+    defaults:
+      run:
+        working-directory: BackEnd
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-backend-npm-${{ hashFiles('BackEnd/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        run: npm run test:cov
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-coverage
+          path: BackEnd/coverage/
+          retention-days: 7
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: build-and-lint
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: stellar_test
+          POSTGRES_PASSWORD: stellar_test
+          POSTGRES_DB: stellar_earn_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: BackEnd
+
+    env:
+      NODE_ENV: test
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: stellar_test
+      DB_PASSWORD: stellar_test
+      DB_DATABASE: stellar_earn_test
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-backend-npm-${{ hashFiles('BackEnd/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run integration tests
+        run: npm run test:integration
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: build-and-lint
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: stellar_test
+          POSTGRES_PASSWORD: stellar_test
+          POSTGRES_DB: stellar_earn_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: BackEnd
+
+    env:
+      NODE_ENV: test
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: stellar_test
+      DB_PASSWORD: stellar_test
+      DB_DATABASE: stellar_earn_e2e
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-backend-npm-${{ hashFiles('BackEnd/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+  backend-ci-gate:
+    name: Backend CI Gate
+    runs-on: ubuntu-latest
+    needs: [build-and-lint, unit-tests, integration-tests, e2e-tests]
+    if: always()
+
+    steps:
+      - name: Validate all checks passed
+        run: |
+          build_status="${{ needs.build-and-lint.result }}"
+          unit_status="${{ needs.unit-tests.result }}"
+          integration_status="${{ needs.integration-tests.result }}"
+          e2e_status="${{ needs.e2e-tests.result }}"
+
+          echo "Build & lint: $build_status"
+          echo "Unit tests:   $unit_status"
+          echo "Integration:  $integration_status"
+          echo "E2E:          $e2e_status"
+
+          if [ "$build_status" != "success" ]; then
+            echo "Build or lint failed"
+            exit 1
+          fi
+
+          if [ "$unit_status" != "success" ]; then
+            echo "Unit tests failed"
+            exit 1
+          fi
+
+          if [ "$integration_status" != "success" ]; then
+            echo "Integration tests failed"
+            exit 1
+          fi
+
+          if [ "$e2e_status" != "success" ]; then
+            echo "E2E tests failed"
+            exit 1
+          fi
+
+          echo "All backend CI checks passed"
+          exit 0

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -19,6 +19,7 @@ What lives **here** instead is the context Swagger can't express on its own: wha
 | [Module API Reference](./module-apis.md) | Every backend module — its responsibility, its HTTP surface (base path, key routes, auth), and the events it emits or consumes. |
 | [Data Flow & Diagrams](./data-flow.md) | System context, the request pipeline, the quest → verification → payout lifecycle, the event-driven backbone, and trace correlation. Rendered as Mermaid. |
 | [Type Ownership Guidelines](./type-ownership-guidelines.md) | How DTOs, domain models, and view models map across layers — defining type ownership and boundaries. |
+| [Reliability Roadmap](./RELIABILITY_ROADMAP.md) | Milestones for green CI, test quality targets, and performance SLOs. |
  
 ## Platform-wide conventions
  

--- a/docs/backend/RELIABILITY_ROADMAP.md
+++ b/docs/backend/RELIABILITY_ROADMAP.md
@@ -1,0 +1,127 @@
+# Backend Reliability Roadmap
+
+**Status:** Active | **Owner:** Backend maintainers | **Applies to:** `BackEnd/` (NestJS 11 + TypeORM/Postgres)
+
+This document defines the milestones used to track and gate backend reliability. Each milestone has a concrete acceptance condition so that progress can be verified in CI without ambiguity.
+
+---
+
+## Milestone 1 — Green CI
+
+**Goal:** Every pull request targeting `main` must pass a dedicated backend CI pipeline before merge.
+
+### Acceptance conditions
+
+| Check | Condition |
+| --- | --- |
+| TypeScript compilation | `nest build` exits 0 with zero type errors |
+| Unit tests | `npm test` exits 0; all `.spec.ts` files under `BackEnd/src/` pass |
+| E2E tests | `npm run test:e2e` exits 0 against a live Postgres + Redis test environment |
+| Integration tests | `npm run test:integration` exits 0 |
+| Lint | `npm run lint` exits 0 with zero ESLint errors (warnings are allowed) |
+| Format | `prettier --check` exits 0 for all `src/**/*.ts` and `test/**/*.ts` files |
+
+### Definition of "green"
+
+CI is considered green when all six checks above pass in the same pipeline run. A pipeline that skips or soft-fails any check does not count as green.
+
+### Workflow
+
+A dedicated workflow `.github/workflows/backend-ci.yml` is the authoritative gate. It runs on every push and pull request to `main`. See that file for the exact steps.
+
+---
+
+## Milestone 2 — Test Quality
+
+**Goal:** The test suite provides high confidence that regressions are caught before they reach production.
+
+### Coverage targets
+
+Coverage is measured by `npm run test:cov` (Jest + `--coverage`). The thresholds below are enforced in `BackEnd/jest.config.ts` (or the `jest` key in `package.json`) so that Jest fails if any target is missed.
+
+| Metric | Target |
+| --- | --- |
+| Statements | ≥ 80 % |
+| Branches | ≥ 75 % |
+| Functions | ≥ 80 % |
+| Lines | ≥ 80 % |
+
+### Test-type requirements
+
+| Test type | Requirement |
+| --- | --- |
+| Unit (`.spec.ts`) | Every service and controller exported from a module must have a corresponding unit test file |
+| Integration | Each cross-module interaction listed in [Data Flow & Diagrams](./data-flow.md) must have at least one integration test |
+| E2E | Every public HTTP endpoint documented in [Module API Reference](./module-apis.md) must be exercised by at least one E2E spec |
+| Security | Auth bypass and input-injection cases must be covered in `test/security/` |
+
+### Flaky-test policy
+
+A test is flaky when it fails on a retry without a code change. Flaky tests must be resolved within one sprint of discovery. Until resolved they must be quarantined (skipped with a `// TODO: flaky — <issue link>` annotation) so they do not block CI.
+
+### Naming convention
+
+Test files must follow the pattern `<subject>.<type>.ts` where `<type>` is one of `spec`, `e2e-spec`, or `integration-spec`. This matches the regex patterns in `jest-e2e.json` and `jest-integration.json`.
+
+---
+
+## Milestone 3 — Performance Targets
+
+**Goal:** The backend meets latency and throughput SLOs under both steady-state and spike traffic conditions.
+
+### HTTP response-time SLOs (p95, production traffic)
+
+| Endpoint group | p95 target |
+| --- | --- |
+| Quest listing (`GET /api/v1/quests`) | < 500 ms |
+| Quest detail (`GET /api/v1/quests/:id`) | < 300 ms |
+| Quest submission (`POST /api/v1/submissions`) | < 800 ms |
+| Auth (login / token refresh) | < 400 ms |
+| Health probe (`GET /api/v1/health`) | < 100 ms |
+
+These targets align with the thresholds already defined in the k6 load-test profile at `BackEnd/load-tests/quest-submissions.k6.ts`.
+
+### Throughput and error-rate SLOs
+
+| Metric | Target |
+| --- | --- |
+| HTTP error rate (5xx) | < 1 % under sustained load |
+| HTTP error rate (5xx) | < 2 % during spike (150 VUs) |
+| Quest-list throughput | ≥ 100 req/s at 50 VUs |
+| Submission throughput | ≥ 30 req/s at 50 VUs |
+
+### Load-test gate
+
+The k6 profile at `BackEnd/load-tests/quest-submissions.k6.ts` is the reference test. Stages:
+
+| Stage | VUs | Duration |
+| --- | --- | --- |
+| Ramp-up | 0 → 50 | 1 min |
+| Sustained | 50 | 3 min |
+| Spike | 50 → 150 | 30 s |
+| Sustained spike | 150 | 1 min |
+| Ramp-down | 150 → 0 | 1 min |
+
+A load-test run is considered passing when all `thresholds` defined in the k6 options block exit green.
+
+### Database query targets
+
+| Metric | Target |
+| --- | --- |
+| Slow queries (> 500 ms) | Zero in steady state |
+| Index coverage | All foreign-key columns and columns used in `WHERE` / `ORDER BY` clauses on high-traffic tables must be indexed |
+| Connection pool exhaustion | Zero occurrences in production logs |
+
+The Grafana dashboard at `BackEnd/monitoring/grafana/dashboards/database-pool-dashboard.json` is the reference for pool-exhaustion monitoring.
+
+---
+
+## Milestone tracking
+
+| Milestone | Status |
+| --- | --- |
+| M1 — Green CI | In progress |
+| M2 — Test quality | In progress |
+| M3 — Performance targets | In progress |
+
+Milestone status is updated here as conditions are met. A milestone moves to **Done** only when every acceptance condition in its section is satisfied in the `main` branch.


### PR DESCRIPTION
## Summary

closes #1260

- Adds `docs/backend/RELIABILITY_ROADMAP.md` defining three milestones: green CI, test quality, and performance targets with concrete, measurable acceptance conditions.
- Adds `.github/workflows/backend-ci.yml`, a dedicated backend CI pipeline that was missing from the repository. It runs TypeScript compilation, lint, format check, unit tests with coverage upload, integration tests, and E2E tests — each in its own job — behind a final gate job that mirrors the pattern used by `contract-ci.yml`.
- Updates `docs/backend/README.md` to index the new roadmap page.

## Details

**Green CI (Milestone 1):** Defines the six checks that must all pass for CI to be considered green (build, unit, E2E, integration, lint, format). The new `backend-ci.yml` workflow is the authoritative gate; it runs on every push and PR to `main` when `BackEnd/` files change.

**Test Quality (Milestone 2):** Sets coverage thresholds (80% statements/functions/lines, 75% branches), per-test-type requirements mapping to the existing `test/` directory structure, a flaky-test quarantine policy, and naming conventions consistent with `jest-e2e.json` and `jest-integration.json`.

**Performance Targets (Milestone 3):** Codifies the SLOs already implicit in `BackEnd/load-tests/quest-submissions.k6.ts` (p95 < 500 ms quest list, p95 < 800 ms submissions, < 1% error rate) alongside database query targets and the Grafana pool dashboard as the reference monitor. No existing numbers were changed.

## Test plan

- [ ] Confirm `backend-ci.yml` appears in the GitHub Actions tab after merge
- [ ] Verify the gate job (`backend-ci-gate`) blocks the PR status check when any upstream job fails
- [ ] Confirm roadmap document renders correctly on GitHub (tables, headings, internal links)
- [ ] Confirm `docs/backend/README.md` link to `RELIABILITY_ROADMAP.md` resolves
