### PR TITLE
Add quest category index for on-chain filtering

### DIFF
--- a/contracts/earn-quest/docs/STORAGE_LAYOUT.md
+++ b/contracts/earn-quest/docs/STORAGE_LAYOUT.md
@@ -94,8 +94,10 @@ When adding a new `DataKey` variant, follow these rules:
 | 41 | `BadgeTypeIds` | — | `Vec<Symbol>` | Instance | Index of all badge type IDs |
 | 42 | `MinCreatorLevel` | — | `u32` | Instance | Minimum user level to create quests (0 = disabled) |
 | 43 | `CreatorWhitelist` | `address: Address` | `bool` | Instance | Bypass min creator level for this address |
+| 44 | `ClawbackPending` | `quest_id: Symbol`, `recipient: Address` | `ClawbackPending` | Instance | Pending 2-of-2 SuperAdmin clawback approval |
+| 45 | `QuestCategory` | `category: u32` | `Vec<Symbol>` | Instance | Index of quest IDs by numeric category |
 
-**Total variants:** 44
+**Total variants:** 46
 
 ---
 
@@ -103,7 +105,7 @@ When adding a new `DataKey` variant, follow these rules:
 
 | Type | Fields (summary) |
 |------|------------------|
-| `Quest` | `id`, `creator`, `reward_asset`, `reward_amount`, `verifier`, `deadline`, `status`, `total_claims` |
+| `Quest` | `id`, `creator`, `reward_asset`, `reward_amount`, `verifier`, `deadline`, `category`, `status`, `total_claims` |
 | `QuestMetadataCore` | `title`, `description`, `category` |
 | `QuestMetadataExtended` | `requirements`, `tags` |
 | `Submission` | `quest_id`, `submitter`, `proof_hash`, `status`, `claimed_amount`, `timestamp` |
@@ -117,6 +119,7 @@ When adding a new `DataKey` variant, follow these rules:
 | `Commitment` | `hash`, `timestamp` |
 | `VerifierStake` | `token`, `amount`, `is_active` |
 | `BadgeType` | `id`, `name`, `description`, `xp_reward` |
+| `ClawbackPending` | `initiator`, `asset`, `amount` |
 | `PlatformStats` | `total_quests_created`, `total_submissions`, `total_rewards_distributed`, `total_active_users`, `total_rewards_claimed` (assembled on read from split keys) |
 
 Full struct definitions: `src/types.rs`.
@@ -129,7 +132,7 @@ The `#[cfg(test)]` module `layout_tests` in `storage.rs` enforces:
 
 - Every `DataKey` variant has a **unique Rust discriminant** (no accidental duplicate enum arms).
 - The canonical `VARIANT_NAMES` list has **no duplicate strings**.
-- The live variant count matches the documented count (44).
+- The live variant count matches the documented count (46).
 
 Run:
 

--- a/contracts/earn-quest/src/escrow.rs
+++ b/contracts/earn-quest/src/escrow.rs
@@ -271,6 +271,7 @@ pub fn cancel_quest(env: &Env, quest_id: &Symbol, caller: &Address) -> Result<i1
     let mut quest = quest;
     quest.status = QuestStatus::Cancelled;
     storage::set_quest(env, quest_id, &quest);
+    storage::remove_quest_from_category_index(env, quest.category, quest_id);
 
     // Refund escrow if it exists (uses a single read inside refund_remaining)
     let refunded = if storage::has_escrow(env, quest_id) {
@@ -318,6 +319,7 @@ pub fn expire_quest(env: &Env, quest_id: &Symbol, caller: &Address) -> Result<i1
     let mut quest = quest;
     quest.status = QuestStatus::Expired;
     storage::set_quest(env, quest_id, &quest);
+    storage::remove_quest_from_category_index(env, quest.category, quest_id);
 
     let refunded = if storage::has_escrow(env, quest_id) {
         refund_remaining(env, quest_id)?

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -273,6 +273,39 @@ impl EarnQuestContract {
         )
     }
 
+    /// Registers a new quest with an explicit numeric category for filtering.
+    ///
+    /// Existing `register_quest` calls keep using category `0`; this entry point
+    /// lets new quests opt into category-specific discovery without breaking the
+    /// current client API.
+    pub fn register_quest_with_category(
+        env: Env,
+        id: Symbol,
+        creator: Address,
+        reward_asset: Address,
+        reward_amount: i128,
+        verifier: Address,
+        deadline: u64,
+        category: u32,
+    ) -> Result<(), Error> {
+        security::require_not_paused(&env)?;
+        creator.require_auth();
+        validation::validate_symbol_length(&id)?;
+        validation::validate_addresses_distinct(&creator, &verifier)?;
+        validation::validate_reward_amount(reward_amount)?;
+        validation::validate_deadline(&env, deadline)?;
+        quest::register_quest_with_category(
+            &env,
+            &id,
+            &creator,
+            &reward_asset,
+            reward_amount,
+            &verifier,
+            deadline,
+            category,
+        )
+    }
+
     /// Registers a new quest with detailed metadata.
     ///
     /// # Arguments
@@ -1065,6 +1098,16 @@ impl EarnQuestContract {
         limit: u32,
     ) -> Vec<Quest> {
         quest::get_quests_by_creator(&env, &creator, offset, limit)
+    }
+
+    /// Returns quests for a numeric category.
+    pub fn get_quests_by_category(
+        env: Env,
+        category: u32,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Quest> {
+        quest::get_quests_by_category(&env, category, offset, limit)
     }
 
     /// Returns a list of currently active quests.

--- a/contracts/earn-quest/src/quest.rs
+++ b/contracts/earn-quest/src/quest.rs
@@ -50,6 +50,29 @@ pub fn register_quest(
     verifier: &Address,
     deadline: u64,
 ) -> Result<(), Error> {
+    register_quest_with_category(
+        env,
+        id,
+        creator,
+        reward_asset,
+        reward_amount,
+        verifier,
+        deadline,
+        0,
+    )
+}
+
+/// Registers a new quest with an explicit numeric category for indexed queries.
+pub fn register_quest_with_category(
+    env: &Env,
+    id: &Symbol,
+    creator: &Address,
+    reward_asset: &Address,
+    reward_amount: i128,
+    verifier: &Address,
+    deadline: u64,
+    category: u32,
+) -> Result<(), Error> {
     validation::validate_symbol_length(id)?;
 
     if storage::has_quest(env, id) {
@@ -76,12 +99,14 @@ pub fn register_quest(
         reward_amount,
         verifier: verifier.clone(),
         deadline,
+        category,
         status: QuestStatus::Active,
         total_claims: 0,
     };
 
     storage::set_quest(env, id, &quest);
     storage::add_quest_id(env, id)?;
+    storage::add_quest_to_category_index(env, category, id)?;
     storage::inc_platform_quests_created(env);
     storage::add_platform_rewards_distributed(env, reward_amount as u128);
 
@@ -371,6 +396,33 @@ pub fn get_quests_by_creator(env: &Env, creator: &Address, offset: u32, limit: u
         if let Some(id) = ids.get(i) {
             if let Ok(quest) = storage::get_quest(env, &id) {
                 if &quest.creator == creator {
+                    if matched >= offset {
+                        results.push_back(quest);
+                        count += 1;
+                    }
+                    matched += 1;
+                }
+            }
+        }
+    }
+
+    results
+}
+
+/// Retrieves quests by numeric category using the category index.
+pub fn get_quests_by_category(env: &Env, category: u32, offset: u32, limit: u32) -> Vec<Quest> {
+    let ids = storage::get_quest_ids_by_category(env, category);
+    let mut results = Vec::new(env);
+    let mut matched = 0u32;
+    let mut count = 0u32;
+
+    for i in 0..ids.len() {
+        if i >= validation::MAX_SCAN_ITERATIONS || count >= limit {
+            break;
+        }
+        if let Some(id) = ids.get(i) {
+            if let Ok(quest) = storage::get_quest(env, &id) {
+                if quest.category == category {
                     if matched >= offset {
                         results.push_back(quest);
                         count += 1;

--- a/contracts/earn-quest/src/storage.rs
+++ b/contracts/earn-quest/src/storage.rs
@@ -101,6 +101,8 @@ pub enum DataKey {
     CreatorWhitelist(Address),
     /// Pending clawback record keyed by (quest_id, recipient)
     ClawbackPending(Symbol, Address),
+    /// Category index keyed by a numeric category, storing quest ids in insertion order
+    QuestCategory(u32),
 }
 
 //================================================================================
@@ -1113,6 +1115,49 @@ pub fn add_quest_id(env: &Env, id: &Symbol) -> Result<(), Error> {
     Ok(())
 }
 
+pub fn get_quest_ids_by_category(env: &Env, category: u32) -> Vec<Symbol> {
+    env.storage()
+        .instance()
+        .get(&DataKey::QuestCategory(category))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn add_quest_to_category_index(
+    env: &Env,
+    category: u32,
+    id: &Symbol,
+) -> Result<(), Error> {
+    let mut ids = get_quest_ids_by_category(env, category);
+    validation::validate_max_quests(ids.len())?;
+
+    for i in 0..ids.len() {
+        if ids.get(i).unwrap() == *id {
+            return Ok(());
+        }
+    }
+
+    ids.push_back(id.clone());
+    env.storage()
+        .instance()
+        .set(&DataKey::QuestCategory(category), &ids);
+    Ok(())
+}
+
+pub fn remove_quest_from_category_index(env: &Env, category: u32, id: &Symbol) {
+    let mut ids = get_quest_ids_by_category(env, category);
+    let mut i = 0u32;
+    while i < ids.len() {
+        if ids.get(i).unwrap() == *id {
+            ids.remove(i);
+            env.storage()
+                .instance()
+                .set(&DataKey::QuestCategory(category), &ids);
+            return;
+        }
+        i += 1;
+    }
+}
+
 //================================================================================
 // Platform & Creator Stats Storage
 // PlatformStats is split into individual counters for atomic single-field updates.
@@ -1470,9 +1515,11 @@ mod layout_tests {
         "BadgeTypeIds",
         "MinCreatorLevel",
         "CreatorWhitelist",
+        "ClawbackPending",
+        "QuestCategory",
     ];
 
-    const EXPECTED_VARIANT_COUNT: usize = 44;
+    const EXPECTED_VARIANT_COUNT: usize = 46;
 
     /// One sample instance per `DataKey` variant for layout audits.
     fn all_data_keys(env: &Env) -> Vec<DataKey> {
@@ -1525,6 +1572,8 @@ mod layout_tests {
         keys.push_back(DataKey::BadgeTypeIds);
         keys.push_back(DataKey::MinCreatorLevel);
         keys.push_back(DataKey::CreatorWhitelist(addr.clone()));
+        keys.push_back(DataKey::ClawbackPending(quest_id.clone(), addr.clone()));
+        keys.push_back(DataKey::QuestCategory(1));
         keys
     }
 

--- a/contracts/earn-quest/src/types.rs
+++ b/contracts/earn-quest/src/types.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{contracttype, Address, BytesN, String, Symbol, Vec, U256};
 // ─────────────────────────────────────────────────────────────────────────────
 // Quest
 // ─────────────────────────────────────────────────────────────────────────────
-// Quest is already lean (8 fields, no Vec).  No split needed.
+// Quest is already lean (9 fields, no Vec).  No split needed.
 
 /// Represents a quest on the StellarEarn platform.
 #[contracttype]
@@ -21,6 +21,8 @@ pub struct Quest {
     pub verifier: Address,
     /// Unix timestamp when the quest expires.
     pub deadline: u64,
+    /// Numeric category used for on-chain filtering.
+    pub category: u32,
     /// Current status of the quest.
     pub status: QuestStatus,
     /// Total number of successful claims.

--- a/contracts/earn-quest/tests/test_queries.rs
+++ b/contracts/earn-quest/tests/test_queries.rs
@@ -23,6 +23,27 @@ fn register(
     client.register_quest(&id, creator, &token, &reward, &verifier, &99999u64);
 }
 
+fn register_with_category(
+    client: &EarnQuestContractClient,
+    env: &Env,
+    id: soroban_sdk::Symbol,
+    creator: &Address,
+    reward: i128,
+    category: u32,
+) {
+    let token = Address::generate(env);
+    let verifier = Address::generate(env);
+    client.register_quest_with_category(
+        &id,
+        creator,
+        &token,
+        &reward,
+        &verifier,
+        &99999u64,
+        &category,
+    );
+}
+
 //================================================================================
 // get_active_quests
 //================================================================================
@@ -130,6 +151,105 @@ fn test_get_quests_by_creator_unknown_creator_returns_empty() {
     register(&client, &env, symbol_short!("Q1"), &creator, 100);
 
     let results = client.get_quests_by_creator(&unknown, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+//================================================================================
+// get_quests_by_category
+//================================================================================
+
+#[test]
+fn test_get_quests_by_category_returns_only_category_quests() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register_with_category(&client, &env, symbol_short!("D1"), &creator, 100, 1);
+    register_with_category(&client, &env, symbol_short!("N1"), &creator, 200, 2);
+    register_with_category(&client, &env, symbol_short!("D2"), &creator, 300, 1);
+
+    let defi = client.get_quests_by_category(&1, &0, &10);
+    assert_eq!(defi.len(), 2);
+    assert_eq!(defi.get(0).unwrap().id, symbol_short!("D1"));
+    assert_eq!(defi.get(1).unwrap().id, symbol_short!("D2"));
+
+    let nft = client.get_quests_by_category(&2, &0, &10);
+    assert_eq!(nft.len(), 1);
+    assert_eq!(nft.get(0).unwrap().id, symbol_short!("N1"));
+}
+
+#[test]
+fn test_get_quests_by_category_paginates_index_results() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register_with_category(&client, &env, symbol_short!("C1"), &creator, 100, 7);
+    register_with_category(&client, &env, symbol_short!("C2"), &creator, 200, 7);
+    register_with_category(&client, &env, symbol_short!("C3"), &creator, 300, 7);
+
+    let page = client.get_quests_by_category(&7, &1, &1);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page.get(0).unwrap().id, symbol_short!("C2"));
+}
+
+#[test]
+fn test_get_quests_by_category_unknown_category_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+
+    register_with_category(&client, &env, symbol_short!("C1"), &creator, 100, 3);
+
+    let results = client.get_quests_by_category(&9, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_category_index_removes_cancelled_quests() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+    let quest_id = symbol_short!("CX");
+
+    register_with_category(&client, &env, quest_id.clone(), &creator, 100, 4);
+    client.cancel_quest(&quest_id, &creator);
+
+    let results = client.get_quests_by_category(&4, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_category_index_removes_expired_quests() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    let client = setup(&env);
+    let creator = Address::generate(&env);
+    let token = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let quest_id = symbol_short!("EX");
+    let deadline = 1_000u64 + 86_400;
+
+    client.register_quest_with_category(
+        &quest_id,
+        &creator,
+        &token,
+        &100i128,
+        &verifier,
+        &deadline,
+        &5u32,
+    );
+
+    env.ledger()
+        .with_mut(|l| l.timestamp = deadline + 20);
+    client.expire_quest(&quest_id, &creator);
+
+    let results = client.get_quests_by_category(&5, &0, &10);
     assert_eq!(results.len(), 0);
 }
 


### PR DESCRIPTION
## Summary
- add a numeric category field to Quest and expose get_quests_by_category
- maintain a category-to-quest index when quests are created, cancelled, or expired
- cover filtering, pagination, empty results, and terminal-state index removal in tests
- update the storage layout audit/docs for the new key

Fixes #1714

## Tests
- Not run.