### PR TITLE
[BE-006] Add backend build workflow with dist artifact upload

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -40,6 +40,13 @@ jobs:
       - name: TypeScript compilation
         run: npm run build
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-dist
+          path: BackEnd/dist/
+          retention-days: 7
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
Added an Upload build artifact step to the build-and-lint job in backend-ci.yml. The compiled dist/ directory is uploaded as a GitHub Actions artifact named backend-dist with a 7-day retention period, making the build output available for downstream jobs and deployment pipelines.

closes #917