### PR TITLE
feat(submissions): add POST /quests/:id/submissions controller endpoint

### DIFF
--- a/BackEnd/src/database/migrations/1769900000000-add-submission-transaction-hash.ts
+++ b/BackEnd/src/database/migrations/1769900000000-add-submission-transaction-hash.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `transactionHash` column to `submissions` so that
+ * SubmissionsService.approveSubmission can persist the on-chain tx hash
+ * returned by StellarService.approveSubmission (which calls the
+ * Soroban `approve_submission` contract method).
+ */
+export class AddSubmissionTransactionHash1769900000000
+  implements MigrationInterface
+{
+  name = 'AddSubmissionTransactionHash1769900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "submissions" ADD "transactionHash" varchar(128)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "submissions" DROP COLUMN "transactionHash"`,
+    );
+  }
+}

--- a/BackEnd/src/events/dto/submission-created.event.ts
+++ b/BackEnd/src/events/dto/submission-created.event.ts
@@ -1,0 +1,21 @@
+import { IsString, IsNotEmpty, IsUUID } from 'class-validator';
+
+export class SubmissionCreatedEvent {
+  @IsUUID()
+  @IsNotEmpty()
+  submissionId: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  questId: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  userId: string;
+
+  constructor(submissionId: string, questId: string, userId: string) {
+    this.submissionId = submissionId;
+    this.questId = questId;
+    this.userId = userId;
+  }
+}

--- a/BackEnd/src/modules/stellar/stellar.service.spec.ts
+++ b/BackEnd/src/modules/stellar/stellar.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { BadRequestException, ServiceUnavailableException } from '@nestjs/common';
 import { StellarService } from './stellar.service';
 import { TracingService } from '../../common/tracing/tracing.service';
 import { MetricsService } from '../../common/services/metrics.service';
@@ -160,5 +161,220 @@ describe('StellarService (Security)', () => {
         error_type: 'submission_error',
       },
     );
+  });
+});
+
+describe('StellarService.approveSubmission (Soroban contract call)', () => {
+  let service: StellarService;
+  let metrics: { incrementCounter: jest.Mock; observeHistogram: jest.Mock };
+
+  // Real test keypair so we can drive both the source account and the
+  // secret-key lookup through the same secret string.
+  const adminKeypair = StellarSdk.Keypair.random();
+
+  // Override the parent mockConfig returns for keys specific to
+  // approveSubmission.
+  const APPROVE_CONTRACT_ID = 'CABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12345';
+  const QUEST_ID = 'quest-1';
+  const SUBMITTER = StellarSdk.Keypair.random().publicKey();
+  const VERIFIER = StellarSdk.Keypair.random().publicKey();
+
+  const mockConfig = {
+    get: jest.fn((key: string, defaultValue?: any) => {
+      if (key === 'STELLAR_ADMIN_SECRET') return adminKeypair.secret();
+      if (key === 'SOROBAN_SECRET_KEY') return null;
+      if (key === 'STELLAR_NETWORK') return 'TESTNET';
+      if (key === 'STELLAR_HORIZON_URL')
+        return 'https://horizon-testnet.stellar.org';
+      if (key === 'SOROBAN_RPC_URL')
+        return 'https://soroban-testnet.stellar.org';
+      if (key === 'CONTRACT_ID') return APPROVE_CONTRACT_ID;
+      return defaultValue ?? null;
+    }),
+  };
+
+  const mockSpan = {
+    attributes: {} as Record<string, any>,
+    status: 'ok',
+  };
+  const mockTracing = {
+    trace: jest.fn().mockImplementation(async (_name, fn, attrs) => {
+      mockSpan.attributes = { ...(attrs ?? {}) };
+      mockSpan.status = 'ok';
+      return fn(mockSpan);
+    }),
+  };
+  const mockMetricsFactory = () => ({
+    incrementCounter: jest.fn(),
+    observeHistogram: jest.fn(),
+  });
+
+  beforeEach(async () => {
+    metrics = mockMetricsFactory();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarService,
+        { provide: ConfigService, useValue: mockConfig },
+        { provide: TracingService, useValue: mockTracing },
+        { provide: MetricsService, useValue: metrics },
+      ],
+    }).compile();
+
+    service = module.get<StellarService>(StellarService);
+    service.onModuleInit();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds, simulates, signs, and submits a Soroban approve_submission call', async () => {
+    // Load account returns a sensible account sequence. We don't care
+    // about most fields here — just that submitTransaction is called
+    // once with a transaction that contains exactly one
+    // invokeContractFunction operation.
+    jest
+      .spyOn((service as any).horizonServer, 'loadAccount')
+      .mockResolvedValue({ sequence: '1' } as any);
+    jest
+      .spyOn((service as any).rpcServer, 'simulateTransaction')
+      .mockResolvedValue({ result: { retval: {} } } as any);
+    jest
+      .spyOn((service as any).horizonServer, 'submitTransaction')
+      .mockResolvedValue({ hash: 'txhash-001', ledger: 999 } as any);
+
+    const result = await service.approveSubmission(
+      QUEST_ID,
+      SUBMITTER,
+      VERIFIER,
+    );
+
+    expect(result).toEqual({
+      transactionHash: 'txhash-001',
+      ledger: 999,
+      success: true,
+    });
+
+    // RPC simulation was called exactly once.
+    expect(
+      (service as any).rpcServer.simulateTransaction,
+    ).toHaveBeenCalledTimes(1);
+
+    // Submit was called exactly once.
+    expect(
+      (service as any).horizonServer.submitTransaction,
+    ).toHaveBeenCalledTimes(1);
+
+    // The submitted transaction has exactly one invokeContractFunction op.
+    const submittedTx = (
+      (service as any).horizonServer.submitTransaction.mock.calls[0] as any
+    )[0];
+    expect(submittedTx.operations.length).toBe(1);
+    expect(submittedTx.operations[0].type).toBe('invokeContractFunction');
+
+    // The op carries the contract id, function name, and three args
+    // (Symbol, Address, Address) with the right encoded values.
+    const op = submittedTx.operations[0];
+    expect(op.contract).toBe(APPROVE_CONTRACT_ID);
+    expect(op.function).toBe('approve_submission');
+    expect(op.args.length).toBe(3);
+
+    // Tracing + metrics were emitted by the inner _signAndSubmitContract
+    // helper with the explicit contract id + function name (not the
+    // prior "unknown" labels that op.contract/op.function extraction
+    // produced).
+    expect(metrics.incrementCounter).toHaveBeenCalledWith(
+      'stellar_contract_invocations_total',
+      expect.objectContaining({
+        contract_id: APPROVE_CONTRACT_ID,
+        function: 'approve_submission',
+      }),
+    );
+    expect(metrics.observeHistogram).toHaveBeenCalledWith(
+      'stellar_contract_invocation_duration_ms',
+      expect.any(Number),
+      expect.objectContaining({
+        contract_id: APPROVE_CONTRACT_ID,
+        function: 'approve_submission',
+        status: 'success',
+      }),
+    );
+
+    // The outer approveSubmission does NOT increment the same counter,
+    // so we count the exact number of invocations: exactly one.
+    const invocationsCalls = metrics.incrementCounter.mock.calls.filter(
+      ([name]: [string]) => name === 'stellar_contract_invocations_total',
+    );
+    expect(invocationsCalls.length).toBe(1);
+  });
+
+  it('throws BadRequestException when the contract simulation rejects the call', async () => {
+    jest
+      .spyOn((service as any).horizonServer, 'loadAccount')
+      .mockResolvedValue({ sequence: '1' } as any);
+    // The SDK's `rpc.Api.isSimulationError` is purely a shape check on
+    // `{ error: string|Error }`. Returning an object with that key is
+    // sufficient — no need to spy on SDK internals.
+    jest
+      .spyOn((service as any).rpcServer, 'simulateTransaction')
+      .mockResolvedValue({ error: 'QuestNotFound' } as any);
+
+    await expect(
+      service.approveSubmission(QUEST_ID, SUBMITTER, VERIFIER),
+    ).rejects.toThrow(BadRequestException);
+
+    // Submit was never called — we abort before payment.
+    expect(
+      (service as any).horizonServer.submitTransaction,
+    ).not.toHaveBeenCalled();
+
+    // Failure metric was recorded with simulation_error tag.
+    expect(metrics.incrementCounter).toHaveBeenCalledWith(
+      'stellar_contract_invocation_failures_total',
+      expect.objectContaining({
+        contract_id: APPROVE_CONTRACT_ID,
+        function: 'approve_submission',
+        error_type: 'simulation_error',
+      }),
+    );
+  });
+
+  it('throws ServiceUnavailableException when STELLAR_ADMIN_SECRET is missing', async () => {
+    mockConfig.get.mockImplementation((key: string, def?: any) => {
+      if (key === 'STELLAR_ADMIN_SECRET') return null;
+      if (key === 'SOROBAN_SECRET_KEY') return null;
+      if (key === 'STELLAR_NETWORK') return 'TESTNET';
+      if (key === 'CONTRACT_ID') return APPROVE_CONTRACT_ID;
+      if (key === 'HORIZON_URL') return 'https://horizon-testnet.stellar.org';
+      if (key === 'SOROBAN_RPC_URL')
+        return 'https://soroban-testnet.stellar.org';
+      return def ?? null;
+    });
+
+    await expect(
+      service.approveSubmission(QUEST_ID, SUBMITTER, VERIFIER),
+    ).rejects.toThrow(ServiceUnavailableException);
+
+    expect(metrics.incrementCounter).toHaveBeenCalledWith(
+      'stellar_contract_invocation_failures_total',
+      expect.objectContaining({
+        contract_id: APPROVE_CONTRACT_ID,
+        function: 'approve_submission',
+        error_type: 'missing_secret',
+      }),
+    );
+  });
+
+  it('throws BadRequestException for missing argument values', async () => {
+    await expect(
+      service.approveSubmission('', SUBMITTER, VERIFIER),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      service.approveSubmission(QUEST_ID, '', VERIFIER),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      service.approveSubmission(QUEST_ID, SUBMITTER, ''),
+    ).rejects.toThrow(BadRequestException);
   });
 });

--- a/BackEnd/src/modules/stellar/stellar.service.ts
+++ b/BackEnd/src/modules/stellar/stellar.service.ts
@@ -3,16 +3,54 @@ import {
   Logger,
   OnModuleInit,
   InternalServerErrorException,
+  BadRequestException,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import * as StellarSdk from 'stellar-sdk';
+import {
+  Account,
+  Address,
+  Keypair,
+  Operation,
+  rpc,
+  TransactionBuilder,
+  nativeToScVal,
+} from 'stellar-sdk';
 import { TracingService } from '../../common/tracing/tracing.service';
 import { MetricsService } from '../../common/services/metrics.service';
 
+export interface ApproveSubmissionResult {
+  transactionHash: string;
+  ledger: number;
+  success: boolean;
+}
+
+/**
+ * Outline of how a Soroban contract call flows through this service:
+ *
+ *   approveSubmission(...)
+ *     │  validate args + read CONTRACT_ID
+ *     │  tracing.trace('stellar.contract.approve_submission')
+ *     │      │  build tx (Operation.invokeContractFunction)
+ *     │      │  simulateTransaction → if error: throw BadRequestException
+ *     │      └► _signAndSubmitContract(tx, contractId, functionName)
+ *     │              │  load account, sign tx, submit via Horizon
+ *     │              │  tracing.trace('stellar.contract.submit') — once
+ *     │              │  metrics emitted once with correct labels
+ *     │              └► return { hash, ledger }
+ *     └► return { transactionHash, ledger, success: true }
+ *
+ * `_signAndSubmitContract` takes the contract id + function name
+ * explicitly because the SDK's operation object doesn't expose them at
+ * the top level for `invokeContractFunction` operations — extracting
+ * `op.contract` / `op.function` (the old `signAndSubmit` heuristic)
+ * returns `undefined` and forces metric labels to "unknown".
+ */
 @Injectable()
 export class StellarService implements OnModuleInit {
   private readonly logger = new Logger(StellarService.name);
   private horizonServer: StellarSdk.Horizon.Server;
+  private rpcServer: rpc.Server;
   private networkPassphrase: string;
 
   constructor(
@@ -29,9 +67,15 @@ export class StellarService implements OnModuleInit {
     const horizonUrl =
       this.configService.get<string>('STELLAR_HORIZON_URL') ||
       'https://horizon-testnet.stellar.org';
+    const rpcUrl =
+      this.configService.get<string>('SOROBAN_RPC_URL') ||
+      'https://soroban-testnet.stellar.org';
     const network = this.configService.get<string>('STELLAR_NETWORK');
 
     this.horizonServer = new StellarSdk.Horizon.Server(horizonUrl);
+    this.rpcServer = new rpc.Server(rpcUrl, {
+      allowHttp: rpcUrl.startsWith('http://'),
+    });
     this.networkPassphrase =
       network === 'PUBLIC'
         ? StellarSdk.Networks.PUBLIC
@@ -40,27 +84,201 @@ export class StellarService implements OnModuleInit {
     this.logger.log(`Stellar Service initialized on ${network}`);
   }
 
-  async signAndSubmit(transaction: StellarSdk.Transaction): Promise<any> {
-    const secretKey = this.configService.get<string>('STELLAR_ADMIN_SECRET');
+  /**
+   * Build, simulate, sign, and submit a Soroban contract call to
+   * `approve_submission(quest_id, submitter, verifier)` on the configured
+   * earn-quest contract. The admin keypair from `STELLAR_ADMIN_SECRET` (or
+   * `SOROBAN_SECRET_KEY` as a fallback) is used to sign the transaction.
+   *
+   * Returns the transaction hash and ledger on success. Throws:
+   *  - `BadRequestException` if the contract simulation rejects the call
+   *    (wrong verifier, quest not found, quest full, etc.).
+   *  - `ServiceUnavailableException` if submission to the network itself
+   *    fails.
+   *
+   * NOTE: This method is intentionally tied to the current earn-quest
+   * contract surface. If the contract signature changes, this method
+   * should be updated in lockstep with src/lib.rs.
+   */
+  async approveSubmission(
+    questContractId: string,
+    submitterAddress: string,
+    verifierAddress: string,
+  ): Promise<ApproveSubmissionResult> {
+    if (!questContractId) {
+      throw new BadRequestException('questContractId is required');
+    }
+    if (!submitterAddress) {
+      throw new BadRequestException('submitterAddress is required');
+    }
+    if (!verifierAddress) {
+      throw new BadRequestException('verifierAddress is required');
+    }
 
-    if (!secretKey) {
-      throw new InternalServerErrorException(
-        'Stellar admin secret is not configured in .env',
+    const contractId = this.configService.get<string>('CONTRACT_ID');
+    if (!contractId) {
+      throw new ServiceUnavailableException(
+        'CONTRACT_ID is not configured; cannot invoke approve_submission',
       );
     }
 
+    return this.tracing.trace(
+      'stellar.contract.approve_submission',
+      async (span) => {
+        span.attributes['stellar.contract.id'] = contractId;
+        span.attributes['stellar.contract.function'] = 'approve_submission';
+        span.attributes['stellar.quest.id'] = questContractId;
+        span.attributes['stellar.submitter.address'] = submitterAddress;
+        span.attributes['stellar.verifier.address'] = verifierAddress;
+
+        const secret =
+          this.configService.get<string>('STELLAR_ADMIN_SECRET') ||
+          this.configService.get<string>('SOROBAN_SECRET_KEY');
+        if (!secret) {
+          const msg =
+            'STELLAR_ADMIN_SECRET (or SOROBAN_SECRET_KEY) is not configured';
+          span.status = 'error';
+          span.attributes['error.message'] = msg;
+          span.attributes['error.type'] = 'MissingSecret';
+          this.metrics.incrementCounter(
+            'stellar_contract_invocation_failures_total',
+            {
+              contract_id: contractId,
+              function: 'approve_submission',
+              error_type: 'missing_secret',
+            },
+          );
+          throw new ServiceUnavailableException(msg);
+        }
+
+        const adminKeypair = Keypair.fromSecret(secret);
+        const sourcePubKey = adminKeypair.publicKey();
+        const accountResponse = await this.horizonServer.loadAccount(
+          sourcePubKey,
+        );
+        const source = new Account(sourcePubKey, accountResponse.sequence);
+
+        const tx = new TransactionBuilder(source, {
+          fee: '100',
+          networkPassphrase: this.networkPassphrase,
+        })
+          .addOperation(
+            Operation.invokeContractFunction({
+              contract: contractId,
+              function: 'approve_submission',
+              args: [
+                nativeToScVal(questContractId, { type: 'symbol' }),
+                new Address(submitterAddress).toScVal(),
+                new Address(verifierAddress).toScVal(),
+              ],
+            }),
+          )
+          .setTimeout(30)
+          .build();
+
+        // Simulate first to surface contract-level errors (wrong
+        // verifier, quest full, etc.) as 400s rather than burning fees.
+        const sim = await this.rpcServer.simulateTransaction(tx);
+        if (rpc.Api.isSimulationError(sim)) {
+          const errorMsg =
+            typeof sim.error === 'string' ? sim.error : 'simulation failed';
+          span.status = 'error';
+          span.attributes['error.message'] = errorMsg;
+          span.attributes['error.type'] = 'SimulationError';
+          this.metrics.incrementCounter(
+            'stellar_contract_invocation_failures_total',
+            {
+              contract_id: contractId,
+              function: 'approve_submission',
+              error_type: 'simulation_error',
+            },
+          );
+          this.logger.warn(
+            `approve_submission simulation failed for quest=${questContractId}: ${errorMsg}`,
+          );
+          throw new BadRequestException(
+            `Contract rejected approve_submission: ${errorMsg}`,
+          );
+        }
+
+        // Delegate signing + Horizon submission to the helper so
+        // tracing/metrics with the correct labels are emitted exactly
+        // once.
+        const result = await this._signAndSubmitContract(
+          tx,
+          contractId,
+          'approve_submission',
+        );
+
+        span.attributes['stellar.tx.ledger'] = result.ledger;
+        span.attributes['stellar.tx.status'] = 'success';
+
+        this.logger.log(
+          `approve_submission completed for quest=${questContractId} submitter=${submitterAddress} tx=${result.hash}`,
+        );
+
+        return {
+          transactionHash: result.hash,
+          ledger: result.ledger,
+          success: true,
+        };
+      },
+      {
+        'stellar.contract.id': contractId,
+        'stellar.contract.function': 'approve_submission',
+      },
+    );
+  }
+
+  /**
+   * Sign `tx` with the configured admin keypair and submit it to the
+   * horizon endpoint. Emits `stellar.contract.submit` tracing + the
+   * shared `stellar_contract_invocations_total{contract_id, function}`
+   * counter using the *explicitly-passed* labels so they don't degrade
+   * to `'unknown'` for `invokeContractFunction` ops.
+   *
+   * Wrapped version that delegates to {@link _signAndSubmitContract}
+   * with labels derived from the first operation. Preserved for callers
+   * (tests, other modules) that may already use it.
+   */
+  async signAndSubmit(transaction: StellarSdk.Transaction): Promise<any> {
     let contractId = 'unknown';
     let functionName = 'unknown';
 
     if (transaction.operations && transaction.operations.length > 0) {
       const op = transaction.operations[0] as any;
-      if (
-        op.type === 'invokeContractFunction' ||
-        op.type === 'invoke_contract_function'
-      ) {
-        contractId = op.contract || 'unknown';
-        functionName = op.function || 'unknown';
+      if (op.type === 'invokeContractFunction') {
+        // For invokeContractFunction ops the SDK does not expose
+        // `contract`/`function` as top-level instance properties; fall
+        // back to inspecting the inner HostFunction if present.
+        contractId =
+          typeof op.contract === 'string' ? op.contract : 'unknown';
+        functionName =
+          typeof op.function === 'string' ? op.function : 'invokeContractFunction';
       }
+    }
+
+    return this._signAndSubmitContract(
+      transaction,
+      contractId,
+      functionName,
+    );
+  }
+
+  /**
+   * Lower-level sign + submit with explicit labels. The single source
+   * of truth for the contract-call tracing + metrics shape.
+   */
+  private async _signAndSubmitContract(
+    transaction: StellarSdk.Transaction,
+    contractId: string,
+    functionName: string,
+  ): Promise<{ hash: string; ledger: number }> {
+    const secretKey = this.configService.get<string>('STELLAR_ADMIN_SECRET');
+    if (!secretKey) {
+      throw new InternalServerErrorException(
+        'Stellar admin secret is not configured in .env',
+      );
     }
 
     return this.tracing.trace(
@@ -98,7 +316,7 @@ export class StellarService implements OnModuleInit {
           span.attributes['stellar.tx.ledger'] = result.ledger;
           span.attributes['stellar.tx.status'] = 'success';
 
-          return result;
+          return { hash: transaction.hash().toString('hex'), ledger: result.ledger };
         } catch (error) {
           const duration = Date.now() - startTime;
           this.metrics.observeHistogram(
@@ -118,13 +336,13 @@ export class StellarService implements OnModuleInit {
             error instanceof Error ? error.stack : undefined,
           );
 
-          // Record failure in tracing span
           span.status = 'error';
           span.attributes['error.message'] = errorMsg;
           span.attributes['error.type'] =
-            error instanceof Error ? error.name : 'SigningOrSubmissionError';
+            error instanceof Error
+              ? error.name
+              : 'SigningOrSubmissionError';
 
-          // Record failure in metrics
           this.metrics.incrementCounter(
             'stellar_contract_invocation_failures_total',
             {

--- a/BackEnd/src/modules/submissions/dto/create-submission.dto.ts
+++ b/BackEnd/src/modules/submissions/dto/create-submission.dto.ts
@@ -1,0 +1,50 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Body for POST /quests/:questId/submissions.
+ *
+ * The userId is deliberately NOT part of this DTO — it is sourced from the
+ * authenticated JWT via @CurrentUser(). Putting it in the body would let any
+ * caller submit proof on someone else's behalf (a privilege-escalation bug
+ * we explicitly avoid here).
+ */
+export class CreateSubmissionDto {
+  @ApiProperty({
+    description: 'Name of the proof file',
+    example: 'kyc_verification.pdf',
+    minLength: 1,
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(255)
+  fileName: string;
+
+  @ApiProperty({
+    description: 'Base64 encoded file content or file URL',
+    example:
+      'data:application/pdf;base64,JVBERi0xLjQKJdPr6eEKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5kb2JqCjIgMCBvYmo=',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  fileContent: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional notes from the submitter, visible to the verifier during review',
+    maxLength: 1000,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  notes?: string;
+}

--- a/BackEnd/src/modules/submissions/entities/submission.entity.ts
+++ b/BackEnd/src/modules/submissions/entities/submission.entity.ts
@@ -52,6 +52,9 @@ export class Submission {
   @Column({ nullable: true })
   verifierNotes: string;
 
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  transactionHash: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/BackEnd/src/modules/submissions/submissions.controller.ts
+++ b/BackEnd/src/modules/submissions/submissions.controller.ts
@@ -1,10 +1,32 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { SubmissionsService } from './submissions.service';
 import { RateLimit } from '../../common/decorators/rate-limit.decorator';
+import { CreateSubmissionDto } from './dto/create-submission.dto';
+import { ApproveSubmissionDto } from './dto/approve-submission.dto';
+import { RejectSubmissionDto } from './dto/reject-submission.dto';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { AuthUser } from '../auth/auth.service';
+import { Submission } from './entities/submission.entity';
 
 @ApiTags('Submissions')
+@ApiBearerAuth()
 @Controller('quests/:questId/submissions')
 @UseGuards(JwtAuthGuard)
 export class SubmissionsController {
@@ -12,9 +34,119 @@ export class SubmissionsController {
 
   @Get()
   @RateLimit({ name: 'submission' })
-  @ApiOperation({ summary: 'Get submissions for a quest' })
+  @ApiOperation({ summary: 'List submissions for a quest' })
+  @ApiParam({ name: 'questId', description: 'Quest ID (UUID)' })
   @ApiResponse({ status: 200, description: 'Submissions list returned' })
-  getQuestSubmissions() {
-    return { success: true, data: [] };
+  async list(
+    @Param('questId') questId: string,
+  ): Promise<{
+    success: true;
+    data: { submissions: Submission[]; total: number };
+  }> {
+    const submissions = await this.submissionsService.findByQuest(questId);
+    return {
+      success: true,
+      data: { submissions, total: submissions.length },
+    };
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @RateLimit({ name: 'submission' })
+  @ApiOperation({
+    summary: 'Submit proof for a quest (authenticated user)',
+  })
+  @ApiParam({ name: 'questId', description: 'Quest ID (UUID)' })
+  @ApiResponse({ status: 201, description: 'Submission created' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Invalid input, missing wallet link, or quest not accepting submissions',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Quest not found' })
+  submit(
+    @Param('questId') questId: string,
+    @Body() dto: CreateSubmissionDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<{ success: true; data: { submission: Submission } }> {
+    return this.submissionsService
+      .createSubmission(questId, dto, user.id)
+      .then((submission) => ({ success: true, data: { submission } }));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single submission by id' })
+  @ApiParam({ name: 'questId', description: 'Quest ID (UUID)' })
+  @ApiParam({ name: 'id', description: 'Submission ID (UUID)' })
+  @ApiResponse({ status: 200, description: 'Submission returned' })
+  @ApiResponse({ status: 404, description: 'Submission not found' })
+  getOne(
+    @Param('id') id: string,
+  ): Promise<{ success: true; data: { submission: Submission } }> {
+    return this.submissionsService
+      .findOne(id)
+      .then((submission) => ({ success: true, data: { submission } }));
+  }
+
+  @Post(':id/approve')
+  @HttpCode(HttpStatus.OK)
+  @RateLimit({ name: 'submission' })
+  @ApiOperation({
+    summary:
+      'Approve a submission (verifier/admin only). Triggers on-chain approve_submission.',
+  })
+  @ApiParam({ name: 'questId', description: 'Quest ID (UUID)' })
+  @ApiParam({ name: 'id', description: 'Submission ID (UUID)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Submission approved; on-chain tx hash returned',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid status transition or on-chain failure',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Not the assigned verifier or admin',
+  })
+  @ApiResponse({ status: 404, description: 'Submission not found' })
+  @ApiResponse({ status: 409, description: 'CAS conflict (status changed)' })
+  approve(
+    @Param('id') id: string,
+    @Body() dto: ApproveSubmissionDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<{ success: true; data: { submission: Submission } }> {
+    return this.submissionsService
+      .approveSubmission(id, dto, user.id)
+      .then((submission) => ({ success: true, data: { submission } }));
+  }
+
+  @Post(':id/reject')
+  @HttpCode(HttpStatus.OK)
+  @RateLimit({ name: 'submission' })
+  @ApiOperation({ summary: 'Reject a submission (verifier/admin only)' })
+  @ApiParam({ name: 'questId', description: 'Quest ID (UUID)' })
+  @ApiParam({ name: 'id', description: 'Submission ID (UUID)' })
+  @ApiResponse({ status: 200, description: 'Submission rejected' })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid status transition or empty reason',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Not the assigned verifier or admin',
+  })
+  @ApiResponse({ status: 404, description: 'Submission not found' })
+  reject(
+    @Param('id') id: string,
+    @Body() dto: RejectSubmissionDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<{ success: true; data: { submission: Submission } }> {
+    return this.submissionsService
+      .rejectSubmission(id, dto, user.id)
+      .then((submission) => ({ success: true, data: { submission } }));
   }
 }

--- a/BackEnd/src/modules/submissions/submissions.module.ts
+++ b/BackEnd/src/modules/submissions/submissions.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { StellarModule } from '../stellar/stellar.module';
 
 import { SubmissionsController } from './submissions.controller';
 import { SubmissionsService } from './submissions.service';
@@ -12,6 +13,7 @@ import { Submission } from './entities/submission.entity';
     TypeOrmModule.forFeature([Submission]),
     EventEmitterModule,
     NotificationsModule,
+    StellarModule,
   ],
   controllers: [SubmissionsController],
   providers: [SubmissionsService],

--- a/BackEnd/src/modules/submissions/submissions.module.ts
+++ b/BackEnd/src/modules/submissions/submissions.module.ts
@@ -7,10 +7,12 @@ import { StellarModule } from '../stellar/stellar.module';
 import { SubmissionsController } from './submissions.controller';
 import { SubmissionsService } from './submissions.service';
 import { Submission } from './entities/submission.entity';
+import { Quest } from '../quests/entities/quest.entity';
+import { User } from '../users/entities/user.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Submission]),
+    TypeOrmModule.forFeature([Submission, Quest, User]),
     EventEmitterModule,
     NotificationsModule,
     StellarModule,

--- a/BackEnd/src/modules/submissions/submissions.service.spec.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { BadRequestException } from '@nestjs/common';
 import { SubmissionsService } from './submissions.service';
 import { Submission } from './entities/submission.entity';
 import { NotificationsService } from '../notifications/notifications.service';
+import { StellarService } from '../stellar/stellar.service';
 import { SubmissionBuilder } from '../../../test/utils/submission.builder';
 
 const buildUpdateBuilder = (affected = 1) => {
@@ -23,6 +25,7 @@ describe('SubmissionsService (N+1 prevention)', () => {
     sendSubmissionApproved: jest.Mock;
     sendSubmissionRejected: jest.Mock;
   };
+  let stellarService: { approveSubmission: jest.Mock };
 
   const buildSubmission = () =>
     new SubmissionBuilder()
@@ -58,11 +61,20 @@ describe('SubmissionsService (N+1 prevention)', () => {
       sendSubmissionRejected: jest.fn().mockResolvedValue(undefined),
     };
 
+    stellarService = {
+      approveSubmission: jest.fn().mockResolvedValue({
+        transactionHash: 'mock-tx-hash-001',
+        ledger: 42,
+        success: true,
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SubmissionsService,
         { provide: getRepositoryToken(Submission), useValue: submissionsRepo },
         { provide: NotificationsService, useValue: notifications },
+        { provide: StellarService, useValue: stellarService },
         { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
@@ -107,6 +119,81 @@ describe('SubmissionsService (N+1 prevention)', () => {
       expect(result.status).toBe('APPROVED');
       expect(result.approvedBy).toBe('verifier-1');
       expect(result.verifierNotes).toBe('looks good');
+    });
+
+    it('invokes StellarService.approveSubmission with the quest id, submitter, and verifier after the DB CAS update', async () => {
+      const submission = buildSubmission();
+      submissionsRepo.findOne.mockResolvedValue(submission);
+      submissionsRepo.createQueryBuilder =
+        buildUpdateBuilder().createQueryBuilder;
+
+      await service.approveSubmission(
+        'sub-1',
+        { notes: 'looks good' },
+        'verifier-1',
+      );
+
+      expect(stellarService.approveSubmission).toHaveBeenCalledTimes(1);
+      expect(stellarService.approveSubmission).toHaveBeenCalledWith(
+        submission.quest.contractTaskId,
+        submission.user.stellarAddress,
+        'verifier-1',
+      );
+    });
+
+    it('persists the on-chain transaction hash on the submission record', async () => {
+      const submission = buildSubmission();
+      submissionsRepo.findOne.mockResolvedValue(submission);
+      submissionsRepo.createQueryBuilder =
+        buildUpdateBuilder().createQueryBuilder;
+
+      await service.approveSubmission(
+        'sub-1',
+        { notes: 'ok' },
+        'verifier-1',
+      );
+
+      // The tx-hash write happens AFTER the chain call, with the tx hash
+      // returned by StellarService.approveSubmission.
+      expect(submissionsRepo.update).toHaveBeenCalledWith(
+        'sub-1',
+        expect.objectContaining({ transactionHash: 'mock-tx-hash-001' }),
+      );
+    });
+
+    it('rolls DB status back and throws BadRequest when the chain call fails', async () => {
+      const submission = buildSubmission();
+      submissionsRepo.findOne.mockResolvedValue(submission);
+      submissionsRepo.createQueryBuilder =
+        buildUpdateBuilder().createQueryBuilder;
+      stellarService.approveSubmission.mockRejectedValueOnce(
+        new BadRequestException(
+          'Contract rejected approve_submission: QuestNotFound',
+        ),
+      );
+
+      await expect(
+        service.approveSubmission('sub-1', { notes: 'ok' }, 'verifier-1'),
+      ).rejects.toThrow(BadRequestException);
+
+      // Status reverts and approvedBy/approvedAt are cleared. verifierNotes
+      // is intentionally preserved (verifier's review context, not approval
+      // state).
+      expect(submissionsRepo.update).toHaveBeenCalledWith(
+        'sub-1',
+        expect.objectContaining({
+          status: 'PENDING',
+          approvedBy: undefined,
+          approvedAt: undefined,
+        }),
+      );
+      // The submission should NOT have been marked PAID or have a tx hash.
+      expect(submissionsRepo.update).not.toHaveBeenCalledWith(
+        'sub-1',
+        expect.objectContaining({ transactionHash: expect.anything() }),
+      );
+      // Approval notification must NOT have been sent on a failed chain call.
+      expect(notifications.sendSubmissionApproved).not.toHaveBeenCalled();
     });
   });
 

--- a/BackEnd/src/modules/submissions/submissions.service.spec.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { SubmissionsService } from './submissions.service';
 import { Submission } from './entities/submission.entity';
+import { User } from '../users/entities/user.entity';
 import { NotificationsService } from '../notifications/notifications.service';
 import { StellarService } from '../stellar/stellar.service';
 import { SubmissionBuilder } from '../../../test/utils/submission.builder';
+
+// Vitest-style fake verifier for User repo mocks. The StellarService call
+// path requires the verifier to have a Stellar public key; tests use a
+// sentinel address distinct from any submitter address so assertions can
+// tell the two apart.
+const VERIFIER_ID = 'verifier-1';
+const VERIFIER_STELLAR_ADDRESS = 'GVERIFIERSTELLARADDRESS0000000000000000000000';
+
 
 const buildUpdateBuilder = (affected = 1) => {
   const execute = jest.fn().mockResolvedValue({ affected });
@@ -21,6 +30,7 @@ const buildUpdateBuilder = (affected = 1) => {
 describe('SubmissionsService (N+1 prevention)', () => {
   let service: SubmissionsService;
   let submissionsRepo: any;
+  let usersRepo: any;
   let notifications: {
     sendSubmissionApproved: jest.Mock;
     sendSubmissionRejected: jest.Mock;
@@ -45,6 +55,15 @@ describe('SubmissionsService (N+1 prevention)', () => {
       })
       .build();
 
+  /**
+   * Default verifier record returned by the User repo. Each test can
+   * mutate it directly via `verifierRecord.stellarAddress = null` etc.
+   */
+  const verifierRecord: { id: string; stellarAddress: string | null } = {
+    id: VERIFIER_ID,
+    stellarAddress: VERIFIER_STELLAR_ADDRESS,
+  };
+
   beforeEach(async () => {
     submissionsRepo = {
       findOne: jest.fn(),
@@ -54,6 +73,17 @@ describe('SubmissionsService (N+1 prevention)', () => {
       manager: {
         getRepository: jest.fn(),
       },
+    };
+
+    // The service now looks up the verifier via User repo to bind the
+    // verifier's Stellar public key into the on-chain tx.
+    usersRepo = {
+      findOne: jest.fn(({ where }) => {
+        if (where?.id === VERIFIER_ID) {
+          return Promise.resolve(verifierRecord);
+        }
+        return Promise.resolve(null);
+      }),
     };
 
     notifications = {
@@ -73,6 +103,7 @@ describe('SubmissionsService (N+1 prevention)', () => {
       providers: [
         SubmissionsService,
         { provide: getRepositoryToken(Submission), useValue: submissionsRepo },
+        { provide: getRepositoryToken(User), useValue: usersRepo },
         { provide: NotificationsService, useValue: notifications },
         { provide: StellarService, useValue: stellarService },
         { provide: EventEmitter2, useValue: { emit: jest.fn() } },
@@ -84,6 +115,11 @@ describe('SubmissionsService (N+1 prevention)', () => {
     // Bypass the (currently stubbed) verifier-authorization check so the
     // tests can focus on the data-access code path under test.
     jest.spyOn(service as any, 'checkAdminRole').mockResolvedValue(true);
+
+    // Reset verifier fixture between tests so a missing-stellarAddress
+    // test does not bleed into the next one.
+    verifierRecord.id = VERIFIER_ID;
+    verifierRecord.stellarAddress = VERIFIER_STELLAR_ADDRESS;
   });
 
   describe('approveSubmission', () => {
@@ -121,7 +157,7 @@ describe('SubmissionsService (N+1 prevention)', () => {
       expect(result.verifierNotes).toBe('looks good');
     });
 
-    it('invokes StellarService.approveSubmission with the quest id, submitter, and verifier after the DB CAS update', async () => {
+    it('invokes StellarService.approveSubmission with quest id, submitter Stellar address, and verifier Stellar address (NOT the verifier UUID)', async () => {
       const submission = buildSubmission();
       submissionsRepo.findOne.mockResolvedValue(submission);
       submissionsRepo.createQueryBuilder =
@@ -130,15 +166,139 @@ describe('SubmissionsService (N+1 prevention)', () => {
       await service.approveSubmission(
         'sub-1',
         { notes: 'looks good' },
-        'verifier-1',
+        VERIFIER_ID,
       );
 
       expect(stellarService.approveSubmission).toHaveBeenCalledTimes(1);
+      // CRITICAL: The chain expects a Stellar Address (`G...`) for the
+      // verifier argument. Passing a backend user UUID would cause the
+      // Soroban SDK to throw on Address construction. We must bind the
+      // verifier's `stellarAddress` after looking them up, not the raw id.
       expect(stellarService.approveSubmission).toHaveBeenCalledWith(
         submission.quest.contractTaskId,
         submission.user.stellarAddress,
-        'verifier-1',
+        VERIFIER_STELLAR_ADDRESS,
       );
+    });
+
+    it('looks the verifier up AFTER the submission findOne and BEFORE the Stellar service call', async () => {
+      const submission = buildSubmission();
+      submissionsRepo.findOne.mockResolvedValue(submission);
+      submissionsRepo.createQueryBuilder =
+        buildUpdateBuilder().createQueryBuilder;
+
+      await service.approveSubmission(
+        'sub-1',
+        { notes: 'looks good' },
+        VERIFIER_ID,
+      );
+
+      const subCallOrder = (submissionsRepo.findOne as jest.Mock).mock
+        .invocationCallOrder[0];
+      const stellarCallOrder = (stellarService.approveSubmission as jest.Mock)
+        .mock.invocationCallOrder[0];
+      // Exactly one verifier lookup, falling strictly between the
+      // submission fetch and the chain call. Catches regressions where
+      // someone moves the lookup to AFTER the CAS (DB-leak bug) or AFTER
+      // the chain call (defeats the purpose of validation).
+      const verifierLookups = (usersRepo.findOne as jest.Mock).mock.calls
+        .map((call, idx) => ({ call, idx }))
+        .filter(({ call }) => call[0]?.where?.id === VERIFIER_ID);
+      expect(verifierLookups).toHaveLength(1);
+      const verifierCallOrder = (usersRepo.findOne as jest.Mock).mock
+        .invocationCallOrder[verifierLookups[0].idx];
+      expect(subCallOrder).toBeLessThan(verifierCallOrder);
+      expect(verifierCallOrder).toBeLessThan(stellarCallOrder);
+    });
+
+    it('throws BadRequestException when the verifier has no Stellar address linked', async () => {
+      const submission = buildSubmission();
+      submissionsRepo.findOne.mockResolvedValue(submission);
+      submissionsRepo.createQueryBuilder =
+        buildUpdateBuilder().createQueryBuilder;
+      verifierRecord.stellarAddress = null;
+
+      await expect(
+        service.approveSubmission(
+          'sub-1',
+          { notes: 'looks good' },
+          VERIFIER_ID,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      // CRITICAL: The CAS update must NOT have run before the verifier
+      // validation. If it did, the DB would be left in a phantom APPROVED
+      // state with no rollback path. Assert `createQueryBuilder` was never
+      // called so a regression that re-introduces post-CAS validation is
+      // caught immediately.
+      const updateBuilder = submissionsRepo.createQueryBuilder as jest.Mock;
+      expect(updateBuilder).not.toHaveBeenCalled();
+      // No chain call should have been attempted.
+      expect(stellarService.approveSubmission).not.toHaveBeenCalled();
+      // No notifications should have been sent.
+      expect(notifications.sendSubmissionApproved).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when the verifier record does not exist', async () => {
+      const submission = buildSubmission();
+      submissionsRepo.findOne.mockResolvedValue(submission);
+      submissionsRepo.createQueryBuilder =
+        buildUpdateBuilder().createQueryBuilder;
+      // Override the default User-repo lookup to return null for any id.
+      usersRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.approveSubmission(
+          'sub-1',
+          { notes: 'looks good' },
+          'ghost-verifier',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      // Same invariant: DB must not be mutated on validation failure.
+      const updateBuilder = submissionsRepo.createQueryBuilder as jest.Mock;
+      expect(updateBuilder).not.toHaveBeenCalled();
+      expect(stellarService.approveSubmission).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException and does NOT mutate the DB when the submitter has no Stellar address linked', async () => {
+      // Build a submission whose submitter has NO Stellar address. The
+      // submitter-side check must short-circuit BEFORE the verifier lookup
+      // (which would otherwise trigger) and BEFORE the CAS update.
+      const submission = new SubmissionBuilder()
+        .withId('sub-1')
+        .withQuestId('quest-1')
+        .withUserId('user-1')
+        .withStatus('PENDING' as any)
+        .withProof({})
+        .withQuest({
+          id: 'quest-1',
+          title: 'Complete KYC',
+          rewardAmount: 10,
+        })
+        .withUser({
+          id: 'user-1',
+          stellarAddress: null,
+        })
+        .build();
+      submissionsRepo.findOne.mockResolvedValue(submission);
+      submissionsRepo.createQueryBuilder =
+        buildUpdateBuilder().createQueryBuilder;
+
+      await expect(
+        service.approveSubmission(
+          'sub-1',
+          { notes: 'looks good' },
+          VERIFIER_ID,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      // No DB CAS update, no verifier lookup, no chain call, no notification.
+      const updateBuilder = submissionsRepo.createQueryBuilder as jest.Mock;
+      expect(updateBuilder).not.toHaveBeenCalled();
+      expect(usersRepo.findOne).not.toHaveBeenCalled();
+      expect(stellarService.approveSubmission).not.toHaveBeenCalled();
+      expect(notifications.sendSubmissionApproved).not.toHaveBeenCalled();
     });
 
     it('persists the on-chain transaction hash on the submission record', async () => {

--- a/BackEnd/src/modules/submissions/submissions.service.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   NotFoundException,
   BadRequestException,
   ForbiddenException,
@@ -10,7 +11,7 @@ import { Repository } from 'typeorm';
 import { Submission } from './entities/submission.entity';
 import { ApproveSubmissionDto } from './dto/approve-submission.dto';
 import { RejectSubmissionDto } from './dto/reject-submission.dto';
-// import { StellarService } from '../stellar/stellar.service';
+import { StellarService } from '../stellar/stellar.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { Quest } from '../quests/entities/quest.entity';
 import { User } from '../users/entities/user.entity';
@@ -33,10 +34,12 @@ import { SubmissionApprovedEvent } from '../../events/dto/submission-approved.ev
 
 @Injectable()
 export class SubmissionsService {
+  private readonly logger = new Logger(SubmissionsService.name);
+
   constructor(
     @InjectRepository(Submission)
     private submissionsRepository: Repository<Submission>,
-    // private stellarService: StellarService,
+    private stellarService: StellarService,
     private notificationsService: NotificationsService,
     private eventEmitter: EventEmitter2,
     private metricsService: MetricsService,
@@ -100,23 +103,52 @@ export class SubmissionsService {
       );
     }
 
+    // Capture the row's pre-approval status so we can roll back reliably if
+    // the on-chain call fails. Anything in `approveDto` that we already
+    // persisted (notes, etc.) is intentionally left in place — notes are
+    // verifier context, not approval state, and losing them on chain error
+    // would be more harmful than keeping them.
+    const previousStatus = submission.status;
+
+    let onChainTxHash: string | undefined;
     try {
-      // await this.stellarService.approveSubmission(
-      //   quest.contractTaskId,
-      //   user.stellarAddress,
-      //   quest.rewardAmount,
-      // );
+      const onChainResult = await this.stellarService.approveSubmission(
+        quest.contractTaskId,
+        user.stellarAddress,
+        verifierId,
+      );
+      onChainTxHash = onChainResult.transactionHash;
     } catch (error) {
+      // Roll the DB status back so the submission remains actionable.
+      // We deliberately keep verifierNotes (verifier's review context)
+      // and approvedAt/approvedBy cleared, which yields the same
+      // observable state as if the call had never been attempted.
       await this.submissionsRepository.update(submissionId, {
-        status: submission.status,
+        status: previousStatus,
         approvedBy: undefined,
         approvedAt: undefined,
       });
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `On-chain approve_submission failed for submission=${submissionId}: ${errorMessage}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      this.metricsService.incrementCounter(
+        'submission_approval_chain_failure_total',
+      );
+      // Re-throw with the typed exception the caller expects; preserve the
+      // underlying message so operators can diagnose from the API response.
       throw new BadRequestException(
         `Failed to process on-chain approval: ${errorMessage}`,
       );
+    }
+
+    if (onChainTxHash) {
+      await this.submissionsRepository.update(submissionId, {
+        transactionHash: onChainTxHash,
+      });
+      submission.transactionHash = onChainTxHash;
     }
 
     // Apply the persisted changes to the in-memory entity instead of

--- a/BackEnd/src/modules/submissions/submissions.service.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.ts
@@ -5,9 +5,24 @@ import {
   BadRequestException,
   ForbiddenException,
   ConflictException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Brackets, Repository } from 'typeorm';
+
+/**
+ * Sentinel error thrown inside the capacity-gate transaction when the
+ * conditional UPDATE returns zero affected rows. We deliberately throw a
+ * typed sentinel rather than a NestJS HTTP exception so the transaction
+ * rolls back cleanly; the outer catch is responsible for re-fetching the
+ * quest and surfacing the right exception type to the caller.
+ */
+class CapacityGateFailedError extends Error {
+  constructor() {
+    super('Capacity gate did not match any quest row');
+    this.name = 'CapacityGateFailedError';
+  }
+}
 import { Submission, SubmissionStatus } from './entities/submission.entity';
 import { ApproveSubmissionDto } from './dto/approve-submission.dto';
 import { RejectSubmissionDto } from './dto/reject-submission.dto';
@@ -55,10 +70,24 @@ export class SubmissionsService {
   /**
    * Create a new submission for a quest.
    *
-   * Validates the submitter's status BEFORE we write anything:
-   *   1. Authenticated user exists AND has a Stellar wallet linked.
-   *   2. The quest exists, is ACTIVE, and has not reached its max completions.
-   * Then INSERTs the row in PENDING and emits a `submission.created` event.
+   * Three pre-flight gates run BEFORE any DB write, preserving the
+   * validator-before-mutate invariant:
+   *   1. Authenticated user exists.
+   *   2. Authenticated user has a Stellar wallet linked.
+   *
+   * Then, inside a single transaction:
+   *   3. Atomic capacity gate via a conditional UPDATE that atomically
+   *      increments `quest.currentCompletions` only if the quest exists,
+   *      is ACTIVE, AND the row still has remaining capacity.
+   *   4. INSERT the new Submission row in PENDING.
+   *
+   * Both writes share the same transaction so a failure of the INSERT
+   * after the increment rolls back the increment — no leaked capacity.
+   *
+   * If the conditional UPDATE returns zero affected rows, we throw a
+   * typed sentinel inside the transaction (causing rollback) then
+   * re-fetch the quest in the outer catch to disambiguate NotFound vs
+   * not-ACTIVE vs full and surface the right typed exception.
    *
    * @param questId  Quest the submission is for (UUID from path).
    * @param dto      Validated proof payload. userId is NOT in this DTO; the
@@ -70,8 +99,8 @@ export class SubmissionsService {
     dto: CreateSubmissionDto,
     userId: string,
   ): Promise<Submission> {
-    // Submitter gate: must have a Stellar wallet linked so a later on-chain
-    // approve flow has the public key it needs.
+    // 1. Submitter gate — runs OUTSIDE the transaction so we don't
+    //    hold a row lock while checking an unrelated table.
     const user = await this.usersRepository.findOne({
       where: { id: userId },
       withDeleted: false,
@@ -85,36 +114,82 @@ export class SubmissionsService {
       );
     }
 
-    // Quest gate: must exist, be ACTIVE, and have remaining capacity.
-    const quest = await this.questsRepository.findOne({
-      where: { id: questId },
-      withDeleted: false,
-    });
-    if (!quest) {
-      throw new NotFoundException(`Quest with ID ${questId} not found`);
-    }
-    if (quest.status !== 'ACTIVE') {
-      throw new BadRequestException(
-        `Quest is not accepting submissions (current status: ${quest.status})`,
+    // 2. Atomic capacity gate + submission INSERT in one transaction.
+    //    The conditional WHERE narrows the row-level lock to the single
+    //    quest row, so the lock is held for microseconds.
+    let saved: Submission | undefined;
+    try {
+      await this.submissionsRepository.manager.transaction(
+        async (entityManager) => {
+          const capacityResult = await entityManager
+            .createQueryBuilder()
+            .update(Quest)
+            .set({
+              currentCompletions: () => 'currentCompletions + 1',
+              // TypeORM's QueryBuilder.update() does not auto-update
+              // @UpdateDateColumn — we set it explicitly so the quest
+              // row reflects the most recent submission time.
+              updatedAt: () => 'CURRENT_TIMESTAMP',
+            })
+            .where('id = :questId', { questId })
+            .andWhere('status = :active', { active: 'ACTIVE' })
+            .andWhere(
+              new Brackets((qb) => {
+                qb.where('maxCompletions IS NULL').orWhere(
+                  'currentCompletions < maxCompletions',
+                );
+              }),
+            )
+            .execute();
+          if (!capacityResult.affected) {
+            // Sentinel-throw inside the transaction ⇒ rollback. The
+            // outer catch re-reads the quest to disambiguate.
+            throw new CapacityGateFailedError();
+          }
+          const submission = entityManager.create(Submission, {
+            questId,
+            userId,
+            proof: {
+              fileName: dto.fileName,
+              fileContent: dto.fileContent,
+            },
+            status: SubmissionStatus.PENDING,
+            verifierNotes: dto.notes ?? null,
+          });
+          saved = await entityManager.save(submission);
+        },
       );
-    }
-    if (
-      typeof quest.maxCompletions === 'number' &&
-      quest.currentCompletions >= quest.maxCompletions
-    ) {
-      throw new BadRequestException(
-        'Quest has reached its maximum completions',
-      );
+    } catch (err) {
+      if (err instanceof CapacityGateFailedError) {
+        // Re-fetch the quest to disambiguate the failure cause. This is
+        // a cheap read; we accept the extra round-trip in exchange for
+        // a precise exception type to the caller.
+        const current = await this.questsRepository.findOne({
+          where: { id: questId },
+          withDeleted: false,
+        });
+        if (!current) {
+          throw new NotFoundException(`Quest with ID ${questId} not found`);
+        }
+        if (current.status !== 'ACTIVE') {
+          throw new BadRequestException(
+            `Quest is not accepting submissions (current status: ${current.status})`,
+          );
+        }
+        throw new BadRequestException(
+          'Quest has reached its maximum completions',
+        );
+      }
+      throw err;
     }
 
-    const submission = this.submissionsRepository.create({
-      questId,
-      userId,
-      proof: { fileName: dto.fileName, fileContent: dto.fileContent },
-      status: SubmissionStatus.PENDING,
-      verifierNotes: dto.notes ?? null,
-    });
-    const saved = await this.submissionsRepository.save(submission);
+    // Saved cannot be undefined here because the transaction either
+    // committed (saved was set) or threw (caught above).
+    if (!saved) {
+      throw new InternalServerErrorException(
+        'Submission save failed inside transaction',
+      );
+    }
 
     this.eventEmitter.emit(
       'submission.created',

--- a/BackEnd/src/modules/submissions/submissions.service.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.ts
@@ -8,9 +8,10 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Submission } from './entities/submission.entity';
+import { Submission, SubmissionStatus } from './entities/submission.entity';
 import { ApproveSubmissionDto } from './dto/approve-submission.dto';
 import { RejectSubmissionDto } from './dto/reject-submission.dto';
+import { CreateSubmissionDto } from './dto/create-submission.dto';
 import { StellarService } from '../stellar/stellar.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { Quest } from '../quests/entities/quest.entity';
@@ -32,6 +33,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { QuestCompletedEvent } from '../../events/dto/quest-completed.event';
 import { SubmissionRejectedEvent } from '../../events/dto/submission-rejected.event';
 import { SubmissionApprovedEvent } from '../../events/dto/submission-approved.event';
+import { SubmissionCreatedEvent } from '../../events/dto/submission-created.event';
 
 @Injectable()
 export class SubmissionsService {
@@ -42,11 +44,90 @@ export class SubmissionsService {
     private submissionsRepository: Repository<Submission>,
     @InjectRepository(User)
     private usersRepository: Repository<User>,
+    @InjectRepository(Quest)
+    private questsRepository: Repository<Quest>,
     private stellarService: StellarService,
     private notificationsService: NotificationsService,
     private eventEmitter: EventEmitter2,
     private metricsService: MetricsService,
   ) {}
+
+  /**
+   * Create a new submission for a quest.
+   *
+   * Validates the submitter's status BEFORE we write anything:
+   *   1. Authenticated user exists AND has a Stellar wallet linked.
+   *   2. The quest exists, is ACTIVE, and has not reached its max completions.
+   * Then INSERTs the row in PENDING and emits a `submission.created` event.
+   *
+   * @param questId  Quest the submission is for (UUID from path).
+   * @param dto      Validated proof payload. userId is NOT in this DTO; the
+   *                 controller injects it from the authenticated JWT.
+   * @param userId   Authenticated user id from `req.user.id`.
+   */
+  async createSubmission(
+    questId: string,
+    dto: CreateSubmissionDto,
+    userId: string,
+  ): Promise<Submission> {
+    // Submitter gate: must have a Stellar wallet linked so a later on-chain
+    // approve flow has the public key it needs.
+    const user = await this.usersRepository.findOne({
+      where: { id: userId },
+      withDeleted: false,
+    });
+    if (!user) {
+      throw new ForbiddenException('Authenticated user not found');
+    }
+    if (!user.stellarAddress) {
+      throw new BadRequestException(
+        'You must link a Stellar wallet before submitting proof',
+      );
+    }
+
+    // Quest gate: must exist, be ACTIVE, and have remaining capacity.
+    const quest = await this.questsRepository.findOne({
+      where: { id: questId },
+      withDeleted: false,
+    });
+    if (!quest) {
+      throw new NotFoundException(`Quest with ID ${questId} not found`);
+    }
+    if (quest.status !== 'ACTIVE') {
+      throw new BadRequestException(
+        `Quest is not accepting submissions (current status: ${quest.status})`,
+      );
+    }
+    if (
+      typeof quest.maxCompletions === 'number' &&
+      quest.currentCompletions >= quest.maxCompletions
+    ) {
+      throw new BadRequestException(
+        'Quest has reached its maximum completions',
+      );
+    }
+
+    const submission = this.submissionsRepository.create({
+      questId,
+      userId,
+      proof: { fileName: dto.fileName, fileContent: dto.fileContent },
+      status: SubmissionStatus.PENDING,
+      verifierNotes: dto.notes ?? null,
+    });
+    const saved = await this.submissionsRepository.save(submission);
+
+    this.eventEmitter.emit(
+      'submission.created',
+      new SubmissionCreatedEvent(saved.id, questId, userId),
+    );
+    this.metricsService.incrementCounter('submission_create_total');
+
+    this.logger.log(
+      `Submission ${saved.id} created for quest=${questId} by user=${userId}`,
+    );
+
+    return saved;
+  }
 
   /**
    * Approve a submission and trigger on-chain reward distribution

--- a/BackEnd/src/modules/submissions/submissions.service.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.ts
@@ -16,6 +16,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { Quest } from '../quests/entities/quest.entity';
 import { User } from '../users/entities/user.entity';
 import { MetricsService } from '../../common/services/metrics.service';
+import { UserRole } from '../auth/enums/user-role.enum';
 
 interface QuestVerifier {
   id: string;
@@ -39,6 +40,8 @@ export class SubmissionsService {
   constructor(
     @InjectRepository(Submission)
     private submissionsRepository: Repository<Submission>,
+    @InjectRepository(User)
+    private usersRepository: Repository<User>,
     private stellarService: StellarService,
     private notificationsService: NotificationsService,
     private eventEmitter: EventEmitter2,
@@ -72,6 +75,40 @@ export class SubmissionsService {
     await this.validateVerifierAuthorization(quest.id, verifierId);
     this.validateStatusTransition(submission.status, 'APPROVED');
 
+    // Validate the submitter has a Stellar address linked BEFORE we mutate
+    // any DB state. Without this gate, a submission whose submitter has not
+    // linked a wallet would be marked APPROVED locally but never settle on
+    // chain, leaving the row stuck without a tx hash and without a recoverable
+    // path forward.
+    if (!user.stellarAddress) {
+      throw new BadRequestException(
+        'Submitter does not have a Stellar address linked',
+      );
+    }
+
+    // Resolve the verifier to a Stellar public key BEFORE the DB CAS update.
+    // The chain expects a Stellar Address (`G…`) for the verifier argument,
+    // NOT a backend user UUID, and `new Address('uuid')` in the SDK throws on
+    // construction. Performing this lookup pre-CAS ensures a missing verifier
+    // record or an unlinked verifier stellarAddress surfaces as the right
+    // exception type without leaving the submission row in a phantom
+    // APPROVED state (which the post-CAS chain-failure rollback path cannot
+    // reach for these failure modes).
+    const verifier = await this.usersRepository.findOne({
+      where: { id: verifierId },
+      relations: [],
+    });
+    if (!verifier) {
+      throw new ForbiddenException(
+        `Verifier with id ${verifierId} not found`,
+      );
+    }
+    if (!verifier.stellarAddress) {
+      throw new BadRequestException(
+        'Verifier does not have a Stellar address linked; cannot sign on their behalf',
+      );
+    }
+
     const approvedAt = new Date();
 
     // Calculate review duration for SLA tracking
@@ -97,12 +134,6 @@ export class SubmissionsService {
       );
     }
 
-    if (!user.stellarAddress) {
-      throw new BadRequestException(
-        'User does not have a Stellar address linked',
-      );
-    }
-
     // Capture the row's pre-approval status so we can roll back reliably if
     // the on-chain call fails. Anything in `approveDto` that we already
     // persisted (notes, etc.) is intentionally left in place — notes are
@@ -115,7 +146,7 @@ export class SubmissionsService {
       const onChainResult = await this.stellarService.approveSubmission(
         quest.contractTaskId,
         user.stellarAddress,
-        verifierId,
+        verifier.stellarAddress,
       );
       onChainTxHash = onChainResult.transactionHash;
     } catch (error) {

--- a/BackEnd/test/submissions/submissions-flow.e2e-spec.ts
+++ b/BackEnd/test/submissions/submissions-flow.e2e-spec.ts
@@ -66,6 +66,15 @@ describe('Submission Create + Approve flow (e2e)', () => {
   let stellarService: any;
   let notificationsService: any;
   let eventEmitter: { emit: jest.Mock };
+  let mockEntityManager: any;
+
+  /**
+   * The capacity-gate conditional UPDATE returns `affected: 1` on success
+   * and `affected: 0` when the WHERE clause filtered out everything (quest
+   * doesn't exist, isn't ACTIVE, or is at capacity). Tests flip this
+   * between assertions to drive the failure paths.
+   */
+  let nextCapacityAffected = 1;
 
   /**
    * Build a saved-shaped submission that the service fills out on
@@ -111,6 +120,31 @@ describe('Submission Create + Approve flow (e2e)', () => {
     },
   });
 
+  /**
+   * Wire the next-capacity-affected value onto the mockEntityManager.
+   * Reset between tests via `setNextCapacityAffected(1)`.
+   */
+  const setupEntityManagerMock = () => {
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ affected: nextCapacityAffected });
+    const andWhere = jest.fn().mockReturnValue({ execute });
+    const where = jest.fn().mockReturnValue({ andWhere });
+    const set = jest.fn().mockReturnValue({ where });
+    const update = jest.fn().mockReturnValue({ set });
+    mockEntityManager = {
+      createQueryBuilder: jest.fn(() => ({ update })),
+      create: jest.fn((_Entity: any, payload: Submission) => ({
+        ...payload,
+        id: SUBMISSION_ID,
+        status: SubmissionStatus.PENDING,
+      })),
+      save: jest.fn((submission: Submission) =>
+        Promise.resolve({ ...submission, id: submission.id ?? SUBMISSION_ID }),
+      ),
+    };
+  };
+
   beforeAll(async () => {
     submissionsRepo = {
       findOne: jest.fn(),
@@ -118,6 +152,14 @@ describe('Submission Create + Approve flow (e2e)', () => {
       create: jest.fn(),
       save: jest.fn(),
       update: jest.fn().mockResolvedValue(undefined),
+      // manager.transaction powers the new atomic-capacity-gate flow.
+      // We invoke the callback synchronously with a mock EntityManager
+      // so the chain for the conditional UPDATE is observable.
+      manager: {
+        transaction: jest.fn(async (cb: any) => cb(mockEntityManager)),
+      },
+      // createQueryBuilder on the repo is used by approveSubmission's
+      // CAS update; kept separate from the entityManager chain.
       createQueryBuilder: jest.fn(() => ({
         update: jest.fn().mockReturnThis(),
         set: jest.fn().mockReturnThis(),
@@ -153,6 +195,8 @@ describe('Submission Create + Approve flow (e2e)', () => {
     };
 
     eventEmitter = { emit: jest.fn().mockReturnValue(undefined) };
+
+    setupEntityManagerMock();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       controllers: [SubmissionsController],
@@ -205,17 +249,16 @@ describe('Submission Create + Approve flow (e2e)', () => {
       transactionHash: APPROVE_TX_HASH,
       ledger: 42,
     });
+    // Re-init the entityManager mock so each test gets a fresh chain.
+    nextCapacityAffected = 1;
+    setupEntityManagerMock();
   });
 
   // ──────────────────────────────────────────────────────────────────────
   // CREATE — POST /quests/:questId/submissions
   // ──────────────────────────────────────────────────────────────────────
   describe('POST /quests/:questId/submissions', () => {
-    it('201 happy path: persisted PENDING, submission.created emitted', async () => {
-      const saved = buildSavedSubmission();
-      submissionsRepo.create.mockReturnValue(saved);
-      submissionsRepo.save.mockResolvedValue(saved);
-
+    it('201 happy path: capacity gate passes inside transaction, submission.created emitted', async () => {
       const res = await request(app.getHttpServer())
         .post(`/quests/${QUEST_ID}/submissions`)
         .set('X-Test-User-Id', SUBMITTER_ID)
@@ -230,15 +273,24 @@ describe('Submission Create + Approve flow (e2e)', () => {
       expect(res.body.data.submission.status).toBe('PENDING');
       expect(res.body.data.submission.proof.fileName).toBe('kyc.pdf');
 
-      expect(submissionsRepo.create).toHaveBeenCalledTimes(1);
-      const createdArg = submissionsRepo.create.mock.calls[0][0];
+      // The new flow must have invoked the transaction-mocked manager and
+      // the entityManager chain for the capacity gate.
+      expect(submissionsRepo.manager.transaction).toHaveBeenCalledTimes(1);
+      expect(mockEntityManager.createQueryBuilder).toHaveBeenCalled();
+
+      // The submission row was created and saved INSIDE the transaction.
+      expect(mockEntityManager.create).toHaveBeenCalledTimes(1);
+      const createdArg = mockEntityManager.create.mock.calls[0][1];
       expect(createdArg).toMatchObject({
         questId: QUEST_ID,
         userId: SUBMITTER_ID,
         status: 'PENDING',
       });
+      expect(mockEntityManager.save).toHaveBeenCalledTimes(1);
 
-      expect(submissionsRepo.save).toHaveBeenCalledTimes(1);
+      // Submissions repo .create/.save are no longer used by createSubmission.
+      expect(submissionsRepo.create).not.toHaveBeenCalled();
+      expect(submissionsRepo.save).not.toHaveBeenCalled();
 
       const createdEvent = eventEmitter.emit.mock.calls.find(
         (call: any[]) => call[0] === 'submission.created',
@@ -246,7 +298,7 @@ describe('Submission Create + Approve flow (e2e)', () => {
       expect(createdEvent).toBeDefined();
     });
 
-    it('400 when the submitter has no Stellar wallet linked', async () => {
+    it('400 when the submitter has no Stellar wallet linked (no DB write)', async () => {
       submitterRecord.stellarAddress = null;
 
       const res = await request(app.getHttpServer())
@@ -259,10 +311,16 @@ describe('Submission Create + Approve flow (e2e)', () => {
         .expect(HttpStatus.BAD_REQUEST);
 
       expect(res.body.message).toMatch(/stellar wallet/i);
-      expect(submissionsRepo.create).not.toHaveBeenCalled();
+      // The validator-before-mutate invariant: capacity-gate transaction
+      // must NOT have run.
+      expect(submissionsRepo.manager.transaction).not.toHaveBeenCalled();
+      expect(mockEntityManager.create).not.toHaveBeenCalled();
     });
 
-    it('404 when the quest does not exist', async () => {
+    it('404 when the quest does not exist (capacity gate succeeds? No \u2014 rejects at disambiguation)', async () => {
+      // Force capacity gate to fail so the disambiguation re-fetch runs.
+      nextCapacityAffected = 0;
+      setupEntityManagerMock();
       questsRepo.findOne.mockResolvedValueOnce(null);
 
       await request(app.getHttpServer())
@@ -271,38 +329,47 @@ describe('Submission Create + Approve flow (e2e)', () => {
         .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
         .expect(HttpStatus.NOT_FOUND);
 
-      expect(submissionsRepo.create).not.toHaveBeenCalled();
+      // transaction was attempted, sentinel-threw, but the disambiguation
+      // re-read confirmed the quest does not exist.
+      expect(submissionsRepo.manager.transaction).toHaveBeenCalledTimes(1);
+      expect(mockEntityManager.create).not.toHaveBeenCalled();
     });
 
-    it('400 when the quest is not ACTIVE (e.g. PAUSED)', async () => {
+    it('400 when the quest is not ACTIVE (disambiguation surfaces precise error)', async () => {
+      nextCapacityAffected = 0;
+      setupEntityManagerMock();
       questsRepo.findOne.mockResolvedValueOnce({
         ...questRecord,
         status: 'PAUSED',
       });
 
-      await request(app.getHttpServer())
+      const res = await request(app.getHttpServer())
         .post(`/quests/${QUEST_ID}/submissions`)
         .set('X-Test-User-Id', SUBMITTER_ID)
         .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
         .expect(HttpStatus.BAD_REQUEST);
 
-      expect(submissionsRepo.create).not.toHaveBeenCalled();
+      expect(res.body.message).toMatch(/not accepting submissions/i);
+      expect(mockEntityManager.create).not.toHaveBeenCalled();
     });
 
     it('400 when the quest has reached its maximum completions', async () => {
+      nextCapacityAffected = 0;
+      setupEntityManagerMock();
       questsRepo.findOne.mockResolvedValueOnce({
         ...questRecord,
         currentCompletions: 100,
         maxCompletions: 100,
       });
 
-      await request(app.getHttpServer())
+      const res = await request(app.getHttpServer())
         .post(`/quests/${QUEST_ID}/submissions`)
         .set('X-Test-User-Id', SUBMITTER_ID)
         .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
         .expect(HttpStatus.BAD_REQUEST);
 
-      expect(submissionsRepo.create).not.toHaveBeenCalled();
+      expect(res.body.message).toMatch(/maximum completions/i);
+      expect(mockEntityManager.create).not.toHaveBeenCalled();
     });
 
     it('400 when the body is invalid (empty fileName)', async () => {
@@ -312,10 +379,10 @@ describe('Submission Create + Approve flow (e2e)', () => {
         .send({ fileName: '', fileContent: 'b64' })
         .expect(HttpStatus.BAD_REQUEST);
 
-      expect(submissionsRepo.create).not.toHaveBeenCalled();
+      expect(submissionsRepo.manager.transaction).not.toHaveBeenCalled();
     });
 
-    it('401 when the auth override denies the request', async () => {
+    it('403 when the auth override denies the request', async () => {
       await request(app.getHttpServer())
         .post(`/quests/${QUEST_ID}/submissions`)
         .set('X-Test-Auth', 'deny')
@@ -330,10 +397,6 @@ describe('Submission Create + Approve flow (e2e)', () => {
   describe('POST /quests/:questId/submissions/:id/approve (after submit)', () => {
     it('full happy path: submit -> approve -> status APPROVED + txHash persisted', async () => {
       // ── Step 1: SUBMIT ────────────────────────────────────────────────
-      const created = buildSavedSubmission();
-      submissionsRepo.create.mockReturnValue(created);
-      submissionsRepo.save.mockResolvedValue(created);
-
       const submitRes = await request(app.getHttpServer())
         .post(`/quests/${QUEST_ID}/submissions`)
         .set('X-Test-User-Id', SUBMITTER_ID)
@@ -394,11 +457,8 @@ describe('Submission Create + Approve flow (e2e)', () => {
       expect(completedEvent).toBeDefined();
     });
 
-    it('chain call fails: rolls DB status back, returns 500 with chain error, no notification', async () => {
+    it('chain call fails: rolls DB status back, returns 400 with chain error, no notification', async () => {
       // ── Step 1: SUBMIT (success) ──────────────────────────────────────
-      const created = buildSavedSubmission();
-      submissionsRepo.create.mockReturnValue(created);
-      submissionsRepo.save.mockResolvedValue(created);
       await request(app.getHttpServer())
         .post(`/quests/${QUEST_ID}/submissions`)
         .set('X-Test-User-Id', SUBMITTER_ID)
@@ -423,10 +483,12 @@ describe('Submission Create + Approve flow (e2e)', () => {
       expect(res.body.message).toMatch(/On-chain approval failed|QuestNotFound/);
 
       // Rollback path: status reverts to PENDING, approved_* cleared.
-      const rollbackCall = submissionsRepo.update.mock.calls.find((call: any[]) => {
-        const payload = call[1];
-        return payload?.status === 'PENDING' && payload?.approvedBy == null;
-      });
+      const rollbackCall = submissionsRepo.update.mock.calls.find(
+        (call: any[]) => {
+          const payload = call[1];
+          return payload?.status === 'PENDING' && payload?.approvedBy == null;
+        },
+      );
       expect(rollbackCall).toBeDefined();
 
       // No txHash must have been written.
@@ -441,9 +503,6 @@ describe('Submission Create + Approve flow (e2e)', () => {
 
     it('verifier must have a Stellar wallet: 400 BadRequest, no DB write', async () => {
       // Submit (success)
-      const created = buildSavedSubmission();
-      submissionsRepo.create.mockReturnValue(created);
-      submissionsRepo.save.mockResolvedValue(created);
       await request(app.getHttpServer())
         .post(`/quests/${QUEST_ID}/submissions`)
         .set('X-Test-User-Id', SUBMITTER_ID)

--- a/BackEnd/test/submissions/submissions-flow.e2e-spec.ts
+++ b/BackEnd/test/submissions/submissions-flow.e2e-spec.ts
@@ -1,0 +1,498 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  HttpStatus,
+  ValidationPipe,
+  BadRequestException,
+} from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SubmissionsService } from '#src/modules/submissions/submissions.service';
+import { StellarService } from '#src/modules/stellar/stellar.service';
+import { NotificationsService } from '#src/modules/notifications/notifications.service';
+import { SubmissionsController } from '#src/modules/submissions/submissions.controller';
+import { JwtAuthGuard } from '#src/modules/auth/guards/jwt-auth.guard';
+import {
+  Submission,
+  SubmissionStatus,
+} from '#src/modules/submissions/entities/submission.entity';
+import { SubmissionBuilder } from '../../../test/utils/submission.builder';
+import { Quest } from '#src/modules/quests/entities/quest.entity';
+import { User } from '#src/modules/users/entities/user.entity';
+import { Notification } from '#src/modules/notifications/entities/notification.entity';
+import { UserRole } from '#src/modules/auth/enums/user-role.enum';
+
+/**
+ * Default fixture values. Tests can mutate these in `beforeEach` to
+ * drive different scenarios (e.g. null stellarAddress, missing quest).
+ */
+const SUBMITTER_ID = 'submitter-1';
+const SUBMITTER_STELLAR = 'GSUBMITTERSTELLARADDRESS000000000000000000000000';
+const VERIFIER_ID = 'verifier-1';
+const VERIFIER_STELLAR = 'GVERIFIERSTELLARADDRESS0000000000000000000000';
+const QUEST_ID = 'a1b2c3d4-0000-0000-0000-000000000001';
+const SUBMISSION_ID = 'a1b2c3d4-0000-0000-0000-000000000010';
+const APPROVE_TX_HASH = 'mock-approve-tx-001';
+
+const submitterRecord: { id: string; stellarAddress: string | null } = {
+  id: SUBMITTER_ID,
+  stellarAddress: SUBMITTER_STELLAR,
+};
+
+const verifierRecord: { id: string; stellarAddress: string | null } = {
+  id: VERIFIER_ID,
+  stellarAddress: VERIFIER_STELLAR,
+};
+
+const questRecord: Partial<Quest> = {
+  id: QUEST_ID,
+  title: 'Complete KYC',
+  rewardAmount: 10,
+  contractTaskId: 'onchain-task-1',
+  status: 'ACTIVE',
+  currentCompletions: 0,
+  maxCompletions: 100,
+  createdBy: VERIFIER_ID,
+  verifiers: [{ id: VERIFIER_ID }],
+};
+
+describe('Submission Create + Approve flow (e2e)', () => {
+  let app: INestApplication<App>;
+  let submissionsRepo: any;
+  let questsRepo: any;
+  let usersRepo: any;
+  let stellarService: any;
+  let notificationsService: any;
+  let eventEmitter: { emit: jest.Mock };
+
+  /**
+   * Build a saved-shaped submission that the service fills out on
+   * `createSubmission`. Using a builder keeps the entity shape
+   * consistent with the rest of the test suite.
+   */
+  const buildSavedSubmission = (overrides: Partial<Submission> = {}) =>
+    new SubmissionBuilder()
+      .withId(SUBMISSION_ID)
+      .withQuestId(QUEST_ID)
+      .withUserId(SUBMITTER_ID)
+      .withStatus(SubmissionStatus.PENDING)
+      .withProof({
+        fileName: 'kyc.pdf',
+        fileContent: 'base64content',
+      })
+      .withQuest({
+        id: QUEST_ID,
+        title: 'Complete KYC',
+        rewardAmount: 10,
+        contractTaskId: 'onchain-task-1',
+      })
+      .withUser({
+        id: SUBMITTER_ID,
+        stellarAddress: SUBMITTER_STELLAR,
+      })
+      .build(overrides as any);
+
+  /**
+   * Test-time authentication. The override guard reads the user identity
+   * from `X-Test-*` headers so a single test can drive multiple roles
+   * (submitter, verifier, no auth, etc.) without invoking the real JWT
+   * pipeline.
+   */
+  const buildAuthOverride = () => ({
+    canActivate: (ctx: any) => {
+      if (ctx.headers['x-test-auth'] === 'deny') return false;
+      ctx.switchToHttp().getRequest().user =
+        ctx.headers['x-test-user-id'] === VERIFIER_ID
+          ? { id: VERIFIER_ID, role: UserRole.ADMIN }
+          : { id: SUBMITTER_ID, role: UserRole.USER };
+      return true;
+    },
+  });
+
+  beforeAll(async () => {
+    submissionsRepo = {
+      findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+      create: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn(() => ({
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 1 }),
+      })),
+    };
+
+    questsRepo = {
+      findOne: jest.fn().mockResolvedValue(questRecord),
+    };
+
+    usersRepo = {
+      findOne: jest.fn(({ where: { id } }: any) => {
+        if (id === SUBMITTER_ID) return Promise.resolve(submitterRecord);
+        if (id === VERIFIER_ID) return Promise.resolve(verifierRecord);
+        return Promise.resolve(null);
+      }),
+    };
+
+    stellarService = {
+      approveSubmission: jest.fn().mockResolvedValue({
+        success: true,
+        transactionHash: APPROVE_TX_HASH,
+        ledger: 42,
+      }),
+    };
+
+    notificationsService = {
+      sendSubmissionApproved: jest.fn().mockResolvedValue({ id: 'notif-1' }),
+      sendSubmissionRejected: jest.fn().mockResolvedValue({ id: 'notif-2' }),
+    };
+
+    eventEmitter = { emit: jest.fn().mockReturnValue(undefined) };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [SubmissionsController],
+      providers: [
+        SubmissionsService,
+        { provide: StellarService, useValue: stellarService },
+        { provide: NotificationsService, useValue: notificationsService },
+        { provide: EventEmitter2, useValue: eventEmitter },
+        {
+          provide: getRepositoryToken(Submission),
+          useValue: submissionsRepo,
+        },
+        { provide: getRepositoryToken(Quest), useValue: questsRepo },
+        { provide: getRepositoryToken(User), useValue: usersRepo },
+        { provide: getRepositoryToken(Notification), useValue: undefined },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(buildAuthOverride())
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore defaults between tests.
+    submitterRecord.id = SUBMITTER_ID;
+    submitterRecord.stellarAddress = SUBMITTER_STELLAR;
+    verifierRecord.id = VERIFIER_ID;
+    verifierRecord.stellarAddress = VERIFIER_STELLAR;
+    questRecord.id = QUEST_ID;
+    questRecord.status = 'ACTIVE';
+    questRecord.maxCompletions = 100;
+    questRecord.currentCompletions = 0;
+    stellarService.approveSubmission.mockResolvedValue({
+      success: true,
+      transactionHash: APPROVE_TX_HASH,
+      ledger: 42,
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // CREATE — POST /quests/:questId/submissions
+  // ──────────────────────────────────────────────────────────────────────
+  describe('POST /quests/:questId/submissions', () => {
+    it('201 happy path: persisted PENDING, submission.created emitted', async () => {
+      const saved = buildSavedSubmission();
+      submissionsRepo.create.mockReturnValue(saved);
+      submissionsRepo.save.mockResolvedValue(saved);
+
+      const res = await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({
+          fileName: 'kyc.pdf',
+          fileContent: 'base64content',
+          notes: 'see attached',
+        })
+        .expect(HttpStatus.CREATED);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.submission.status).toBe('PENDING');
+      expect(res.body.data.submission.proof.fileName).toBe('kyc.pdf');
+
+      expect(submissionsRepo.create).toHaveBeenCalledTimes(1);
+      const createdArg = submissionsRepo.create.mock.calls[0][0];
+      expect(createdArg).toMatchObject({
+        questId: QUEST_ID,
+        userId: SUBMITTER_ID,
+        status: 'PENDING',
+      });
+
+      expect(submissionsRepo.save).toHaveBeenCalledTimes(1);
+
+      const createdEvent = eventEmitter.emit.mock.calls.find(
+        (call: any[]) => call[0] === 'submission.created',
+      );
+      expect(createdEvent).toBeDefined();
+    });
+
+    it('400 when the submitter has no Stellar wallet linked', async () => {
+      submitterRecord.stellarAddress = null;
+
+      const res = await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({
+          fileName: 'kyc.pdf',
+          fileContent: 'base64content',
+        })
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(res.body.message).toMatch(/stellar wallet/i);
+      expect(submissionsRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('404 when the quest does not exist', async () => {
+      questsRepo.findOne.mockResolvedValueOnce(null);
+
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
+        .expect(HttpStatus.NOT_FOUND);
+
+      expect(submissionsRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('400 when the quest is not ACTIVE (e.g. PAUSED)', async () => {
+      questsRepo.findOne.mockResolvedValueOnce({
+        ...questRecord,
+        status: 'PAUSED',
+      });
+
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(submissionsRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('400 when the quest has reached its maximum completions', async () => {
+      questsRepo.findOne.mockResolvedValueOnce({
+        ...questRecord,
+        currentCompletions: 100,
+        maxCompletions: 100,
+      });
+
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(submissionsRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('400 when the body is invalid (empty fileName)', async () => {
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({ fileName: '', fileContent: 'b64' })
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(submissionsRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('401 when the auth override denies the request', async () => {
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-Auth', 'deny')
+        .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
+        .expect(HttpStatus.FORBIDDEN);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // SUBMIT → APPROVE — full flow via HTTP
+  // ──────────────────────────────────────────────────────────────────────
+  describe('POST /quests/:questId/submissions/:id/approve (after submit)', () => {
+    it('full happy path: submit -> approve -> status APPROVED + txHash persisted', async () => {
+      // ── Step 1: SUBMIT ────────────────────────────────────────────────
+      const created = buildSavedSubmission();
+      submissionsRepo.create.mockReturnValue(created);
+      submissionsRepo.save.mockResolvedValue(created);
+
+      const submitRes = await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
+        .expect(HttpStatus.CREATED);
+
+      expect(submitRes.body.data.submission.status).toBe('PENDING');
+
+      // ── Step 2: APPROVE ───────────────────────────────────────────────
+      // The service will re-fetch the submission by id to attempt approval.
+      const fetched = buildSavedSubmission();
+      submissionsRepo.findOne.mockResolvedValue(fetched);
+
+      const approveRes = await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions/${SUBMISSION_ID}/approve`)
+        .set('X-Test-User-Id', VERIFIER_ID)
+        .send({ notes: 'looks good' })
+        .expect(HttpStatus.OK);
+
+      expect(approveRes.body.success).toBe(true);
+      expect(approveRes.body.data.submission.status).toBe('APPROVED');
+      expect(approveRes.body.data.submission.transactionHash).toBe(
+        APPROVE_TX_HASH,
+      );
+
+      // StellarService must be called with the verifier's Stellar public
+      // key (NOT the backend UUID).
+      expect(stellarService.approveSubmission).toHaveBeenCalledTimes(1);
+      expect(stellarService.approveSubmission).toHaveBeenCalledWith(
+        fetched.quest.contractTaskId,
+        fetched.user.stellarAddress,
+        VERIFIER_STELLAR,
+      );
+
+      // The chain txHash must be persisted on the submission row.
+      expect(submissionsRepo.update).toHaveBeenCalledWith(
+        SUBMISSION_ID,
+        expect.objectContaining({ transactionHash: APPROVE_TX_HASH }),
+      );
+
+      // The approval notification must have dispatched.
+      expect(notificationsService.sendSubmissionApproved).toHaveBeenCalledTimes(
+        1,
+      );
+
+      // Both events must have fired.
+      const createdEvent = eventEmitter.emit.mock.calls.find(
+        (c: any[]) => c[0] === 'submission.created',
+      );
+      const approvedEvent = eventEmitter.emit.mock.calls.find(
+        (c: any[]) => c[0] === 'submission.approved',
+      );
+      const completedEvent = eventEmitter.emit.mock.calls.find(
+        (c: any[]) => c[0] === 'quest.completed',
+      );
+      expect(createdEvent).toBeDefined();
+      expect(approvedEvent).toBeDefined();
+      expect(completedEvent).toBeDefined();
+    });
+
+    it('chain call fails: rolls DB status back, returns 500 with chain error, no notification', async () => {
+      // ── Step 1: SUBMIT (success) ──────────────────────────────────────
+      const created = buildSavedSubmission();
+      submissionsRepo.create.mockReturnValue(created);
+      submissionsRepo.save.mockResolvedValue(created);
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
+        .expect(HttpStatus.CREATED);
+
+      // ── Step 2: APPROVE ───────────────────────────────────────────────
+      const fetched = buildSavedSubmission();
+      submissionsRepo.findOne.mockResolvedValue(fetched);
+      stellarService.approveSubmission.mockRejectedValueOnce(
+        new BadRequestException(
+          'Contract rejected approve_submission: QuestNotFound',
+        ),
+      );
+
+      const res = await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions/${SUBMISSION_ID}/approve`)
+        .set('X-Test-User-Id', VERIFIER_ID)
+        .send({ notes: 'looks good' })
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(res.body.message).toMatch(/On-chain approval failed|QuestNotFound/);
+
+      // Rollback path: status reverts to PENDING, approved_* cleared.
+      const rollbackCall = submissionsRepo.update.mock.calls.find((call: any[]) => {
+        const payload = call[1];
+        return payload?.status === 'PENDING' && payload?.approvedBy == null;
+      });
+      expect(rollbackCall).toBeDefined();
+
+      // No txHash must have been written.
+      const txHashWrite = submissionsRepo.update.mock.calls.find(
+        (call: any[]) => typeof call[1]?.transactionHash === 'string',
+      );
+      expect(txHashWrite).toBeUndefined();
+
+      // No approval notification must have been sent.
+      expect(notificationsService.sendSubmissionApproved).not.toHaveBeenCalled();
+    });
+
+    it('verifier must have a Stellar wallet: 400 BadRequest, no DB write', async () => {
+      // Submit (success)
+      const created = buildSavedSubmission();
+      submissionsRepo.create.mockReturnValue(created);
+      submissionsRepo.save.mockResolvedValue(created);
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .send({ fileName: 'kyc.pdf', fileContent: 'b64' })
+        .expect(HttpStatus.CREATED);
+
+      // Approve — verifier has no wallet
+      const fetched = buildSavedSubmission();
+      submissionsRepo.findOne.mockResolvedValue(fetched);
+      verifierRecord.stellarAddress = null;
+
+      await request(app.getHttpServer())
+        .post(`/quests/${QUEST_ID}/submissions/${SUBMISSION_ID}/approve`)
+        .set('X-Test-User-Id', VERIFIER_ID)
+        .send({ notes: 'looks good' })
+        .expect(HttpStatus.BAD_REQUEST);
+
+      // CAS update must NOT have run (validator-before-CAS invariant).
+      // If a future regression re-orders the verifier check after the CAS,
+      // this assertion catches it.
+      expect(submissionsRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(stellarService.approveSubmission).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // READ — GET /quests/:questId/submissions/:id
+  // ──────────────────────────────────────────────────────────────────────
+  describe('GET /quests/:questId/submissions/:id', () => {
+    it('returns the submission when found', async () => {
+      const found = buildSavedSubmission();
+      submissionsRepo.findOne.mockResolvedValue(found);
+
+      const res = await request(app.getHttpServer())
+        .get(`/quests/${QUEST_ID}/submissions/${SUBMISSION_ID}`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .expect(HttpStatus.OK);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.submission.id).toBe(SUBMISSION_ID);
+    });
+
+    it('404 when not found', async () => {
+      submissionsRepo.findOne.mockResolvedValueOnce(null);
+
+      await request(app.getHttpServer())
+        .get(`/quests/${QUEST_ID}/submissions/does-not-exist`)
+        .set('X-Test-User-Id', SUBMITTER_ID)
+        .expect(HttpStatus.NOT_FOUND);
+    });
+  });
+});

--- a/BackEnd/test/utils/submission.builder.ts
+++ b/BackEnd/test/utils/submission.builder.ts
@@ -26,6 +26,7 @@ export class SubmissionBuilder {
     rejectedAt: null,
     rejectionReason: null,
     verifierNotes: null,
+    transactionHash: null,
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     deletedAt: null,
@@ -35,6 +36,11 @@ export class SubmissionBuilder {
 
   withId(id: string): this {
     this.data.id = id;
+    return this;
+  }
+
+  withTransactionHash(hash: string): this {
+    this.data.transactionHash = hash;
     return this;
   }
 
@@ -68,8 +74,13 @@ export class SubmissionBuilder {
     return this;
   }
 
+  /**
+   * Set the quest; merges with a sensible default `contractTaskId` so
+   * approval-flow tests that bind `quest.contractTaskId` into a Soroban
+   * `approve_submission` call don't fail at the input-validation gate.
+   */
   withQuest(quest: Record<string, unknown>): this {
-    this.data.quest = quest as any;
+    this.data.quest = { contractTaskId: 'default-task-id', ...quest } as any;
     return this;
   }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,590 @@
-# Architecture Diagram
+# Architecture
 
-## System Overview
+> A complete reference of how the **five components** of StellarEarn — the Frontend, the Backend, the Soroban Smart Contract, the Subgraph event indexer, and the Database — fit together, exchange data, and ship to production.
 
-This document provides an architectural overview of the Stellar Earn application, focusing on the core modules and their interactions.
+This document has two halves:
 
-## Module Architecture
+1. **How the system works end-to-end** (top of this file) — the cross-component topology, request lifecycle, event vocabulary, data ownership, deployment topology, and current-state caveats.
+2. **How the backend is wired internally** (lower half, preserved from the original `docs/ARCHITECTURE.md`) — the NestJS module graph, entity ER diagram, reputation system flow, sequence diagrams, module responsibilities table, common layer, event-driven architecture, security layers, scalability, and observability.
+
+Both halves are intended to be readable independently; the cross-component half is the recommended starting point for new contributors.
+
+---
+
+## Table of Contents
+
+- [1. What StellarEarn is](#1-what-stellarearn-is)
+- [2. The 5 components](#2-the-5-components)
+- [3. System topology](#3-system-topology)
+- [4. The quest lifecycle, end-to-end](#4-the-quest-lifecycle-end-to-end)
+- [5. Data ownership — who is the source of truth](#5-data-ownership--who-is-the-source-of-truth)
+- [6. Event taxonomy (Contract → Subgraph → Frontend)](#6-event-taxonomy-contract--subgraph--frontend)
+- [7. Backend module dependency graph](#7-backend-module-dependency-graph)
+- [8. Deployment / runtime topology](#8-deployment--runtime-topology)
+- [9. Current-state caveats](#9-current-state-caveats)
+- [10. Where to read more](#10-where-to-read-more)
+- [11. NestJS module architecture (preserved)](#11-nestjs-module-architecture-preserved)
+- [12. Entity relationships (preserved)](#12-entity-relationships-preserved)
+- [13. Reputation system architecture (preserved)](#13-reputation-system-architecture-preserved)
+- [14. Module data flow (preserved)](#14-module-data-flow-preserved)
+- [15. Module responsibilities (preserved)](#15-module-responsibilities-preserved)
+- [16. Common layer (preserved)](#16-common-layer-preserved)
+- [17. Event-driven architecture (preserved)](#17-event-driven-architecture-preserved)
+- [18. Security architecture (preserved)](#18-security-architecture-preserved)
+- [19. Scalability, monitoring & observability (preserved)](#19-scalability-monitoring--observability-preserved)
+
+---
+
+## 1. What StellarEarn is
+
+**StellarEarn** is a *quest-based earning platform* on Stellar / Soroban. Teams create quests (a task + reward + verifier), contributors submit proofs of completion, verifiers approve them, and rewards are paid out — partly on-chain via a Soroban smart contract, partly through a backend "payouts" ledger that mirrors chain settlement.
+
+Five components collaborate to make this work. Each one has a non-trivial responsibility that would be expensive to host in any of the others:
+
+| # | Component | What it owns | Why it exists |
+|---|---|---|---|
+| 1 | **Frontend** *(Next.js 14 App Router, Vercel)* | UX, wallet integration, optimistic UI, client-side caching | Give a human a usable surface for quests, submissions, rewards |
+| 2 | **Backend** *(NestJS, Docker)* | Business logic, off-chain persistence, authorization, event bus, scheduled jobs | Orchestrate the system; enforce rate limits, moderation, quotas, and RBAC |
+| 3 | **Smart Contract** *(Soroban / Rust, on-chain)* | Authoritative quest state, escrow, payment, reputation, pause, upgrade | Be the trust-minimized source of truth for value movement |
+| 4 | **Subgraph** *(TypeScript indexer, The Graph–style)* | Mirrors on-chain events into a queryable GraphQL API | Light up frontends with fast historical queries without paying RPC costs |
+| 5 | **Database** *(PostgreSQL + Redis, Docker)* | Off-chain entities, event store, audit, caches, jobs, feature flags | Hold the things the contract can't economically store (free-form titles, audit, indexes) |
+
+The next sections show exactly **how these pieces talk to each other**, **what data each owns**, and **what gaps the current code has**.
+
+---
+
+## 2. The 5 components
+
+### 2.1 Frontend — `FrontEnd/my-app`
+
+A Next.js 14 App Router application. State is managed in a local Zustand store; data fetching goes through a centralized Axios client (`lib/api/client.ts`) with JWT bearer auth, request retry, and SWR-style stale-while-revalidate caching. Wallet integration uses `@creit.tech/stellar-wallets-kit` (Freighter / Albedo / xBull).
+
+**Key paths:**
+
+- `app/[locale]/(quests|rewards|dashboard|profile|admin|notifications|settings)/...` — App Router pages, all locale-prefixed
+- `lib/api/{quests,submissions,payouts,user,admin,...}.ts` — typed API clients + zod validation
+- `lib/hooks/{useQuests,useClaim,useSubmission,useAuth,...}` — custom hooks that compose API + store
+- `context/{WalletContext,AuthContext}.tsx` — global wallet / auth state
+- `lib/store/slices/{questSlice,submissionSlice,...}.ts` — Zustand slices
+- `components/quest/{QuestCard,QuestList,QuestWizard,...}` — feature components + a 5-step create wizard
+- `components/rewards/{RewardsList,ClaimRewards,PendingRewards,ClaimButton,...}` — payout UX
+
+**Speaks to:**
+
+- Backend — REST over HTTPS, JWT bearer
+- Contract directly — when the user signs a `claim` XDR on the client side (the `useClaim` flow bypasses the backend's mocked payout path)
+
+### 2.2 Backend — `BackEnd`
+
+A NestJS application with ⇆O 20+ feature modules. Persistence via TypeORM + PostgreSQL, secondary cache in Redis, scheduled jobs in BullMQ. Cross-cutting concerns (rate limit, throttler, feature flags, traces, metrics, sanitization) all live in `BackEnd/src/common/`.
+
+**Key paths:**
+
+- `src/modules/{quests,submissions,payouts,users,auth,webhooks,notifications,moderation,analytics,jobs,feature-flags,stellar,websocket,...}` — feature modules
+- `src/events/{listeners,handlers,event-store,interfaces,dto}` — domain event bus + event-store persistence + DLQ
+- `src/config/{stellar,cache,moderation,throttler,feature-flags,security,...}` — typed env-var config
+- `src/database/{data-source.ts,migrations/}` — TypeORM DataSource + migrations
+- `src/common/{guards,interceptors,pipes,decorators,filters,services,tracing}` — cross-cutting
+
+**Speaks to:**
+
+- Frontend — REST/HTTPS (controllers in each module)
+- Contract — `@stellar/stellar-sdk` (`StellarService.signAndSubmit`) and `SorobanQuestReaderService` (read-only contract simulation) and Horizon REST for ledger confirmations
+- Database — TypeORM repos + raw SQL migrations
+- Subgraph — **does not call directly**; they share authoritative state via the chain + their separate indexes
+- Redis — caching layer + BullMQ job store
+- Sentry — error tracking
+- OTel — distributed tracing
+
+### 2.3 Smart Contract — `Contract_archived/earn-quest/` *(canonical Rust)*
+
+A `#![no_std]` Soroban contract compiled to Wasm. It implements the quest lifecycle: register → submit proof → approve/reject (with escrow payout + reputation grant on approval) → expire/cancel/pause/upgrade. Lifecycle emissions drive the subgraph.
+
+**Key paths:**
+
+- `src/lib.rs` — public contract methods
+- `src/quest.rs`, `src/submission.rs`, `src/payout.rs` — lifecycle
+- `src/escrow.rs`, `src/reputation.rs` — value movement + XP
+- `src/pausable.rs`, `src/admin.rs`, `src/upgrade.rs` — operations/safety
+- `src/storage.rs`, `src/types.rs`, `src/errors.rs` — contract types
+- `tests/` — 12 Rust test suites (unit + edge + property + integration + arithmetic safety)
+
+**Speaks to:**
+
+- Anyone with a Stellar secret + the contract ID — it's public on chain
+- Backend — receives `submit_proof`, `approve_submission`, `register_quest`, `get_quest` (via simulations); emits events any indexer can subscribe to
+
+### 2.4 Subgraph — `subgraph/`
+
+A TypeScript listener + GraphQL server that mirrors on-chain events into a database and exposes them as GraphQL. Event topics are declared in `subgraph/src/config/topics.ts`; transformations live in `mappings/index.ts`.
+
+**Key paths:**
+
+- `src/storage/listener.ts` — Soroban event poller
+- `src/mappings/index.ts` — event → entity
+- `src/storage/database.ts` — entity persistence
+- `src/api/server.ts`, `src/api/resolvers.ts` — GraphQL endpoint
+- `schema/schema.graphql` — entity schema
+- `Dockerfile`, `docker-compose.yml` — containerization, exposes :4000
+
+**Speaks to:**
+
+- Contract (RPC events)
+- Its own Postgres (entity mirror)
+- Frontend (GraphQL queries) — and indirectly the backend, which can query the same API
+
+### 2.5 Database — Postgres + Redis
+
+Two persistent services in `BackEnd/docker-compose.yml`. Postgres is the *primary* source of truth for off-chain state; Redis is the *secondary* cache and BullMQ job store.
+
+**Postgres holds:**
+
+- **Core entities** — `quest`, `submission`, `payout`, `user`, `notification`
+- **Operations** — `event_store`, `poison_message`, `moderation_item`, `moderation_appeal`, `feature_flag`, `feature_flag_audit`
+- **Multi-sig + escrow** — `multisig_wallet`, `multisig_signer`, `multisig_signature`, `multisig_transaction`, `quota_usage`, `quota_config`
+- **Auth** — `refresh_token`, `two_factor`
+- **Migration bookkeeping** — `typeorm_migrations`
+
+**Redis holds:**
+
+- Active ephemeral sessions (JWT refresh tokens)
+- Cache-aside results for quests / payouts / users (`cache.config.ts` defines TTLs)
+- BullMQ job queue state for the `jobs/` processors
+
+---
+
+## 3. System topology
+
+The 5 components, the edges between them, and an at-a-glance view of which edge does what.
+
+```mermaid
+flowchart LR
+  classDef fe fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+  classDef be fill:#fff3e0,stroke:#f57c00,color:#e65100
+  classDef ct fill:#fce4ec,stroke:#c2185b,color:#880e4f
+  classDef sg fill:#e8f5e9,stroke:#388e3c,color:#1b5e20
+  classDef db fill:#f3e5f5,stroke:#7b1fa2,color:#4a148c
+
+  subgraph FE["Frontend — Next.js 14 · Vercel"]
+    A[App Router pages]:::fe
+    H[Custom hooks +<br/>Zustand store]:::fe
+    C[Axios client +<br/>SWR cacheManager]:::fe
+    W[WalletContext<br/>sign XDR]:::fe
+  end
+
+  subgraph BE["Backend — NestJS · Docker"]
+    R[REST controllers]:::be
+    M[Service modules]:::be
+    E[Event bus +<br/>EventStore + DLQ]:::be
+    CR[Cron jobs]:::be
+    S[Stellar SDK<br/>StellarService]:::be
+  end
+
+  subgraph CHAIN["Contract — Soroban / WASM"]
+    C1[earn-quest.wasm]:::ct
+    C2[Contract storage<br/>storage.rs]:::ct
+  end
+
+  subgraph SG["Subgraph — TypeScript"]
+    L[storage/listener.ts]:::sg
+    R2[api/resolvers.ts]:::sg
+    SPG[(Subgraph Postgres)]:::sg
+  end
+
+  subgraph DB["Database — Postgres + Redis"]
+    PG[(TypeORM entities<br/>quest · submission · payout ·<br/>user · notification · event_store)]:::db
+    RDS[(Redis cache +<br/>BullMQ jobs)]:::db
+  end
+
+  C -- "HTTPS REST<br/>JWT Bearer" --> R
+  W -- "signed tx<br/>(direct claim)" --> C1
+
+  R --> M
+  M <--> PG
+  M --> E
+  M --> S
+  M -. "cron" .-> CR
+  M --> RDS
+
+  S -- "submitTransaction /<br/>simulateTransaction" --> C1
+  C1 --- C2
+  C1 -- "publish events" --> L
+  L --> SPG
+  SPG --> R2
+  R2 -- "GraphQL query" --> C
+
+  E --> PG
+  C -. "WS live push" .-> A
+```
+
+**Edge legend:**
+
+- Solid black arrow: synchronous request-driven flow
+- Solid gray dashed: scheduled / cron
+- Dotted: event / pub-sub channel
+- Double line (`A --- B`): tight-coupling (contract ↔ storage; ↔-↔: bidirectional)
+
+---
+
+## 4. The quest lifecycle, end-to-end
+
+A single quest's life, traced from "admin creates it" through "user claims reward." This sequence shows the **intended** path — see [§9 Current-state caveats](#9-current-state-caveats) for the gaps currently observed in the source.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Admin
+    actor Contributor
+    actor Verifier
+    participant FE as Frontend<br/>(Next.js)
+    participant BE as Backend<br/>(NestJS)
+    participant DB as Postgres
+    participant Mod as Moderation +<br/>Quota
+    participant Stellar as StellarService<br/>(stellar-sdk)
+    participant Chain as Contract<br/>(earn-quest)
+    participant Sub as Subgraph<br/>listener
+    participant SG as Subgraph<br/>GraphQL
+    participant Wallet as Wallet<br/>(Freighter)
+
+    Note over Admin,Wallet: 1) Admin creates a quest (off-chain ledger first)
+    Admin->>FE: POST /quests (admin wizard)
+    FE->>BE: POST /api/v1/quests (JWT, ADMIN)
+    BE->>Mod: enforceQuestCreationQuota<br/>scanText(title+body)
+    Mod-->>BE: ok
+    BE->>DB: INSERT quest row<br/>(status DRAFT/ACTIVE)
+    BE-->>FE: 201 quest response
+
+    Note over Contributor,Wallet: 2) Contributor submits proof
+    Contributor->>FE: open quest, submit proof
+    FE->>BE: POST /api/v1/quests/:id/submissions
+    BE->>Chain: submit_proof(quest_id, submitter, proof_hash)
+    Chain->>Chain: validate_quest_active<br/>(deadline, status, capacity)
+    Chain->>Chain: storage::set_submission(Pending)
+    Chain-->>BE: ok
+    Chain-->>Sub: emit (proof_sub, quest_id, submitter)
+    Sub->>SG: upsert Submission entity
+    BE-->>FE: 201 submission
+
+    Note over Verifier,Chain: 3) Verifier approves → on-chain payment
+    Verifier->>FE: click Approve
+    FE->>BE: POST /quests/:q/submissions/:s/approve
+    BE->>DB: CAS UPDATE submission<br/>WHERE status=PENDING → APPROVED
+    BE-->>FE: ok + emit 'submission.approved'
+    Note right of BE: Today the contract<br/>call is commented out;<br/>intended path shown
+    BE->>Stellar: tx = invoke(approve_submission(...))
+    Stellar->>Chain: simulate + submit<br/>(signAndSubmit)
+    Chain->>Chain: submission.status=Approved<br/>quest.total_claims += 1<br/>payout::process_payout<br/>reputation::award_xp(+100)<br/>status=Paid
+    Chain-->>Sub: emit (approved, sub_paid)
+    Sub->>SG: update entities
+    Chain-->>Stellar: tx hash + ledger
+    Stellar-->>BE: confirmed
+
+    Note over Contributor,Wallet: 4) Contributor sees reward, claims (signed)
+    FE->>SG: GET /graphql (rewards, payouts)
+    SG-->>FE: paginated rewards + XP + level
+    Contributor->>FE: ClaimRewards → useClaim
+    FE->>Wallet: signTransaction(XDR)
+    Wallet-->>FE: signed XDR
+    FE->>Chain: submit signed tx
+    Chain-->>FE: success
+    Chain-->>Sub: ledger event
+```
+
+The same flow, contracted into a one-liner:
+
+1. Admin creates → Postgres quest row + backend event
+2. Submitter submits → on-chain submission + `(proof_sub)` event
+3. Verifier approves → Postgres CAS update + (currently disabled) on-chain `approve_submission` ⇒ emits `(approved, sub_paid)` and pays escrow
+4. Submitter claims ⇒ on-client signing ⇒ on-chain transfer ⇒ ledger event ⇒ subgraph updates ⇒ UI repaints
+
+---
+
+## 5. Data ownership — who is the source of truth
+
+There are **two sources of truth** and a *mirror*. Getting this wrong is the most common bug class in this system — never assume the chain and the Postgres row are in sync without checking.
+
+```mermaid
+flowchart LR
+  classDef db fill:#f3e5f5,stroke:#7b1fa2
+  classDef ct fill:#fce4ec,stroke:#c2185b
+  classDef sg fill:#e8f5e9,stroke:#388e3c
+
+  subgraph DB["Postgres (Backend owns)"]
+    Qe[(quest)]:::db
+    Se[(submission)]:::db
+    Pe[(payout)]:::db
+    Ue[(user + reputation)]:::db
+    Ne[(notification)]:::db
+    Ese[(event_store +<br/>poison_message)]:::db
+  end
+
+  subgraph CHAIN["Contract instance storage"]
+    Qs[(Quest struct)]:::ct
+    Ss[(Submission struct)]:::ct
+    Us[(UserStats struct)]:::ct
+    Ecs[(Escrow balance)]:::ct
+    Cfgs[(ContractConfig /<br/>PauseState)]:::ct
+  end
+
+  subgraph SG["Subgraph Postgres (mirror)"]
+    Qm[(Quest mirror)]:::sg
+    Sm[(Submission mirror)]:::sg
+    Um[(UserStats mirror)]:::sg
+    Tm[(Event timeline)]:::sg
+  end
+
+  Qe -. "intended: register_quest()<br/>(NOT called today)" .-> Qs
+  Qs -. "SorobanQuestReaderService<br/>get_quest()" .- Qe
+
+  Se -. "submit_proof /<br/>approve_submission" .-> Ss
+  Ss -. "intended: backend reads" .- Se
+
+  Ue -. "reputation::award_xp()<br/>on chain + backend XP listener" .-> Us
+  Us -. "get_user_stats()" .- Ue
+
+  Pe -. "settlement-finality mirror<br/>of chain tx" .-> Ecs
+
+  Qs ==> Qm
+  Ss ==> Sm
+  Us ==> Um
+  Qm --> Tm
+  Sm --> Tm
+  Um --> Tm
+```
+
+**Practical rule of thumb for contributors:**
+
+- **Quest metadata** *(title, description, reward amounts in human display)* → Postgres. Chain holds only the canonical IDs and amount (`i128`).
+- **Submission/proof status, lifecycle decisions** → chain is authoritative. Backend mirrors via backend event handlers.
+- **Reputation / XP / badges** → dual-source: chain holds `UserStats` (canonical), backend mirrors via `UserExperienceListener`. Frontend primarily reads backend; on-chain reads are admin / audit only.
+- **Payout completion / settlement** → *officially* chain-tx-bound, *in practice* tracked in `payout` Postgres row (the `PayoutsService.executeStellarPayment` is currently mocked in dev and throws in prod — see §9).
+
+---
+
+## 6. Event taxonomy (Contract → Subgraph → Frontend)
+
+These are the topics the contract emits. Topics are wired in `subgraph/src/config/topics.ts`. New emitters/handlers should land both in `contract/.../lib.rs` and `subgraph/src/config/topics.ts` together.
+
+```mermaid
+flowchart LR
+  classDef ct fill:#fce4ec,stroke:#c2185b
+  classDef fe fill:#e3f2fd,stroke:#1976d2
+  classDef sg fill:#e8f5e9,stroke:#388e3c
+
+  subgraph E1[Contract emits]
+    Q1[("quest_reg")]:::ct
+    Q2[("status_upd")]:::ct
+    Q3[("proof_sub")]:::ct
+    Q4[("approved")]:::ct
+    Q5[("rejected")]:::ct
+    Q6[("sub_paid")]:::ct
+    Q7[("quest_full")]:::ct
+    Q8[("quest_exp / auto_exp")]:::ct
+    Q9[("quest_can")]:::ct
+    Q10[("emergency_wdr")]:::ct
+  end
+
+  Listener["subgraph/src/storage/listener.ts<br/>(polls RPC events)"]:::sg
+  TopicMap["subgraph/src/config/topics.ts<br/>(topic → handler)"]:::sg
+  Mappers["subgraph/src/mappings/index.ts<br/>(ScVal → entity)"]:::sg
+  GQL["schema.graphql<br/>(Quest · Submission · UserStats · Payout · ...)"]:::sg
+  Resolver["api/resolvers.ts"]:::sg
+
+  Q1 & Q2 & Q3 & Q4 & Q5 & Q6 & Q7 & Q8 & Q9 & Q10 --> Listener
+  Listener --> TopicMap
+  TopicMap --> Mappers
+  Mappers --> GQL
+  GQL --> Resolver
+
+  Resolver -- "GraphQL queries:<br/>getQuest(id)<br/>getSubmissions(questId)<br/>getUserStats(address)<br/>getRecentPayouts(addr)" --> FE_pages[Frontend pages:<br/>/rewards · /quests/[id] · /profile/[addr]]:::fe
+```
+
+The backend listens to a separate in-process event bus (`@nestjs/event-emitter`) described in §17 below; the contract bus and the backend bus are independent and emit different events. They share only the **domain vocabulary** (e.g. both have a "submission approved" event, but with different shapes).
+
+---
+
+## 7. Backend module dependency graph
+
+```mermaid
+flowchart TB
+  classDef ext fill:#eef,stroke:#88a
+  classDef cross fill:#fee,stroke:#a88
+  classDef data fill:#efe,stroke:#8a8
+
+  Controllers["REST Controllers<br/>quests · submissions · payouts · auth ·<br/>users · notifications · webhooks · admin · moderation"]
+
+  Guards["Guards<br/>JwtAuthGuard · RolesGuard ·<br/>CSRFGuard · IPWhitelistGuard ·<br/>FeatureFlagGuard · ThrottlerGuard"]
+  class Guards cross
+
+  Q["QuestsService"]
+  S["SubmissionsService"]
+  P["PayoutsService"]
+  U["UsersService"]
+  N["NotificationsService"]
+  M["ModerationService"]
+  Q0["QuotaService"]
+  C["CacheService"]
+  ST["StellarService"]
+  SR["SorobanQuestReaderService"]
+  ESC["EventsService<br/>(EventStore + DLQ)"]
+  WS["WebSocket gateway"]
+  CRON["@nestjs/schedule<br/>(cron jobs)"]
+  JOBS["Jobs / BullMQ processors<br/>(payout, quest-state,<br/>analytics, exports)"]
+  class Q,S,P,U,N,M,Q0,C,ST,SR,ESC,WS,CRON,JOBS cross
+
+  Models[("PostgreSQL<br/>via TypeORM<br/>+ cursor pagination DTOs<br/>+ per-user indexes")]
+  class Models data
+
+  Cache[("Redis cache<br/>(cache-aside / write-through)")]
+  StellarInfra["stellar-sdk<br/>Horizon + Soroban RPC"]
+  class StellarInfra,Cache ext
+
+  Controllers --> Guards
+  Controllers --> Q
+  Controllers --> S
+  Controllers --> P
+  Controllers --> U
+  Controllers --> N
+  Controllers --> M
+  Controllers --> WS
+
+  Q --> M
+  Q --> Q0
+  Q --> ESC
+  Q --> C
+
+  S --> U
+  S --> N
+  S --> ESC
+  S --> ST
+
+  P --> Q0
+  P --> JOBS
+  P --> CRON
+  P --> ESC
+  P --> M
+
+  U --> ST
+  ST --> StellarInfra
+  SR --> StellarInfra
+  C --> Cache
+
+  Q --> Models
+  S --> Models
+  P --> Models
+  U --> Models
+  ESC --> Models
+  N --> Models
+  M --> Models
+```
+
+---
+
+## 8. Deployment / runtime topology
+
+Where each of the 5 components physically runs, the env vars they care about, and the contracts between them.
+
+```mermaid
+flowchart TB
+  classDef fe fill:#e3f2fd,stroke:#1976d2
+  classDef be fill:#fff3e0,stroke:#f57c00
+  classDef ct fill:#fce4ec,stroke:#c2185b
+  classDef sg fill:#e8f5e9,stroke:#388e3c
+  classDef db fill:#f3e5f5,stroke:#7b1fa2
+
+  Browser["Browser / Next.js client"]:::fe
+  Vercel["Vercel (CDN + SSR)"]:::fe
+  Docker["Docker / Compose"]:::be
+  NestJS["NestJS API :3000 (per .env.example)"]:::be
+  DockerDB[("PostgreSQL<br/>(docker-compose)")]:::db
+  Cache[("Redis cache")]:::db
+  SubNode["Subgraph Node<br/>(Docker)"]:::sg
+  SubDB[("Subgraph Postgres")]:::db
+  Soroban["Soroban RPC<br/>+ Stellar Horizon"]:::ct
+  SorobanContract["earn-quest.wasm<br/>(on-chain storage)"]:::ct
+
+  Browser -- "static + client JS" --> Vercel
+  Vercel -- "/api/v1/* HTTPS" --> NestJS
+  NestJS --> DockerDB
+  NestJS --> Cache
+  NestJS -- "submitTransaction /<br/>simulateTransaction" --> Soroban
+  NestJS -- "GET /ledgers (finality)" --> Soroban
+
+  SubNode -- "ledger events" --> Soroban
+  SubNode --> SubDB
+  SubDB -- "GraphQL" --> Vercel
+
+  Soroban --> SorobanContract
+```
+
+| Component | Runtime | Where it's hosted | Critical env vars |
+|---|---|---|---|
+| Frontend | Next.js 14 (Vercel default) | Vercel (or any Node SSR Node 22+) | `NEXT_PUBLIC_STELLAR_NETWORK`, `NEXT_PUBLIC_SOROBAN_RPC_URL`, `NEXT_PUBLIC_CONTRACT_ID`, `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_SENTRY_DSN` |
+| Backend | NestJS (Node ≥ 22) | Docker container (`BackEnd/Dockerfile`-equivalent) | `DATABASE_URL`, `JWT_SECRET`, `STELLAR_NETWORK`, `SOROBAN_RPC_URL`, `CONTRACT_ID`, `STELLAR_FINALITY_CONFIRMATIONS`, `CORS_ORIGINS`, per-endpoint `RATE_LIMIT_*_LIMIT/_TTL` |
+| Contract | Soroban Wasm | Stellar (testnet/mainnet chosen at deploy) | `SOROBAN_SECRET_KEY`, `SOROBAN_RPC_URL`, `ADMIN_ADDRESS` |
+| Subgraph | Node 20-slim | Docker (port 4000) | `CONTRACT_ID`, `RPC_URL`, `API_PORT` |
+| Database | Postgres 15 + Redis 7 | `BackEnd/docker-compose.yml` | `DATABASE_URL`, `DB_POOL_MAX`, `DB_POOL_MIN` |
+
+For full env-var parity validation run:
+
+```bash
+bash scripts/validate-env-parity.sh BackEnd/.env.example BackEnd/.env
+bash scripts/validate-env-parity.sh FrontEnd/my-app/.env.example FrontEnd/my-app/.env.local
+```
+
+---
+
+## 9. Current-state caveats
+
+> These are gaps observed in the source as of this writing. They are noted so contributors don't model the system on intended behavior — the source has TODO spots that need filling before stated flows work end-to-end.
+
+1. **Submissions controller is half-wired.**
+   `BackEnd/src/modules/submissions/submissions.controller.ts` only exposes `GET /quests/:questId/submissions`. The `SubmissionsService` has `approveSubmission` / `rejectSubmission` logic and a commented-out `submitProof` pattern, but **there is no `POST /quests/:id/submissions` endpoint**, so submissions created via the chain today don't have a matching backend creation route.
+
+2. **The on-chain approval call is commented out.**
+   `SubmissionsService.approveSubmission` has the line `await this.stellarService.approveSubmission(...)` *commented out*. The intent is to call `StellarService.signAndSubmit` with the contract's `approve_submission` arguments. Until uncommented, the backend's approval flow stops at the Postgres CAS update + event emit.
+
+3. **`executeStellarPayment` is mocked in dev / unimplemented in prod.**
+   `PayoutsService.executeStellarPayment` returns `mock_tx_${now}_${id}` plus a random ledger in dev/test, and throws `Stellar payment not implemented for production` outside of those. The settlement-finality state machine, cron jobs, retry logic, and admin retry endpoint are all correctly modeled — only the actual Stellar SDK call needs wiring.
+
+4. **The contract is in `Contract_archived/earn-quest/`.**
+   The README and CODEOWNERS suggest a separate `Contract/` directory; the canonical Rust source currently lives under `Contract_archived/`. If you change the contract, update the canonical path.
+
+5. **`scripts/migrate-contract-storage.mjs` does schema-version migration offline.**
+   The tool reads `state.json` (exported from `soroban contract dump`), splits legacy `metadata → metadata_core + metadata_extended`, splits `escrow → escrow_balances + escrow_meta`, normalizes `platform_stats → platform_counters`, and bumps `schema_version: 1 → 2`. **No on-chain auto-migration** is wired — running it without first exporting state will silently drop fields.
+
+6. **Frontend `NEXT_PUBLIC_API_BASE_URL` mismatches backend `.env`.**
+   `FrontEnd/my-app/.env.example` shows `NEXT_PUBLIC_API_BASE_URL=http://localhost:3000`. `BackEnd/.env.example` sets `PORT=3000`. Some READMEs and Swagger screenshots reference `:3001`. Pick one and update both files — the `deploy-contract.sh` and `deploy.sh` orchestrators default to `$BACKEND_PORT=3001` for health checks, so be deliberate about the port choice.
+
+7. **`Makefile` references `infra/docker-compose.yml` which doesn't exist.**
+   `make db-up` and `make docker-up` point at `infra/docker-compose.yml`. The actual file is `BackEnd/docker-compose.yml`. Either add a symlink or update the Makefile.
+
+8. **`pnpm-workspace.yaml` is incomplete.**
+   The file currently only lists `allowBuilds:` overrides with placeholder strings like `set this to true or false`. It doesn't list any workspace packages and probably needs review.
+
+9. **The `feature-flags` system is referenced by all guards but environments aren't seeded.**
+   `FF_ENABLE_*` defaults to `false` for all flags in `.env.example`. Until a real rollout strategy lands, every feature flag-gated route will block new behavior.
+
+---
+
+## 10. Where to read more
+
+- `BackEnd/ReadMe Backend.md` — NestJS quickstart, module list, env vars, deployment
+- `FrontEnd/ReadMe Frontend.md` — Next.js quickstart, hooks, components, deployment
+- `FrontEnd/my-app/README.md` — Next.js dev details, env validation, test commands
+- `Contract_archived/earn-quest/README.md` — contract API, build/test/deploy
+- `BackEnd/src/database/migrations/` — TypeORM migration history + `data-source.ts`
+- `script-inventory.md` — repo-maintained scripts (deploy, audit, monitor)
+- `docs/backend/data-flow.md` — backend-only data flow with module relationships
+- `docs/FRONTEND_ARCHITECTURE.md` — frontend-only architecture
+- `docs/Frontend disaster recovery runbook.md` — incident response
+- `scripts/deploy/deploy.sh` — full-stack deploy orchestrator with `--contract-only` / `--backend-only` etc.
+
+---
+
+## 11. NestJS module architecture (preserved)
+
+The original module-level architecture diagram and tables from the pre-existing `docs/ARCHITECTURE.md` are preserved below for reference. They focus on internal NestJS module wiring rather than the cross-component view above.
 
 ```mermaid
 graph TB
@@ -87,7 +667,9 @@ graph TB
     style STL fill:#ffe1e1
 ```
 
-## Entity Relationships
+---
+
+## 12. Entity relationships (preserved)
 
 ```mermaid
 erDiagram
@@ -198,7 +780,9 @@ erDiagram
     }
 ```
 
-## Reputation System Architecture
+---
+
+## 13. Reputation system architecture (preserved)
 
 ```mermaid
 graph LR
@@ -234,7 +818,9 @@ graph LR
     style D fill:#e1f5ff
 ```
 
-## Module Data Flow
+---
+
+## 14. Module data flow (preserved)
 
 ### Submission Flow
 
@@ -289,7 +875,9 @@ sequenceDiagram
     UserService->>Analytics: Track Reputation Change
 ```
 
-## Module Responsibilities
+---
+
+## 15. Module responsibilities (preserved)
 
 ### Core Modules
 
@@ -315,7 +903,9 @@ sequenceDiagram
 | **WebSocket** | Real-time communication                    |
 | **Webhooks**  | External webhook delivery                  |
 
-## Common Layer
+---
+
+## 16. Common layer (preserved)
 
 The common layer provides shared functionality across modules:
 
@@ -355,7 +945,9 @@ graph TB
     style ENUM fill:#f0f0f0
 ```
 
-## Event-Driven Architecture
+---
+
+## 17. Event-driven architecture (preserved)
 
 The system uses an event-driven architecture for decoupled communication:
 
@@ -399,18 +991,9 @@ graph LR
 - **SubmissionStatusChangedEvent**: Fired when submission status changes
 - **PayoutProcessedEvent**: Fired when a payout is completed
 
-## Technology Stack
+---
 
-- **Backend Framework**: NestJS
-- **ORM**: TypeORM
-- **Database**: PostgreSQL
-- **Blockchain**: Stellar
-- **Cache**: Redis
-- **Queue**: Bull (Redis-based)
-- **Validation**: class-validator
-- **Documentation**: Swagger/OpenAPI
-
-## Security Architecture
+## 18. Security architecture (preserved)
 
 ```mermaid
 graph TB
@@ -443,7 +1026,11 @@ graph TB
     style MID fill:#f5e1ff
 ```
 
-## Scalability Considerations
+---
+
+## 19. Scalability, monitoring & observability (preserved)
+
+### Scalability Considerations
 
 1. **Horizontal Scaling**: Stateless services allow horizontal scaling
 2. **Caching**: Redis cache reduces database load
@@ -452,9 +1039,13 @@ graph TB
 5. **Database Indexing**: Strategic indexes on frequently queried fields
 6. **Pagination**: All list endpoints support pagination
 
-## Monitoring & Observability
+### Monitoring & Observability
 
 - **Logging**: Structured logging with Winston
 - **Tracing**: Distributed tracing support
 - **Health Checks**: Health module for monitoring
 - **Analytics**: Analytics module for business metrics
+
+---
+
+*Maintained by the StellarEarn architecture group. Updates should keep §1–§10 (cross-component) and §11–§19 (NestJS-internal) in sync when modules or contracts change. Diagrams render natively in GitHub, GitLab, Notion, VS Code Markdown preview, and mermaid.live.*


### PR DESCRIPTION
## Summary

Adds the missing `POST /api/v1/quests/:questId/submissions` endpoint plus three sibling routes so the full submit → approve → payout flow is reachable via HTTP and exercisable by a new e2e.

### Service layer — `SubmissionsService.createSubmission`

New `createSubmission(questId, dto, userId)` method that gates a new submission behind three pre-flight validators that run **before** the DB INSERT:

1. Submitter must have a Stellar wallet linked (`BadRequestException` if missing).
2. Quest must exist AND be `ACTIVE` (`NotFoundException` / `BadRequestException`).
3. Quest must not have reached its `maxCompletions` (`BadRequestException` if full).

Then INSERTs a PENDING row and emits `submission.created` for downstream listeners.

Mirrors the validator-before-mutate invariant established in the prior PR (`feat/submissions-stellar-approve`). Constructor injects `@InjectRepository(Quest)` so the new method can look up the target quest.

### Controller layer

| Route | Status | Notes |
|---|---|---|
| `POST /quests/:questId/submissions` | **NEW — the missing endpoint** | `userId` sourced from JWT via `@CurrentUser()`, deliberately NOT in the DTO so callers can't submit on behalf of another user. |
| `GET /quests/:questId/submissions` | FIXED | Replaced placeholder `{ data: [] }` with a real `findByQuest(questId)` call. |
| `GET /quests/:questId/submissions/:id` | NEW | Submission lookup by id. |
| `POST /quests/:questId/submissions/:id/approve` | NEW | Verifier/admin approves — triggers on-chain `approve_submission`. |
| `POST /quests/:questId/submissions/:id/reject` | NEW | Verifier/admin rejects. |

All routes are `@UseGuards(JwtAuthGuard)` (class-level) and rate-limited via `@RateLimit({ name: 'submission' })`.

### DTO + Module + Event

- New `CreateSubmissionDto` — proof-only (`fileName`, `fileContent`, optional `notes`). No `userId`.
- New `SubmissionCreatedEvent` — typed `@IsUUID` for `submissionId`, `questId`, `userId`.
- `SubmissionsModule` now declares `TypeOrmModule.forFeature([Submission, Quest, User])`.

### E2E — `test/submissions/submissions-flow.e2e-spec.ts`

11 scenarios:
- **Submit (1 happy + 6 negative)**: happy emits `submission.created`. Negatives cover missing wallet, missing quest, paused quest, max-completions hit, body validation, auth denied.
- **Submit → Approve (3)**: happy — `txHash` persisted, `StellarService` called with verifier's Stellar public key **NOT** the user UUID (regression guard); chain-failure — status rolls back to PENDING, no `txHash`, no notification; verifier-missing-wallet — `400` + `createQueryBuilder` NOT called.
- **GET by id (2)**: 200 / 404.

### Diff

- This commit (`f638dcc`): 6 files, +791/-7.
- Whole `feat/submissions-create-endpoint` branch is 4 commits ahead of `upstream/main` (`EarnQuestOne/stellar_Earn@59f50f9`).

## Sandbox caveat — jest validation

This PR was prepared in an environment missing `ts-jest`, so I could not run `npx jest` here. Please run:

```
cd BackEnd && npx jest --testPathPatterns=src/modules/submissions,test/submissions --no-coverage
```

…locally before approving. The existing `submissions.service.spec.ts` should still pass unchanged (this PR only ADDS new behavior; the previously-fixed invariants are preserved).

## Followups surfaced by retroactive review

NOT blockers, but worth addressing in follow-up:

1. **Capacity race**: `createSubmission` reads `currentCompletions` vs `maxCompletions` then inserts. Under high concurrency two requests can both pass the gate before either inserts. Fix: wrap atomic SQL update of `currentCompletions` (with `WHERE status='ACTIVE' AND currentCompletions < maxCompletions`) and the submission INSERT in a `manager.transaction`.
2. **Orphaned DTO**: `BackEnd/src/modules/submissions/dto/submit-proof.dto.ts` is still on disk — confirmed unreferenced. Hygiene cleanup.
3. **Wire payout creation**: `PayoutsService.createPayout` is not yet called after `approve_submission` succeeds, so the payout-history API cannot surface reward settlements yet.

## Verification checklist for reviewer

- [ ] `cd BackEnd && npx jest --testPathPatterns=src/modules/submissions,test/submissions --no-coverage` — all green
- [ ] Swagger UI surfaces `POST /quests/{questId}/submissions` with `@ApiBearerAuth`
- [ ] Request without a linked Stellar wallet → 400 matching `/stellar wallet/i`
- [ ] Request for a non-`ACTIVE` quest → 400
- [ ] Approval persists a tx hash on the row and emits `submission.approved` + `quest.completed`
