### PR TITLE
[BE-016] Add Express Request augmentation for correlationId via declaration merging

### DIFF
--- a/BackEnd/src/types/express.d.ts
+++ b/BackEnd/src/types/express.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  namespace Express {
+    interface Request {
+      correlationId?: string;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
Created src/types/express.d.ts which uses TypeScript global namespace merging to extend the Express Request interface with an optional correlationId property. This provides proper typing for middleware that attaches a correlation or trace ID to incoming requests without requiring any runtime code.

closes #927