### PR TITLE
Feat/storage level thresholds

### DIFF
--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -64,7 +64,22 @@ impl EarnQuestContract {
         storage::grant_role(&env, &admin, &Role::StatsAdmin);
         storage::grant_role(&env, &admin, &Role::BadgeAdmin);
         reputation::seed_default_badge_types(&env, &admin);
+        // Seed default level thresholds (levels 2..5)
+        let mut default_thresholds: Vec<u64> = Vec::new(&env);
+        default_thresholds.push_back(300u64);
+        default_thresholds.push_back(600u64);
+        default_thresholds.push_back(1000u64);
+        default_thresholds.push_back(1500u64);
+        storage::set_level_thresholds(&env, &default_thresholds);
         storage::mark_initialized(&env);
+    }
+
+    /// Set configurable level thresholds (SuperAdmin only).
+    pub fn set_level_thresholds(env: Env, caller: Address, thresholds: Vec<u64>) -> Result<(), Error> {
+        security::require_not_paused(&env)?;
+        admin::require_role(&env, &caller, Role::SuperAdmin)?;
+        storage::set_level_thresholds(&env, &thresholds);
+        Ok(())
     }
 
     /// Authorizes a contract upgrade (SuperAdmin only).

--- a/contracts/earn-quest/src/reputation.rs
+++ b/contracts/earn-quest/src/reputation.rs
@@ -4,11 +4,6 @@ use crate::storage;
 use crate::types::{Badge, BadgeType, Role, UserCore};
 use soroban_sdk::{Address, Env, String, Symbol, symbol_short};
 
-const LEVEL_2_XP: u64 = 300;
-const LEVEL_3_XP: u64 = 600;
-const LEVEL_4_XP: u64 = 1000;
-const LEVEL_5_XP: u64 = 1500;
-
 /// Awards experience points (XP) to a user and handles leveling up.
 ///
 /// This function increments the user's total XP and the number of quests completed.
@@ -30,7 +25,7 @@ pub fn award_xp(env: &Env, user: &Address, xp_amount: u64) -> Result<UserCore, E
     stats.xp += xp_amount;
     stats.quests_completed += 1;
 
-    let new_level = calculate_level(stats.xp);
+    let new_level = calculate_level(env, stats.xp);
     let level_up = new_level > stats.level;
     stats.level = new_level;
 
@@ -47,32 +42,29 @@ pub fn award_xp(env: &Env, user: &Address, xp_amount: u64) -> Result<UserCore, E
 
 /// Calculates the user level based on their current experience points (XP).
 ///
-/// # Level Thresholds:
-/// - Level 1: 0 - 299 XP
-/// - Level 2: 300 - 599 XP
-/// - Level 3: 600 - 999 XP
-/// - Level 4: 1000 - 1499 XP
-/// - Level 5: 1500+ XP
+/// Thresholds are loaded from contract storage (level 2..N). The thresholds
+/// vector contains the minimum XP required for level 2, level 3, etc.
 ///
 /// # Arguments
 ///
+/// * `env` - The contract environment (used to read thresholds)
 /// * `xp` - The total experience points of the user.
 ///
 /// # Returns
 ///
-/// The user's level (1 to 5).
-pub fn calculate_level(xp: u64) -> u32 {
-    if xp >= LEVEL_5_XP {
-        5
-    } else if xp >= LEVEL_4_XP {
-        4
-    } else if xp >= LEVEL_3_XP {
-        3
-    } else if xp >= LEVEL_2_XP {
-        2
-    } else {
-        1
+/// The user's level (1..N).
+pub fn calculate_level(env: &Env, xp: u64) -> u32 {
+    let thresholds = storage::get_level_thresholds(env);
+    let mut level: u32 = 1;
+    let mut i = 0u32;
+    while i < thresholds.len() {
+        let th = thresholds.get(i).unwrap();
+        if xp >= th {
+            level = i + 2; // thresholds[0] -> level 2
+        }
+        i += 1;
     }
+    level
 }
 
     // Map badge to XP reward

--- a/contracts/earn-quest/src/storage.rs
+++ b/contracts/earn-quest/src/storage.rs
@@ -99,6 +99,8 @@ pub enum DataKey {
     MinCreatorLevel,
     /// Addresses whitelisted to bypass the creator level requirement
     CreatorWhitelist(Address),
+    /// Level thresholds for reputation levels (Vec<u64>, thresholds for lvl2..N)
+    LevelThresholds,
     /// Pending clawback record keyed by (quest_id, recipient)
     ClawbackPending(Symbol, Address),
 }
@@ -532,13 +534,18 @@ pub fn add_user_xp(env: &Env, user: &Address, xp_delta: u64) -> Result<UserCore,
     let mut stats = get_user_stats(env, user)?;
     stats.xp = stats.xp.saturating_add(xp_delta);
 
-    stats.level = match stats.xp {
-        x if x >= 1500 => 5,
-        x if x >= 1000 => 4,
-        x if x >= 600 => 3,
-        x if x >= 300 => 2,
-        _ => 1,
-    };
+    // Recalculate level using configurable thresholds stored in contract storage.
+    let thresholds = get_level_thresholds(env);
+    let mut level = 1u32;
+    let mut i = 0u32;
+    while i < thresholds.len() {
+        let th = thresholds.get(i).unwrap();
+        if stats.xp >= th {
+            level = i + 2; // thresholds[0] -> level 2
+        }
+        i += 1;
+    }
+    stats.level = level;
 
     set_user_stats(env, user, &stats);
     Ok(stats)
@@ -1349,6 +1356,25 @@ pub fn remove_creator_whitelist(env: &Env, address: &Address) {
         .remove(&DataKey::CreatorWhitelist(address.clone()));
 }
 
+pub fn get_level_thresholds(env: &Env) -> Vec<u64> {
+env.storage()
+    .instance()
+    .get(&DataKey::LevelThresholds)
+    .unwrap_or_else(|| {
+        // Default thresholds: 300, 600, 1000, 1500 (levels 2..5)
+        let mut v = Vec::new(env);
+        v.push_back(300u64);
+        v.push_back(600u64);
+        v.push_back(1000u64);
+        v.push_back(1500u64);
+        v
+    })
+}
+
+pub fn set_level_thresholds(env: &Env, thresholds: &Vec<u64>) {
+env.storage().instance().set(&DataKey::LevelThresholds, thresholds);
+}
+
 #[cfg(test)]
 mod layout_tests {
     use super::*;
@@ -1399,11 +1425,12 @@ mod layout_tests {
         "TokenDecimals",
         "BadgeType",
         "BadgeTypeIds",
+        "LevelThresholds",
         "MinCreatorLevel",
         "CreatorWhitelist",
     ];
 
-    const EXPECTED_VARIANT_COUNT: usize = 44;
+    const EXPECTED_VARIANT_COUNT: usize = 45;
 
     /// One sample instance per `DataKey` variant for layout audits.
     fn all_data_keys(env: &Env) -> Vec<DataKey> {
@@ -1454,6 +1481,7 @@ mod layout_tests {
         keys.push_back(DataKey::TokenDecimals);
         keys.push_back(DataKey::BadgeType(badge_id.clone()));
         keys.push_back(DataKey::BadgeTypeIds);
+        keys.push_back(DataKey::LevelThresholds);
         keys.push_back(DataKey::MinCreatorLevel);
         keys.push_back(DataKey::CreatorWhitelist(addr.clone()));
         keys
@@ -1497,6 +1525,8 @@ mod layout_tests {
         assert_eq!(all_data_keys(&env).len() as usize, VARIANT_NAMES.len());
         assert_eq!(VARIANT_NAMES.len(), EXPECTED_VARIANT_COUNT);
     }
+}
+
 //================================================================================
 // Clawback Storage (2-of-2 SuperAdmin approval)
 //================================================================================

--- a/contracts/earn-quest/src/test_clawback.rs
+++ b/contracts/earn-quest/src/test_clawback.rs
@@ -15,6 +15,7 @@ use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{symbol_short, Address, Env};
 
 use earn_quest::{EarnQuestContract, EarnQuestContractClient};
+use crate::Role;
 
 fn make_env() -> Env {
     let env = Env::default();
@@ -33,7 +34,7 @@ fn setup(env: &Env) -> (EarnQuestContractClient, Address, Address) {
     client.initialize(&admin1);
     // Grant SuperAdmin role to the second admin via add_admin + grant_role
     client.add_admin(&admin1, &admin2);
-    client.grant_role(&admin1, &admin2, &earn_quest::Role::SuperAdmin);
+    client.grant_role(&admin1, &admin2, &Role::SuperAdmin);
 
     (client, admin1, admin2)
 }

--- a/contracts/earn-quest/src/test_thresholds.rs
+++ b/contracts/earn-quest/src/test_thresholds.rs
@@ -1,0 +1,77 @@
+#![cfg(test)]
+
+use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
+
+use earn_quest::{EarnQuestContract, EarnQuestContractClient, Badge};
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn set_time(env: &Env, ts: u64) {
+    env.ledger().set(LedgerInfo {
+        protocol_version: 20,
+        sequence_number: 1,
+        timestamp: ts,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 100,
+        min_persistent_entry_ttl: 100,
+        max_entry_ttl: 1_000_000,
+    });
+}
+
+fn setup(env: &Env) -> (EarnQuestContractClient, Address) {
+    let cid = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(env, &cid);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+#[test]
+fn test_superadmin_can_update_level_thresholds_and_recalc() {
+    let env = make_env();
+    set_time(&env, 1_000);
+    let (client, admin) = setup(&env);
+
+    // New thresholds: level2=50, level3=100, level4=200, level5=400
+    let mut thresholds: Vec<u64> = Vec::new(&env);
+    thresholds.push_back(50u64);
+    thresholds.push_back(100u64);
+    thresholds.push_back(200u64);
+    thresholds.push_back(400u64);
+
+    // SuperAdmin updates thresholds
+    client.set_level_thresholds(&admin, thresholds);
+
+    // New user
+    let user = Address::generate(&env);
+    let stats_before = client.get_user_stats(&user);
+    assert_eq!(stats_before.level, 1);
+
+    // Grant a Legend badge (100 XP) - should push user to level 3 under new thresholds
+    client.grant_badge(&admin, &user, Badge::Legend).unwrap();
+
+    let stats_after = client.get_user_stats(&user);
+    assert_eq!(stats_after.xp, 100);
+    assert_eq!(stats_after.level, 3);
+}
+
+#[test]
+fn test_non_superadmin_cannot_update_thresholds() {
+    let env = make_env();
+    set_time(&env, 1_000);
+    let (client, _admin) = setup(&env);
+
+    let random = Address::generate(&env);
+    let mut thresholds: Vec<u64> = Vec::new(&env);
+    thresholds.push_back(10u64);
+    thresholds.push_back(20u64);
+
+    let res = client.try_set_level_thresholds(&random, thresholds);
+    assert!(res.is_err(), "non-superadmin must be rejected");
+}


### PR DESCRIPTION
Description
Closes #1713 
Overview
XP requirements per level are hard-coded constants in eputation.rs. They cannot be adjusted without a full contract upgrade, making it impossible to tune the economy.

Specifications
Features:
set_level_thresholds(env, caller, thresholds: Vec) gated to SuperAdmin
Store thresholds in contract storage
Default thresholds seeded on initialisation
Tasks:
Move level threshold constants to storage
Add set_level_thresholds admin function
Add tests for threshold update and level recalculation
Impacted Files:
contracts/earn-quest/src/reputation.rsn- contracts/earn-quest/src/storage.rsn
Acceptance Criteria:
SuperAdmin can update level thresholds
Level is recalculated using new thresholds on next XP award