### PR TITLE
[BE-009] Add job timeout and retry policy for long-running test jobs

### DIFF
--- a/BackEnd/package.json
+++ b/BackEnd/package.json
@@ -162,7 +162,11 @@
     "moduleNameMapper": {
       "^#src/(.*)$": "<rootDir>/src/$1",
       "^src/(.*)$": "<rootDir>/src/$1"
-    }
+    },
+    "testTimeout": 30000,
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup-unit-afterenv.ts"
+    ]
   },
   "overrides": {
     "cookie": "0.7.2"

--- a/BackEnd/test/setup-unit-afterenv.ts
+++ b/BackEnd/test/setup-unit-afterenv.ts
@@ -1,0 +1,5 @@
+import { jest } from '@jest/globals';
+
+jest.setTimeout(30000);
+
+jest.retryTimes(1, { logErrorsBeforeRetry: true });


### PR DESCRIPTION
## Summary

- Added `testTimeout: 30000` (30 seconds) to the Jest configuration in `package.json`
- Created `test/setup-unit-afterenv.ts` with `jest.retryTimes(1)` to automatically retry flaky unit tests once
- Used `setupFilesAfterEnv` to apply the timeout and retry policy globally to all unit tests

## Test plan
- [ ] Run `npm test` to verify unit tests respect the 30-second timeout
- [ ] Verify flaky tests auto-retry once before failing

closes #920