### PR TITLE
[BE-011] Fix stale test-helpers import path in auth.service.spec.ts

### DIFF
--- a/BackEnd/src/modules/auth/auth.service.spec.ts
+++ b/BackEnd/src/modules/auth/auth.service.spec.ts
@@ -12,7 +12,7 @@ import {
   createMockJwtService,
   createMockConfigService,
   generateRandomStellarAddress,
-} from '../../test/utils/test-helpers';
+} from 'test/utils/test-helpers';
 
 // Mock the signature utilities
 jest.mock('./utils/signature', () => ({


### PR DESCRIPTION
The import from ../../test/utils/test-helpers in auth.service.spec.ts resolved to src/test/utils/test-helpers which does not exist. Updated to use the test/ alias (test/utils/test-helpers) that is defined via moduleNameMapper in the Jest configuration.

closes #922