### PR TITLE
[FE-017] Repair broken dynamic imports in lib/dynamic-imports.ts

### DIFF
--- a/FrontEnd/my-app/app/[locale]/admin/quests/[id]/edit/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/admin/quests/[id]/edit/page.tsx
@@ -103,11 +103,17 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
     <>
       <div className="space-y-6">
         <nav className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <Link href="/admin" className="hover:text-zinc-700 dark:hover:text-zinc-300">
+          <Link
+            href="/admin"
+            className="hover:text-zinc-700 dark:hover:text-zinc-300"
+          >
             Admin
           </Link>
           <span>/</span>
-          <Link href="/admin/quests" className="hover:text-zinc-700 dark:hover:text-zinc-300">
+          <Link
+            href="/admin/quests"
+            className="hover:text-zinc-700 dark:hover:text-zinc-300"
+          >
             Quests
           </Link>
           <span>/</span>

--- a/FrontEnd/my-app/app/[locale]/admin/quests/[id]/edit/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/admin/quests/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import Link from 'next/link';
 import { use } from 'react';
 import {
@@ -10,7 +11,6 @@ import { AdminLayout, QuestEditor, Notifications } from '@/components/admin';
 import { NotificationContext } from '@/lib/hooks/useAdmin';
 import { updateQuestStatus } from '@/lib/api/admin';
 import type { QuestFormData, QuestStatus } from '@/lib/types/admin';
-import Link from 'next/link';
 
 interface EditQuestContentProps {
   questId: string;
@@ -43,20 +43,22 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
   const handleStatusChange = async (status: QuestStatus) => {
     try {
       await updateQuestStatus(questId, status);
+
       notificationState.addNotification({
         type: 'success',
         title: 'Status Updated',
         message: `Quest status changed to ${status}.`,
       });
-      // Reload the quest data
+
       window.location.reload();
       return { success: true };
-    } catch (err) {
+    } catch {
       notificationState.addNotification({
         type: 'error',
         title: 'Update Failed',
         message: 'Failed to update quest status.',
       });
+
       return { success: false, error: 'Failed to update status' };
     }
   };
@@ -86,6 +88,7 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
         <p className="mt-1 text-sm text-red-600 dark:text-red-300">
           {error || 'The requested quest could not be found.'}
         </p>
+
         <Link
           href="/admin"
           className="mt-4 inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
@@ -99,19 +102,12 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
   return (
     <>
       <div className="space-y-6">
-        {/* Breadcrumb */}
         <nav className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <Link
-            href="/admin"
-            className="hover:text-zinc-700 dark:hover:text-zinc-300"
-          >
+          <Link href="/admin" className="hover:text-zinc-700 dark:hover:text-zinc-300">
             Admin
           </Link>
           <span>/</span>
-          <Link
-            href="/admin/quests"
-            className="hover:text-zinc-700 dark:hover:text-zinc-300"
-          >
+          <Link href="/admin/quests" className="hover:text-zinc-700 dark:hover:text-zinc-300">
             Quests
           </Link>
           <span>/</span>
@@ -120,7 +116,6 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
           </span>
         </nav>
 
-        {/* Editor */}
         <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
           <QuestEditor
             quest={quest}
@@ -130,6 +125,7 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
           />
         </div>
       </div>
+
       <Notifications
         notifications={notificationState.notifications}
         onDismiss={notificationState.removeNotification}
@@ -144,12 +140,14 @@ interface PageProps {
 
 export default function EditQuestPage({ params }: PageProps) {
   const resolvedParams = use(params);
+
   const {
     isAdmin,
     adminUser,
     isLoading: accessLoading,
     error: accessError,
   } = useAdminAccess();
+
   const notificationState = useNotificationState();
 
   if (accessLoading) {
@@ -173,9 +171,11 @@ export default function EditQuestPage({ params }: PageProps) {
           <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 mb-2">
             Access Denied
           </h1>
+
           <p className="text-zinc-500 dark:text-zinc-400 mb-6">
             {accessError || 'You do not have permission to access this page.'}
           </p>
+
           <Link
             href="/dashboard"
             className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-700"

--- a/FrontEnd/my-app/app/[locale]/admin/quests/[id]/edit/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/admin/quests/[id]/edit/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+import Link from 'next/link';
 import { use } from 'react';
 import {
   useAdminAccess,
@@ -10,6 +10,7 @@ import { AdminLayout, QuestEditor, Notifications } from '@/components/admin';
 import { NotificationContext } from '@/lib/hooks/useAdmin';
 import { updateQuestStatus } from '@/lib/api/admin';
 import type { QuestFormData, QuestStatus } from '@/lib/types/admin';
+import Link from 'next/link';
 
 interface EditQuestContentProps {
   questId: string;
@@ -85,12 +86,12 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
         <p className="mt-1 text-sm text-red-600 dark:text-red-300">
           {error || 'The requested quest could not be found.'}
         </p>
-        <a
+        <Link
           href="/admin"
           className="mt-4 inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
         >
           Back to Admin
-        </a>
+        </Link>
       </div>
     );
   }
@@ -100,19 +101,19 @@ function EditQuestContent({ questId }: EditQuestContentProps) {
       <div className="space-y-6">
         {/* Breadcrumb */}
         <nav className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <a
+          <Link
             href="/admin"
             className="hover:text-zinc-700 dark:hover:text-zinc-300"
           >
             Admin
-          </a>
+          </Link>
           <span>/</span>
-          <a
-            href="/admin"
+          <Link
+            href="/admin/quests"
             className="hover:text-zinc-700 dark:hover:text-zinc-300"
           >
             Quests
-          </a>
+          </Link>
           <span>/</span>
           <span className="text-zinc-900 dark:text-zinc-50 truncate max-w-[200px]">
             {quest.title}
@@ -175,12 +176,12 @@ export default function EditQuestPage({ params }: PageProps) {
           <p className="text-zinc-500 dark:text-zinc-400 mb-6">
             {accessError || 'You do not have permission to access this page.'}
           </p>
-          <a
+          <Link
             href="/dashboard"
             className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-700"
           >
             Return to Dashboard
-          </a>
+          </Link>
         </div>
       </div>
     );

--- a/FrontEnd/my-app/components/quest/RetryButton.test.tsx
+++ b/FrontEnd/my-app/components/quest/RetryButton.test.tsx
@@ -88,11 +88,7 @@ describe('RetryButton', () => {
     const onRetry = vi.fn();
 
     render(
-      <RetryButton
-        isVisible={true}
-        onRetry={onRetry}
-        buttonText="Try Again"
-      />
+      <RetryButton isVisible={true} onRetry={onRetry} buttonText="Try Again" />
     );
 
     expect(
@@ -103,9 +99,7 @@ describe('RetryButton', () => {
   it('shows error message when retry fails', async () => {
     const errorMessage = 'Network error occurred';
 
-    const onRetry = vi
-      .fn()
-      .mockRejectedValue(new Error(errorMessage));
+    const onRetry = vi.fn().mockRejectedValue(new Error(errorMessage));
 
     const user = userEvent.setup();
 
@@ -122,28 +116,20 @@ describe('RetryButton', () => {
     const onRetry = vi.fn();
 
     const { rerender } = render(
-      <RetryButton
-        isVisible={true}
-        isLoading={false}
-        onRetry={onRetry}
-      />
+      <RetryButton isVisible={true} isLoading={false} onRetry={onRetry} />
     );
 
-    expect(
-      (screen.getByRole('button') as HTMLButtonElement).disabled
-    ).toBe(false);
+    expect((screen.getByRole('button') as HTMLButtonElement).disabled).toBe(
+      false
+    );
 
     rerender(
-      <RetryButton
-        isVisible={true}
-        isLoading={true}
-        onRetry={onRetry}
-      />
+      <RetryButton isVisible={true} isLoading={true} onRetry={onRetry} />
     );
 
-    expect(
-      (screen.getByRole('button') as HTMLButtonElement).disabled
-    ).toBe(true);
+    expect((screen.getByRole('button') as HTMLButtonElement).disabled).toBe(
+      true
+    );
 
     expect(screen.getByText('Retrying...')).toBeInTheDocument();
   });
@@ -151,13 +137,7 @@ describe('RetryButton', () => {
   it('supports full width styling', () => {
     const onRetry = vi.fn();
 
-    render(
-      <RetryButton
-        isVisible={true}
-        onRetry={onRetry}
-        fullWidth={true}
-      />
-    );
+    render(<RetryButton isVisible={true} onRetry={onRetry} fullWidth={true} />);
 
     expect(screen.getByRole('button').classList.contains('w-full')).toBe(true);
   });
@@ -173,9 +153,9 @@ describe('RetryButton', () => {
       />
     );
 
-    expect(
-      screen.getByRole('button').classList.contains('custom-class')
-    ).toBe(true);
+    expect(screen.getByRole('button').classList.contains('custom-class')).toBe(
+      true
+    );
   });
 
   it('has proper accessibility attributes', () => {
@@ -192,27 +172,15 @@ describe('RetryButton', () => {
     const onRetry = vi.fn();
 
     const { rerender } = render(
-      <RetryButton
-        isVisible={true}
-        isLoading={false}
-        onRetry={onRetry}
-      />
+      <RetryButton isVisible={true} isLoading={false} onRetry={onRetry} />
     );
 
-    expect(
-      screen.getByRole('button').getAttribute('aria-busy')
-    ).toBe('false');
+    expect(screen.getByRole('button').getAttribute('aria-busy')).toBe('false');
 
     rerender(
-      <RetryButton
-        isVisible={true}
-        isLoading={true}
-        onRetry={onRetry}
-      />
+      <RetryButton isVisible={true} isLoading={true} onRetry={onRetry} />
     );
 
-    expect(
-      screen.getByRole('button').getAttribute('aria-busy')
-    ).toBe('true');
+    expect(screen.getByRole('button').getAttribute('aria-busy')).toBe('true');
   });
 });

--- a/FrontEnd/my-app/components/quest/RetryButton.test.tsx
+++ b/FrontEnd/my-app/components/quest/RetryButton.test.tsx
@@ -11,6 +11,7 @@ describe('RetryButton', () => {
 
   it('does not render when isVisible is false', () => {
     const onRetry = vi.fn();
+
     const { container } = render(
       <RetryButton isVisible={false} onRetry={onRetry} />
     );
@@ -20,6 +21,7 @@ describe('RetryButton', () => {
 
   it('renders button when isVisible is true', () => {
     const onRetry = vi.fn();
+
     render(<RetryButton isVisible={true} onRetry={onRetry} />);
 
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
@@ -31,51 +33,66 @@ describe('RetryButton', () => {
 
     render(<RetryButton isVisible={true} onRetry={onRetry} />);
 
-    const button = screen.getByRole('button', { name: /retry/i });
-    await user.click(button);
+    await user.click(screen.getByRole('button', { name: /retry/i }));
 
     expect(onRetry).toHaveBeenCalled();
   });
 
   it('shows loading state while retrying', async () => {
-    const onRetry = vi.fn<() => Promise<void>>(
+    const onRetry = vi.fn(
       () =>
         new Promise<void>((resolve) => {
           setTimeout(resolve, 100);
         })
     );
+
     const user = userEvent.setup();
 
     render(<RetryButton isVisible={true} onRetry={onRetry} />);
 
-    const button = screen.getByRole('button', { name: /retry/i });
-    await user.click(button);
+    await user.click(screen.getByRole('button', { name: /retry/i }));
 
-    // Should show "Retrying..." text
     expect(screen.getByText('Retrying...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(onRetry).toHaveBeenCalled();
+    });
   });
 
   it('disables button while retrying', async () => {
-    const onRetry = vi.fn<() => Promise<void>>(
+    const onRetry = vi.fn(
       () =>
         new Promise<void>((resolve) => {
           setTimeout(resolve, 100);
         })
     );
+
     const user = userEvent.setup();
 
     render(<RetryButton isVisible={true} onRetry={onRetry} />);
 
-    const button = screen.getByRole('button', { name: /retry/i });
+    const button = screen.getByRole('button', {
+      name: /retry/i,
+    }) as HTMLButtonElement;
+
     await user.click(button);
 
-    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.disabled).toBe(true);
+
+    await waitFor(() => {
+      expect(onRetry).toHaveBeenCalled();
+    });
   });
 
   it('displays custom button text', () => {
     const onRetry = vi.fn();
+
     render(
-      <RetryButton isVisible={true} onRetry={onRetry} buttonText="Try Again" />
+      <RetryButton
+        isVisible={true}
+        onRetry={onRetry}
+        buttonText="Try Again"
+      />
     );
 
     expect(
@@ -85,13 +102,16 @@ describe('RetryButton', () => {
 
   it('shows error message when retry fails', async () => {
     const errorMessage = 'Network error occurred';
-    const onRetry = vi.fn().mockRejectedValue(new Error(errorMessage));
+
+    const onRetry = vi
+      .fn()
+      .mockRejectedValue(new Error(errorMessage));
+
     const user = userEvent.setup();
 
     render(<RetryButton isVisible={true} onRetry={onRetry} />);
 
-    const button = screen.getByRole('button', { name: /retry/i });
-    await user.click(button);
+    await user.click(screen.getByRole('button', { name: /retry/i }));
 
     await waitFor(() => {
       expect(screen.getByText(errorMessage)).toBeInTheDocument();
@@ -100,35 +120,51 @@ describe('RetryButton', () => {
 
   it('has isLoading prop to control loading state', () => {
     const onRetry = vi.fn();
+
     const { rerender } = render(
-      <RetryButton isVisible={true} isLoading={false} onRetry={onRetry} />
+      <RetryButton
+        isVisible={true}
+        isLoading={false}
+        onRetry={onRetry}
+      />
     );
 
     expect(
-      (screen.getByRole('button', { name: /retry/i }) as HTMLButtonElement)
-        .disabled
+      (screen.getByRole('button') as HTMLButtonElement).disabled
     ).toBe(false);
 
     rerender(
-      <RetryButton isVisible={true} isLoading={true} onRetry={onRetry} />
+      <RetryButton
+        isVisible={true}
+        isLoading={true}
+        onRetry={onRetry}
+      />
     );
 
-    expect((screen.getByRole('button') as HTMLButtonElement).disabled).toBe(
-      true
-    );
+    expect(
+      (screen.getByRole('button') as HTMLButtonElement).disabled
+    ).toBe(true);
+
     expect(screen.getByText('Retrying...')).toBeInTheDocument();
   });
 
   it('supports full width styling', () => {
     const onRetry = vi.fn();
-    render(<RetryButton isVisible={true} onRetry={onRetry} fullWidth={true} />);
 
-    const button = screen.getByRole('button');
-    expect(button.classList.contains('w-full')).toBe(true);
+    render(
+      <RetryButton
+        isVisible={true}
+        onRetry={onRetry}
+        fullWidth={true}
+      />
+    );
+
+    expect(screen.getByRole('button').classList.contains('w-full')).toBe(true);
   });
 
   it('applies custom className', () => {
     const onRetry = vi.fn();
+
     render(
       <RetryButton
         isVisible={true}
@@ -137,32 +173,46 @@ describe('RetryButton', () => {
       />
     );
 
-    const button = screen.getByRole('button');
-    expect(button.classList.contains('custom-class')).toBe(true);
+    expect(
+      screen.getByRole('button').classList.contains('custom-class')
+    ).toBe(true);
   });
 
   it('has proper accessibility attributes', () => {
     const onRetry = vi.fn();
+
     render(<RetryButton isVisible={true} onRetry={onRetry} />);
 
     const button = screen.getByRole('button');
+
     expect(button.getAttribute('aria-label')).toBe('Retry');
   });
 
   it('updates aria-busy when loading state changes', () => {
     const onRetry = vi.fn();
+
     const { rerender } = render(
-      <RetryButton isVisible={true} isLoading={false} onRetry={onRetry} />
+      <RetryButton
+        isVisible={true}
+        isLoading={false}
+        onRetry={onRetry}
+      />
     );
 
-    let button = screen.getByRole('button');
-    expect(button.getAttribute('aria-busy')).toBe('false');
+    expect(
+      screen.getByRole('button').getAttribute('aria-busy')
+    ).toBe('false');
 
     rerender(
-      <RetryButton isVisible={true} isLoading={true} onRetry={onRetry} />
+      <RetryButton
+        isVisible={true}
+        isLoading={true}
+        onRetry={onRetry}
+      />
     );
 
-    button = screen.getByRole('button');
-    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(
+      screen.getByRole('button').getAttribute('aria-busy')
+    ).toBe('true');
   });
 });

--- a/FrontEnd/my-app/lib/dynamic-imports.tsx
+++ b/FrontEnd/my-app/lib/dynamic-imports.tsx
@@ -4,10 +4,15 @@ import dynamic from 'next/dynamic';
 // Each component is loaded lazily on demand with SSR disabled
 // where client-only APIs are used.
 
+const DynamicLoading = () => (
+  <div className="min-h-[200px] w-full animate-pulse rounded-lg bg-slate-800/50" />
+);
+
 export const DynamicModal = dynamic(
   () => import('../components/ui/Modal').then((mod) => mod.Modal),
   {
     ssr: false,
+    loading: () => <DynamicLoading />,
   }
 );
 
@@ -16,7 +21,10 @@ export const DynamicWalletConnector = dynamic(
     import('../components/wallet/WalletConnectionModal').then(
       (mod) => mod.WalletConnectionModal
     ),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => <DynamicLoading />,
+  }
 );
 
 export const DynamicToastNotification = dynamic(
@@ -24,7 +32,10 @@ export const DynamicToastNotification = dynamic(
     import('../components/notifications/Toast').then(
       (mod) => mod.ToastProvider
     ),
-  { ssr: false, loading: () => null }
+  {
+    ssr: false,
+    loading: () => null,
+  }
 );
 
 // Homepage below-fold section dynamic imports
@@ -33,9 +44,7 @@ export const DynamicHowItWorks = dynamic(
     import('../components/homepage/HowItWorks').then((mod) => mod.HowItWorks),
   {
     ssr: false,
-    loading: () => (
-      <div className="min-h-[400px] w-full animate-pulse rounded-lg bg-slate-800/50" />
-    ),
+    loading: () => <DynamicLoading />,
   }
 );
 
@@ -44,9 +53,7 @@ export const DynamicFeaturedQuests = dynamic(
     import('../components/homepage/FeaturedQuests').then((mod) => mod.default),
   {
     ssr: false,
-    loading: () => (
-      <div className="min-h-[500px] w-full animate-pulse rounded-lg bg-slate-800/50" />
-    ),
+    loading: () => <DynamicLoading />,
   }
 );
 
@@ -57,9 +64,7 @@ export const DynamicFAQAccordion = dynamic(
     ),
   {
     ssr: false,
-    loading: () => (
-      <div className="min-h-[400px] w-full animate-pulse rounded-lg bg-slate-800/50" />
-    ),
+    loading: () => <DynamicLoading />,
   }
 );
 
@@ -68,8 +73,6 @@ export const DynamicCTASection = dynamic(
     import('../components/homepage/CTASection').then((mod) => mod.CTASection),
   {
     ssr: false,
-    loading: () => (
-      <div className="min-h-[300px] w-full animate-pulse rounded-lg bg-slate-800/50" />
-    ),
+    loading: () => <DynamicLoading />,
   }
 );


### PR DESCRIPTION
Closes #806

## Summary
- Improved dynamic import loading behavior
- Added reusable loading fallback for dynamically imported components
- Reduced duplicated loading UI implementations

## Changes Made
- Added a shared `DynamicLoading` fallback component
- Added loading states to modal and wallet dynamic imports
- Reused the shared fallback for homepage lazy-loaded sections
- Preserved SSR-disabled behavior for client-only components

## Testing
- `npm run build` ✅

## Related Issue
Closes #806