### PR TITLE
feat: implement Quest List page with pagination and filters

### DIFF
--- a/FrontEnd/my-app/app/[locale]/quests/loading.tsx
+++ b/FrontEnd/my-app/app/[locale]/quests/loading.tsx
@@ -1,0 +1,32 @@
+import { QuestCardSkeleton } from '@/components/quest/QuestCardSkeleton';
+
+export default function QuestsLoading() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mb-6 lg:mb-8">
+        <div className="h-9 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="mt-2 h-4 w-72 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+
+      {/* Filter bar skeleton */}
+      <div className="mb-6 h-24 animate-pulse rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900" />
+
+      {/* Quest card grid skeleton */}
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <QuestCardSkeleton key={i} />
+        ))}
+      </div>
+
+      {/* Pagination skeleton */}
+      <div className="mt-8 flex justify-center gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-9 w-9 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/FrontEnd/my-app/app/[locale]/quests/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/quests/page.tsx
@@ -1,22 +1,21 @@
 'use client';
 
-import { useState, Suspense, useMemo, useCallback } from 'react';
+import { useState, Suspense, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { SearchBar } from '@/components/ui/SearchBar';
-import { FilterPanel } from '@/components/quest/FilterPanel';
+import { QuestListFilters } from '@/components/quest/QuestListFilters';
 import { QuestList } from '@/components/quest/QuestList';
 import { OfflineIndicator } from '@/components/quest/OfflineIndicator';
 import { Pagination } from '@/components/ui/Pagination';
-import { mockQuests } from '@/lib/mock/quests';
 import { QuestStatus, QuestDifficulty } from '@/lib/types/quest';
 import type { Quest } from '@/lib/types/quest';
 import LazyLoad from '@/components/ui/LazyLoad';
 import { ComponentErrorBoundary } from '@/components/error/ErrorBoundary';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { Sidebar } from '@/components/layout/Sidebar';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+import { useQuests } from '@/lib/hooks/useQuests';
 
 function QuestsContent() {
   const searchParams = useSearchParams();
@@ -24,7 +23,7 @@ function QuestsContent() {
   const [searchQuery, setSearchQuery] = useState('');
   const { isOnline } = useOnlineStatus();
 
-  // Get filters from URL params
+  // Derive filter state from URL search params
   const statusParam = searchParams.get('status');
   const statusFilter =
     statusParam &&
@@ -42,93 +41,85 @@ function QuestsContent() {
   const categoryParam = searchParams.get('category');
   const categoryFilter = categoryParam || undefined;
 
-  // Get page from URL params
+  const minRewardParam = searchParams.get('minReward');
+  const minReward = minRewardParam ? Number(minRewardParam) : undefined;
+
+  const maxRewardParam = searchParams.get('maxReward');
+  const maxReward = maxRewardParam ? Number(maxRewardParam) : undefined;
+
+  const searchParam = searchParams.get('search');
   const pageParam = searchParams.get('page');
   const currentPage = pageParam ? parseInt(pageParam, 10) : 1;
   const limit = 12;
 
-  // Filter quests based on all criteria
-  const filteredQuests = useMemo(() => {
-    let filtered = [...mockQuests];
+  // Wire useQuests hook — filters and pagination are passed to the API
+  const { quests, isLoading, error, pagination, refetch } = useQuests(
+    {
+      status: statusFilter,
+      difficulty: difficultyFilter,
+      category: categoryFilter,
+      search: searchParam ?? searchQuery ?? undefined,
+      minReward,
+      maxReward,
+    },
+    { page: currentPage, limit }
+  );
 
-    // Filter by status
-    if (statusFilter) {
-      filtered = filtered.filter((q) => q.status === statusFilter);
-    }
-
-    // Filter by difficulty
-    if (difficultyFilter) {
-      filtered = filtered.filter((q) => q.difficulty === difficultyFilter);
-    }
-
-    // Filter by category
-    if (categoryFilter) {
-      filtered = filtered.filter((q) => q.category === categoryFilter);
-    }
-
-    // Filter by search query
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (q) =>
-          q.title.toLowerCase().includes(query) ||
-          q.description.toLowerCase().includes(query)
-      );
-    }
-
-    return filtered;
-  }, [statusFilter, difficultyFilter, categoryFilter, searchQuery]);
-
-  // Paginate results
-  const paginatedQuests = useMemo(() => {
-    const start = (currentPage - 1) * limit;
-    const end = start + limit;
-    return filteredQuests.slice(start, end);
-  }, [filteredQuests, currentPage, limit]);
-
-  const totalPages = Math.ceil(filteredQuests.length / limit);
-  const hasMore = currentPage < totalPages;
+  const totalPages = pagination?.totalPages ?? 1;
+  const hasMore = pagination?.hasMore ?? false;
   const hasActiveFilters = !!(
     statusFilter ||
     difficultyFilter ||
     categoryFilter ||
-    searchQuery
+    searchQuery ||
+    minReward !== undefined ||
+    maxReward !== undefined
   );
 
-  // Update URL when filters change
+  // Push filter/pagination updates to URL so state persists across navigation
   const updateURL = useCallback(
     (updates: Record<string, string | null>) => {
       const params = new URLSearchParams(searchParams.toString());
       Object.entries(updates).forEach(([key, value]) => {
-        if (value) {
+        if (value !== null && value !== '') {
           params.set(key, value);
         } else {
           params.delete(key);
         }
       });
-      params.set('page', '1'); // Reset to first page when filters change
-      router.push(`/quests?${params.toString()}`);
+      params.set('page', '1');
+      router.push(`?${params.toString()}`);
     },
     [router, searchParams]
   );
 
   const handleStatusChange = useCallback(
     (status: QuestStatus | undefined) => {
-      updateURL({ status: status || null });
+      updateURL({ status: status ?? null });
     },
     [updateURL]
   );
 
   const handleDifficultyChange = useCallback(
     (difficulty: QuestDifficulty | undefined) => {
-      updateURL({ difficulty: difficulty || null });
+      updateURL({ difficulty: difficulty ?? null });
     },
     [updateURL]
   );
 
   const handleCategoryChange = useCallback(
     (category: string | undefined) => {
-      updateURL({ category: category || null });
+      updateURL({ category: category ?? null });
+    },
+    [updateURL]
+  );
+
+  const handleRewardRangeChange = useCallback(
+    (min: number | undefined, max: number | undefined) => {
+      updateURL({
+        minReward: min !== undefined ? String(min) : null,
+        maxReward: max !== undefined ? String(max) : null,
+      });
     },
     [updateURL]
   );
@@ -143,15 +134,14 @@ function QuestsContent() {
 
   const handleClearFilters = useCallback(() => {
     setSearchQuery('');
-    router.push('/quests');
+    router.push('?');
   }, [router]);
 
-  // Update URL when page changes
   const handlePageChange = useCallback(
     (page: number) => {
       const params = new URLSearchParams(searchParams.toString());
       params.set('page', page.toString());
-      router.push(`/quests?${params.toString()}`);
+      router.push(`?${params.toString()}`);
     },
     [router, searchParams]
   );
@@ -163,23 +153,15 @@ function QuestsContent() {
     [router]
   );
 
-  // Retry handler for reloading quests when coming back online
-  const handleRetry = useCallback(async () => {
-    // In a real app, this would refetch from the API
-    // For now, just a no-op since we're using mock data
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }, []);
-
   return (
     <AppLayout>
-      {/* Offline Indicator */}
       <OfflineIndicator
         isOffline={!isOnline}
         message="You appear to be offline. Quest data may not load properly."
       />
 
       <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        {/* Header content */}
+        {/* Header */}
         <div
           className="mb-6 flex items-center justify-between lg:mb-8"
           data-onboarding="quest-board-header"
@@ -201,6 +183,7 @@ function QuestsContent() {
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -213,26 +196,29 @@ function QuestsContent() {
           </Link>
         </div>
 
-        {/* Search and Filter Section */}
+        {/* Search + Filters */}
         <ComponentErrorBoundary componentName="SearchAndFilters">
           <div
             className="mb-6 space-y-4 rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
             data-onboarding="quest-board-filters"
           >
-            <div className=" lg:max-w-md">
+            <div className="lg:max-w-md">
               <SearchBar
                 onSearch={handleSearch}
                 placeholder="Search quests..."
                 defaultValue={searchQuery}
               />
             </div>
-            <FilterPanel
+            <QuestListFilters
               selectedStatus={statusFilter}
               selectedDifficulty={difficultyFilter}
               selectedCategory={categoryFilter}
+              minReward={minReward}
+              maxReward={maxReward}
               onStatusChange={handleStatusChange}
               onDifficultyChange={handleDifficultyChange}
               onCategoryChange={handleCategoryChange}
+              onRewardRangeChange={handleRewardRangeChange}
               onClearFilters={handleClearFilters}
             />
           </div>
@@ -243,26 +229,26 @@ function QuestsContent() {
           <div className="mb-6" data-onboarding="quest-board-list">
             <LazyLoad>
               <QuestList
-                quests={paginatedQuests as unknown as Quest[]}
-                isLoading={false}
-                error={null}
+                quests={quests as Quest[]}
+                isLoading={isLoading}
+                error={error}
                 onQuestClick={handleQuestClick}
                 hasActiveFilters={hasActiveFilters}
                 onClearFilters={handleClearFilters}
-                onRetry={handleRetry}
+                onRetry={refetch}
               />
             </LazyLoad>
           </div>
         </ComponentErrorBoundary>
 
-        {/* Pagination logic */}
+        {/* Pagination */}
         {totalPages > 1 && (
           <Pagination
             currentPage={currentPage}
             totalPages={totalPages}
             hasMore={hasMore}
             onPageChange={handlePageChange}
-            isLoading={false}
+            isLoading={isLoading}
           />
         )}
       </div>

--- a/FrontEnd/my-app/components/quest/QuestListFilters.tsx
+++ b/FrontEnd/my-app/components/quest/QuestListFilters.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { QuestStatus, QuestDifficulty } from '@/lib/types/quest';
+
+const CATEGORIES = [
+  'Security',
+  'Frontend',
+  'Backend',
+  'Docs',
+  'Testing',
+  'Community',
+];
+
+interface QuestListFiltersProps {
+  selectedStatus?: QuestStatus;
+  selectedDifficulty?: QuestDifficulty;
+  selectedCategory?: string;
+  minReward?: number;
+  maxReward?: number;
+  onStatusChange: (status: QuestStatus | undefined) => void;
+  onDifficultyChange: (difficulty: QuestDifficulty | undefined) => void;
+  onCategoryChange: (category: string | undefined) => void;
+  onRewardRangeChange: (
+    min: number | undefined,
+    max: number | undefined
+  ) => void;
+  onClearFilters: () => void;
+}
+
+export function QuestListFilters({
+  selectedStatus,
+  selectedDifficulty,
+  selectedCategory,
+  minReward,
+  maxReward,
+  onStatusChange,
+  onDifficultyChange,
+  onCategoryChange,
+  onRewardRangeChange,
+  onClearFilters,
+}: QuestListFiltersProps) {
+  const hasActiveFilters = !!(
+    selectedStatus ||
+    selectedDifficulty ||
+    selectedCategory ||
+    minReward !== undefined ||
+    maxReward !== undefined
+  );
+
+  return (
+    <div
+      className="flex flex-wrap items-end gap-3"
+      role="group"
+      aria-label="Quest filters"
+    >
+      {/* Status */}
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="filter-status"
+          className="text-xs font-medium text-zinc-500 dark:text-zinc-400"
+        >
+          Status
+        </label>
+        <select
+          id="filter-status"
+          value={selectedStatus ?? ''}
+          onChange={(e) =>
+            onStatusChange(
+              e.target.value ? (e.target.value as QuestStatus) : undefined
+            )
+          }
+          className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        >
+          <option value="">All Statuses</option>
+          {Object.values(QuestStatus).map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Difficulty */}
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="filter-difficulty"
+          className="text-xs font-medium text-zinc-500 dark:text-zinc-400"
+        >
+          Difficulty
+        </label>
+        <select
+          id="filter-difficulty"
+          value={selectedDifficulty ?? ''}
+          onChange={(e) =>
+            onDifficultyChange(
+              e.target.value
+                ? (e.target.value as QuestDifficulty)
+                : undefined
+            )
+          }
+          className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        >
+          <option value="">All Difficulties</option>
+          {Object.values(QuestDifficulty).map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Category */}
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="filter-category"
+          className="text-xs font-medium text-zinc-500 dark:text-zinc-400"
+        >
+          Category
+        </label>
+        <select
+          id="filter-category"
+          value={selectedCategory ?? ''}
+          onChange={(e) => onCategoryChange(e.target.value || undefined)}
+          className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        >
+          <option value="">All Categories</option>
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Reward range */}
+      <div className="flex flex-col gap-1">
+        <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+          Reward Range (XLM)
+        </span>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            placeholder="Min"
+            value={minReward ?? ''}
+            min={0}
+            aria-label="Minimum reward in XLM"
+            onChange={(e) =>
+              onRewardRangeChange(
+                e.target.value ? Number(e.target.value) : undefined,
+                maxReward
+              )
+            }
+            className="w-24 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+          />
+          <span className="text-sm text-zinc-400" aria-hidden="true">
+            &ndash;
+          </span>
+          <input
+            type="number"
+            placeholder="Max"
+            value={maxReward ?? ''}
+            min={0}
+            aria-label="Maximum reward in XLM"
+            onChange={(e) =>
+              onRewardRangeChange(
+                minReward,
+                e.target.value ? Number(e.target.value) : undefined
+              )
+            }
+            className="w-24 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+          />
+        </div>
+      </div>
+
+      {/* Clear */}
+      {hasActiveFilters && (
+        <button
+          type="button"
+          onClick={onClearFilters}
+          className="self-end rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          Clear Filters
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Wires the existing `useQuests` hook to the quest list page, replacing static mock data with real API data
- Adds a new `QuestListFilters` component with status, difficulty, category, and reward-range filters
- Persists all filter state in URL search params so filters survive page refresh and are shareable
- Adds a `loading.tsx` route-level skeleton rendered by Next.js while the page is fetching
- Passes `isLoading` and `error` from `useQuests` through to `QuestList` so loading and error states render correctly

## Changed Files

| File | Change |
|------|--------|
| `FrontEnd/my-app/app/[locale]/quests/page.tsx` | Replaced `mockQuests` + client-side filter logic with `useQuests` hook; swapped `FilterPanel` for `QuestListFilters`; wired real `isLoading`, `error`, `pagination` from hook |
| `FrontEnd/my-app/app/[locale]/quests/loading.tsx` | **New** — Next.js route loading UI: header skeleton + filter bar skeleton + 9-card grid skeleton + pagination skeleton |
| `FrontEnd/my-app/components/quest/QuestListFilters.tsx` | **New** — dedicated filter bar: Status / Difficulty / Category selects + min/max reward range inputs + Clear Filters button; all state drives URL params |

## How It Works

### Filter persistence
Every filter change calls `updateURL()` which writes the new value into `useSearchParams` and resets `page` to 1. The `useQuests` hook reads the derived filter object, so navigating back/forward or sharing the URL restores the exact filter state.

### Pagination
`useQuests` receives `{ page: currentPage, limit: 12 }`. The `Pagination` component is driven by `pagination.totalPages` and `pagination.hasMore` returned from the hook.

### Loading skeleton
Next.js automatically shows `loading.tsx` while the page segment is suspending. The inner `<Suspense>` fallback in `page.tsx` handles the `useSearchParams` boundary as before.

## Acceptance Criteria

- [x] Quest list renders with real API data via `useQuests`
- [x] Filters (status, difficulty, category, reward range) update URL params and re-fetch
- [x] Pagination works with next/prev controls driven by `pagination.totalPages`
- [x] Loading skeleton shown during fetch (both `loading.tsx` and `isLoading` prop on `QuestList`)
- [x] Empty state handled by existing `QuestList` empty-state when `quests.length === 0`

## Test plan

- [ ] CI typecheck passes (`npx tsc --noEmit`)
- [ ] CI lint passes (`npm run lint`)
- [ ] Selecting a status filter updates the URL and re-renders the list
- [ ] Clearing filters resets URL and shows all quests
- [ ] Navigating to page 2 updates `?page=2` in the URL
- [ ] Hard-refreshing with `?status=Active&page=2` restores the correct state
- [ ] `loading.tsx` skeleton is visible when the route first loads

closes #1670