### PR TITLE
FE-006: Add concurrency cancellation for redundant PR runs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,5 +1,9 @@
 name: Backend CI
 # This workflow is triggered on push and pull request events for the main and master branches, specifically when changes are made to the BackEnd directory or the workflow file itself. It consists of two jobs: "build-and-lint" and "backend-ci-gate".
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [main, master]

--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -1,5 +1,7 @@
 name: Backend Integration Tests
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [main, master]

--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -1,5 +1,7 @@
 name: Contract CI
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [main, master]

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,5 +1,7 @@
 name: Frontend CI
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Closes #795

## Description

This PR implements concurrency cancellation for GitHub Actions workflows to prevent redundant PR runs from consuming resources unnecessarily.

Previously, multiple workflow runs could continue executing when new commits were pushed to the same pull request. This change ensures that older in-progress runs are automatically cancelled when a newer run is triggered.

## Changes Made

- Added GitHub Actions concurrency configuration to PR workflows.
- Enabled automatic cancellation of outdated workflow runs using `cancel-in-progress: true`.
- Applied concurrency grouping based on workflow name and Git reference.

## Implementation

Added:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

