### PR TITLE
feat: add default-safe values for optional observability settings

### DIFF
--- a/BackEnd/src/config/observability.config.ts
+++ b/BackEnd/src/config/observability.config.ts
@@ -1,0 +1,12 @@
+/**
+ * Default-safe observability configuration.
+ * All optional settings fall back to safe defaults if not set.
+ */
+export const observabilityConfig = {
+  logLevel: process.env.LOG_LEVEL ?? 'info',
+  metricsEnabled: process.env.METRICS_ENABLED === 'true',
+  tracingEnabled: process.env.TRACING_ENABLED === 'true',
+  sentryDsn: process.env.SENTRY_DSN ?? '',
+  prometheusPort: parseInt(process.env.PROMETHEUS_PORT ?? '9090', 10),
+  healthCheckPath: process.env.HEALTH_CHECK_PATH ?? '/health',
+} as const;


### PR DESCRIPTION
## Summary
Adds observability.config.ts with default-safe values for LOG_LEVEL, METRICS_ENABLED, TRACING_ENABLED, SENTRY_DSN, PROMETHEUS_PORT, and HEALTH_CHECK_PATH.

closes #936
closes #939
closes #941
closes #1715