### PR TITLE
feat: 2-of-2 SuperAdmin clawback for post-payout fraud recovery

### DIFF
--- a/contracts/earn-quest/CHANGELOG.md
+++ b/contracts/earn-quest/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- 2-of-2 SuperAdmin clawback: `initiate_clawback` and `execute_clawback` entry points in `payout.rs` allow two distinct SuperAdmins to collaboratively recover funds sent to a fraudulent recipient. Emits `ClawbackInitiated` and `ClawbackExecuted` events. Adds `ClawbackPending` storage key, `ClawbackNotFound` (150) and `ClawbackAlreadySigned` (151) error variants.
 - Added 	est_double_claim.rs: verifies that a second claim on the same submission is rejected, preventing double-claim under concurrent attempts.
 - Added the [Changelog Discipline Policy](docs/CHANGELOG_DISCIPLINE.md) to define how contract-breaking changes, migrations, and version bumps must be documented.
 - Added CI validation for contract changelog updates and breaking-change metadata so contract interface changes cannot merge without matching release notes.

--- a/contracts/earn-quest/src/errors.rs
+++ b/contracts/earn-quest/src/errors.rs
@@ -153,4 +153,10 @@ pub enum Error {
     // Creator Level Errors
     /// Creator level is below the minimum required threshold.
     InsufficientCreatorLevel = 146,
+
+    // Clawback Errors
+    /// No pending clawback found for this quest/recipient pair.
+    ClawbackNotFound = 150,
+    /// This SuperAdmin has already signed the pending clawback.
+    ClawbackAlreadySigned = 151,
 }

--- a/contracts/earn-quest/src/events.rs
+++ b/contracts/earn-quest/src/events.rs
@@ -442,3 +442,31 @@ pub fn creator_whitelist_removed(env: &Env, caller: Address, address: Address) {
     let data = ();
     env.events().publish(topics, data);
 }
+
+/// Emitted when the first SuperAdmin initiates a clawback (indexed: quest_id, initiator, recipient).
+pub fn clawback_initiated(
+    env: &Env,
+    quest_id: Symbol,
+    initiator: Address,
+    recipient: Address,
+    asset: Address,
+    amount: i128,
+) {
+    let topics = (symbol_short!("cb_init"), quest_id, initiator, recipient);
+    let data = (asset, amount);
+    env.events().publish(topics, data);
+}
+
+/// Emitted when the second SuperAdmin co-signs and the clawback is executed (indexed: quest_id, executor, recipient).
+pub fn clawback_executed(
+    env: &Env,
+    quest_id: Symbol,
+    executor: Address,
+    recipient: Address,
+    asset: Address,
+    amount: i128,
+) {
+    let topics = (symbol_short!("cb_exec"), quest_id, executor, recipient);
+    let data = (asset, amount);
+    env.events().publish(topics, data);
+}

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -20,6 +20,9 @@ pub mod validation;
 #[cfg(test)]
 mod test_token;
 
+#[cfg(test)]
+mod test_clawback;
+
 use crate::errors::Error;
 use crate::storage::{get_badge_type, list_badge_types};
 
@@ -498,6 +501,35 @@ impl EarnQuestContract {
 
         security::nonreentrant_exit(&env);
         Ok(())
+    }
+
+    /// Initiates a clawback of a post-payout reward (SuperAdmin only).
+    ///
+    /// The first SuperAdmin records the clawback intent. A *different* SuperAdmin
+    /// must call `execute_clawback` to complete the 2-of-2 flow.
+    pub fn initiate_clawback(
+        env: Env,
+        caller: Address,
+        quest_id: Symbol,
+        recipient: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        payout::initiate_clawback(&env, &caller, &quest_id, &recipient, &asset, amount)
+    }
+
+    /// Executes a pending clawback after a second SuperAdmin co-signs.
+    ///
+    /// The caller must be a different SuperAdmin from the one who called
+    /// `initiate_clawback`. Funds are transferred from the recipient back
+    /// to the contract (escrow) and the pending record is cleared.
+    pub fn execute_clawback(
+        env: Env,
+        caller: Address,
+        quest_id: Symbol,
+        recipient: Address,
+    ) -> Result<(), Error> {
+        payout::execute_clawback(&env, &caller, &quest_id, &recipient)
     }
 
     /// Returns the core statistics for a user (XP, level, quests completed).

--- a/contracts/earn-quest/src/payout.rs
+++ b/contracts/earn-quest/src/payout.rs
@@ -83,3 +83,103 @@ pub fn transfer_reward_from_escrow(
 
     transfer_reward(env, reward_asset, to, amount)
 }
+
+// ═══════════════════════════════════════════════════════════════
+// 2-of-2 SuperAdmin Clawback
+// ═══════════════════════════════════════════════════════════════
+
+/// First SuperAdmin flags a post-payout payment for clawback.
+///
+/// The initiator records the clawback intent.  A *different* SuperAdmin
+/// must call `execute_clawback` to complete the transfer back to escrow.
+pub fn initiate_clawback(
+    env: &Env,
+    caller: &Address,
+    quest_id: &Symbol,
+    recipient: &Address,
+    asset: &Address,
+    amount: i128,
+) -> Result<(), Error> {
+    caller.require_auth();
+
+    if !storage::is_super_admin(env, caller) {
+        return Err(Error::Unauthorized);
+    }
+    if amount <= 0 {
+        return Err(Error::InvalidRewardAmount);
+    }
+    // Disallow any further initiation once a pending record exists.
+    if storage::has_clawback(env, quest_id, recipient) {
+        return Err(Error::ClawbackAlreadySigned);
+    }
+
+    storage::set_clawback(
+        env,
+        quest_id,
+        recipient,
+        &storage::ClawbackPending {
+            initiator: caller.clone(),
+            asset: asset.clone(),
+            amount,
+        },
+    );
+
+    crate::events::clawback_initiated(
+        env,
+        quest_id.clone(),
+        caller.clone(),
+        recipient.clone(),
+        asset.clone(),
+        amount,
+    );
+    Ok(())
+}
+
+/// Second SuperAdmin co-signs and pulls funds from the recipient back to the
+/// contract's escrow/treasury address (current contract).
+///
+/// The caller must be a *different* SuperAdmin from the initiator.
+/// On success the pending record is cleared and `ClawbackExecuted` is emitted.
+pub fn execute_clawback(
+    env: &Env,
+    caller: &Address,
+    quest_id: &Symbol,
+    recipient: &Address,
+) -> Result<(), Error> {
+    caller.require_auth();
+
+    if !storage::is_super_admin(env, caller) {
+        return Err(Error::Unauthorized);
+    }
+
+    let pending = storage::get_clawback(env, quest_id, recipient)?;
+
+    if pending.initiator == *caller {
+        return Err(Error::ClawbackAlreadySigned);
+    }
+
+    // Recipient must have authorised the transfer back (Soroban auth model).
+    recipient.require_auth();
+
+    let token_client = token::Client::new(env, &pending.asset);
+    let contract_address = env.current_contract_address();
+
+    // Pull funds from the recipient back to this contract (escrow).
+    let result = token_client.try_transfer(recipient, &contract_address, &pending.amount);
+    match result {
+        Ok(Ok(_)) => {}
+        _ => return Err(Error::TransferFailed),
+    }
+
+    storage::delete_clawback(env, quest_id, recipient);
+
+    crate::events::clawback_executed(
+        env,
+        quest_id.clone(),
+        caller.clone(),
+        recipient.clone(),
+        pending.asset,
+        pending.amount,
+    );
+    Ok(())
+}

--- a/contracts/earn-quest/src/payout.rs
+++ b/contracts/earn-quest/src/payout.rs
@@ -1,5 +1,7 @@
 use crate::errors::Error;
-use soroban_sdk::{token, Address, Env};
+use crate::escrow;
+use crate::storage;
+use soroban_sdk::{token, Address, Env, Symbol};
 
 /// Transfer rewards from the contract escrow to the user (gas-optimized).
 ///
@@ -47,10 +49,6 @@ pub fn transfer_reward(
 // ═══════════════════════════════════════════════════════════════
 // ADD below the existing transfer_reward function
 // ═══════════════════════════════════════════════════════════════
-
-use crate::escrow;
-use crate::storage;
-use soroban_sdk::Symbol;
 
 /// Transfer reward with escrow tracking.
 ///

--- a/contracts/earn-quest/src/storage.rs
+++ b/contracts/earn-quest/src/storage.rs
@@ -96,6 +96,8 @@ pub enum DataKey {
     MinCreatorLevel,
     /// Addresses whitelisted to bypass the creator level requirement
     CreatorWhitelist(Address),
+    /// Pending clawback record keyed by (quest_id, recipient)
+    ClawbackPending(Symbol, Address),
 }
 
 //================================================================================
@@ -1342,4 +1344,42 @@ pub fn remove_creator_whitelist(env: &Env, address: &Address) {
     env.storage()
         .instance()
         .remove(&DataKey::CreatorWhitelist(address.clone()));
+}
+
+//================================================================================
+// Clawback Storage (2-of-2 SuperAdmin approval)
+//================================================================================
+
+/// Pending clawback state: stores the first signer and how much they want to reclaim.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClawbackPending {
+    pub initiator: Address,
+    pub asset: Address,
+    pub amount: i128,
+}
+
+pub fn has_clawback(env: &Env, quest_id: &Symbol, recipient: &Address) -> bool {
+    env.storage()
+        .instance()
+        .has(&DataKey::ClawbackPending(quest_id.clone(), recipient.clone()))
+}
+
+pub fn get_clawback(env: &Env, quest_id: &Symbol, recipient: &Address) -> Result<ClawbackPending, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ClawbackPending(quest_id.clone(), recipient.clone()))
+        .ok_or(Error::ClawbackNotFound)
+}
+
+pub fn set_clawback(env: &Env, quest_id: &Symbol, recipient: &Address, pending: &ClawbackPending) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ClawbackPending(quest_id.clone(), recipient.clone()), pending);
+}
+
+pub fn delete_clawback(env: &Env, quest_id: &Symbol, recipient: &Address) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::ClawbackPending(quest_id.clone(), recipient.clone()));
 }

--- a/contracts/earn-quest/src/test_clawback.rs
+++ b/contracts/earn-quest/src/test_clawback.rs
@@ -1,0 +1,184 @@
+//! Test suite for the 2-of-2 SuperAdmin clawback feature.
+//!
+//! Tests:
+//!   1. Non-SuperAdmin cannot initiate a clawback
+//!   2. First SuperAdmin can initiate a clawback
+//!   3. Same admin cannot both initiate and execute (ClawbackAlreadySigned)
+//!   4. Initiating twice by the same admin returns ClawbackAlreadySigned
+//!   5. Execute fails when no pending clawback exists (ClawbackNotFound)
+//!   6. Execute fails when the caller is not a SuperAdmin
+//!   7. Second SuperAdmin can execute and the record is removed
+
+#![cfg(test)]
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, Address, Env};
+
+use earn_quest::{EarnQuestContract, EarnQuestContractClient};
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+/// Returns a client, a primary super-admin, and a secondary super-admin.
+fn setup(env: &Env) -> (EarnQuestContractClient, Address, Address) {
+    let cid = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(env, &cid);
+
+    let admin1 = Address::generate(env);
+    let admin2 = Address::generate(env);
+
+    client.initialize(&admin1);
+    // Grant SuperAdmin role to the second admin via add_admin + grant_role
+    client.add_admin(&admin1, &admin2);
+    client.grant_role(&admin1, &admin2, &earn_quest::Role::SuperAdmin);
+
+    (client, admin1, admin2)
+}
+
+fn mock_asset(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 1. Non-SuperAdmin cannot initiate
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_non_superadmin_cannot_initiate() {
+    let env = make_env();
+    let (client, _admin1, _admin2) = setup(&env);
+
+    let rando = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let asset = mock_asset(&env);
+    let quest_id = symbol_short!("q1");
+
+    let result = client.try_initiate_clawback(&rando, &quest_id, &recipient, &asset, &100i128);
+    assert!(result.is_err());
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 2. First SuperAdmin can initiate
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_superadmin_can_initiate() {
+    let env = make_env();
+    let (client, admin1, _admin2) = setup(&env);
+
+    let recipient = Address::generate(&env);
+    let asset = mock_asset(&env);
+    let quest_id = symbol_short!("q1");
+
+    client.initiate_clawback(&admin1, &quest_id, &recipient, &asset, &500i128);
+    // No panic means success
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 3. Same admin cannot execute their own initiation
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initiator_cannot_execute() {
+    let env = make_env();
+    let (client, admin1, _admin2) = setup(&env);
+
+    let recipient = Address::generate(&env);
+    let asset = mock_asset(&env);
+    let quest_id = symbol_short!("q1");
+
+    client.initiate_clawback(&admin1, &quest_id, &recipient, &asset, &200i128);
+
+    let result = client.try_execute_clawback(&admin1, &quest_id, &recipient);
+    assert!(result.is_err());
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 4. Initiating twice by the same admin is rejected
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_double_initiate_rejected() {
+    let env = make_env();
+    let (client, admin1, _admin2) = setup(&env);
+
+    let recipient = Address::generate(&env);
+    let asset = mock_asset(&env);
+    let quest_id = symbol_short!("q1");
+
+    client.initiate_clawback(&admin1, &quest_id, &recipient, &asset, &300i128);
+
+    let result = client.try_initiate_clawback(&admin1, &quest_id, &recipient, &asset, &300i128);
+    assert!(result.is_err());
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 5. Execute fails when no pending clawback exists
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_without_initiation_fails() {
+    let env = make_env();
+    let (client, _admin1, admin2) = setup(&env);
+
+    let recipient = Address::generate(&env);
+    let quest_id = symbol_short!("q1");
+
+    let result = client.try_execute_clawback(&admin2, &quest_id, &recipient);
+    assert!(result.is_err());
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 6. Non-SuperAdmin cannot execute
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_non_superadmin_cannot_execute() {
+    let env = make_env();
+    let (client, admin1, _admin2) = setup(&env);
+
+    let rando = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let asset = mock_asset(&env);
+    let quest_id = symbol_short!("q1");
+
+    client.initiate_clawback(&admin1, &quest_id, &recipient, &asset, &100i128);
+
+    let result = client.try_execute_clawback(&rando, &quest_id, &recipient);
+    assert!(result.is_err());
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 7. Happy path: second admin executes, pending record cleared
+//    (token transfer is mocked via mock_all_auths + built-in contract token)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_happy_path_two_admins() {
+    let env = make_env();
+    let (client, admin1, admin2) = setup(&env);
+
+    let recipient = Address::generate(&env);
+    // Use the contract's own built-in token so the transfer resolves.
+    let contract_addr = client.address.clone();
+    let asset = contract_addr.clone();
+
+    // Mint some tokens to the recipient via the contract's built-in token.
+    client.mint(&admin1, &recipient, &1000i128);
+    assert_eq!(client.balance(&recipient), 1000);
+
+    let quest_id = symbol_short!("q1");
+
+    client.initiate_clawback(&admin1, &quest_id, &recipient, &asset, &400i128);
+    client.execute_clawback(&admin2, &quest_id, &recipient);
+
+    // Recipient balance should have decreased by 400.
+    assert_eq!(client.balance(&recipient), 600);
+
+    // A second execute on the same record must now fail (record cleaned up).
+    let result = client.try_execute_clawback(&admin2, &quest_id, &recipient);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes #1723 

## Summary

Adds a clawback mechanism so two SuperAdmins can collaboratively recover funds after a fraudulent payout is detected.

## Changes

| File | What changed |
|---|---|
| `storage.rs` | `ClawbackPending` DataKey + struct + CRUD helpers |
| `errors.rs` | `ClawbackNotFound` (150), `ClawbackAlreadySigned` (151) |
| `events.rs` | `ClawbackInitiated`, `ClawbackExecuted` events |
| `payout.rs` | `initiate_clawback` + `execute_clawback` logic |
| `lib.rs` | Public entry points for both functions; `test_clawback` module registered |
| `test_clawback.rs` | 7 tests covering auth, double-sign guard, missing record, and happy path |

## Flow

1. SuperAdmin A calls `initiate_clawback(quest_id, recipient, asset, amount)` — stores pending record and emits `ClawbackInitiated`.
2. SuperAdmin B (different address) calls `execute_clawback(quest_id, recipient)` — transfers `amount` from recipient back to contract escrow, clears record, emits `ClawbackExecuted`.

## Acceptance Criteria

- [x] Clawback requires two distinct SuperAdmin approvals
- [x] Same admin cannot both initiate and execute (`ClawbackAlreadySigned`)
- [x] Funds returned to escrow/contract after successful clawback
- [x] `ClawbackInitiated` and `ClawbackExecuted` events emitted