### PR TITLE
feat(fe-014): add lucide-react navigation icons to Sidebar and MobileMenu

### DIFF
--- a/FrontEnd/my-app/components/layout/MobileMenu.tsx
+++ b/FrontEnd/my-app/components/layout/MobileMenu.tsx
@@ -89,7 +89,10 @@ export function MobileMenu({ isOpen, onClose, pathname }: MobileMenuProps) {
                 onClick={onClose}
               >
                 {item.icon && (
-                  <item.icon className="mr-3 h-4 w-4 shrink-0" aria-hidden="true" />
+                  <item.icon
+                    className="mr-3 h-4 w-4 shrink-0"
+                    aria-hidden="true"
+                  />
                 )}
                 {item.label}
               </Link>

--- a/FrontEnd/my-app/components/layout/MobileMenu.tsx
+++ b/FrontEnd/my-app/components/layout/MobileMenu.tsx
@@ -79,7 +79,7 @@ export function MobileMenu({ isOpen, onClose, pathname }: MobileMenuProps) {
             return (
               <Link
                 aria-current={active ? 'page' : undefined}
-                className={`block rounded-lg px-3 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#089ec3] ${
+                className={`flex items-center rounded-lg px-3 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#089ec3] ${
                   active
                     ? 'bg-[#089ec3] text-white'
                     : 'text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800'
@@ -88,6 +88,9 @@ export function MobileMenu({ isOpen, onClose, pathname }: MobileMenuProps) {
                 key={item.href}
                 onClick={onClose}
               >
+                {item.icon && (
+                  <item.icon className="mr-3 h-4 w-4 shrink-0" aria-hidden="true" />
+                )}
                 {item.label}
               </Link>
             );

--- a/FrontEnd/my-app/components/layout/Sidebar.test.tsx
+++ b/FrontEnd/my-app/components/layout/Sidebar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Sidebar } from './Sidebar';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/quests',
+}));
+
+const MockIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg data-testid="mock-icon" {...props} />
+);
+
+vi.mock('@/lib/config/navigation', () => ({
+  useTranslatedNavigation: () => ({
+    navigationItems: [
+      {
+        href: '/dashboard',
+        labelKey: 'nav.dashboard',
+        label: 'Dashboard',
+        icon: MockIcon,
+      },
+      {
+        href: '/quests',
+        labelKey: 'nav.quests',
+        label: 'Quests',
+        icon: MockIcon,
+      },
+      {
+        href: '/submissions',
+        labelKey: 'nav.submissions',
+        label: 'Submissions',
+      },
+    ],
+  }),
+  isActiveRoute: (pathname: string, item: { href: string; exact?: boolean }) =>
+    item.exact ? pathname === item.href : pathname.startsWith(item.href),
+}));
+
+describe('Sidebar', () => {
+  it('renders navigation items with labels', () => {
+    render(<Sidebar />);
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Quests')).toBeInTheDocument();
+    expect(screen.getByText('Submissions')).toBeInTheDocument();
+  });
+
+  it('renders lucide icons for items with icon property', () => {
+    render(<Sidebar />);
+
+    const icons = screen.getAllByTestId('mock-icon');
+    expect(icons.length).toBe(2);
+  });
+
+  it('renders NavDot fallback for items without icon', () => {
+    render(<Sidebar />);
+
+    const submissionsLink = screen.getByText('Submissions').closest('a');
+    const navDot = submissionsLink?.querySelector('.rounded-full');
+    expect(navDot).toBeInTheDocument();
+  });
+
+  it('does not render labels when collapsed', () => {
+    render(<Sidebar collapsed />);
+
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Quests')).not.toBeInTheDocument();
+  });
+
+  it('has correct aria-label on aside element', () => {
+    render(<Sidebar />);
+
+    expect(
+      screen.getByRole('complementary', { name: /sidebar navigation/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/FrontEnd/my-app/components/layout/Sidebar.tsx
+++ b/FrontEnd/my-app/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -57,7 +58,11 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   : 'text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800'
               } ${collapsed ? 'justify-center' : 'gap-3'}`}
             >
-              <NavDot active={active} />
+              {item.icon ? (
+                <item.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+              ) : (
+                <NavDot active={active} />
+              )}
               {!collapsed && <span>{item.label}</span>}
             </Link>
           );

--- a/FrontEnd/my-app/lib/config/navigation.ts
+++ b/FrontEnd/my-app/lib/config/navigation.ts
@@ -22,7 +22,12 @@ export interface UserMenuItem {
 }
 
 export const navigationItems: NavigationItem[] = [
-  { href: '/dashboard', labelKey: 'nav.dashboard', exact: true, icon: LayoutDashboard },
+  {
+    href: '/dashboard',
+    labelKey: 'nav.dashboard',
+    exact: true,
+    icon: LayoutDashboard,
+  },
   { href: '/quests', labelKey: 'nav.quests', icon: Target },
   { href: '/submissions', labelKey: 'nav.submissions', icon: FileText },
   { href: '/rewards', labelKey: 'nav.rewards', icon: Gift },

--- a/FrontEnd/my-app/lib/config/navigation.ts
+++ b/FrontEnd/my-app/lib/config/navigation.ts
@@ -1,9 +1,19 @@
 import { useTranslations } from 'next-intl';
+import {
+  LayoutDashboard,
+  Target,
+  FileText,
+  Gift,
+  Settings,
+  Shield,
+  type LucideIcon,
+} from 'lucide-react';
 
 export interface NavigationItem {
   href: string;
   labelKey: string;
   exact?: boolean;
+  icon?: LucideIcon;
 }
 
 export interface UserMenuItem {
@@ -12,12 +22,12 @@ export interface UserMenuItem {
 }
 
 export const navigationItems: NavigationItem[] = [
-  { href: '/dashboard', labelKey: 'nav.dashboard', exact: true },
-  { href: '/quests', labelKey: 'nav.quests' },
-  { href: '/submissions', labelKey: 'nav.submissions' },
-  { href: '/rewards', labelKey: 'nav.rewards' },
-  { href: '/settings/notifications', labelKey: 'nav.settings' },
-  { href: '/admin', labelKey: 'nav.admin' },
+  { href: '/dashboard', labelKey: 'nav.dashboard', exact: true, icon: LayoutDashboard },
+  { href: '/quests', labelKey: 'nav.quests', icon: Target },
+  { href: '/submissions', labelKey: 'nav.submissions', icon: FileText },
+  { href: '/rewards', labelKey: 'nav.rewards', icon: Gift },
+  { href: '/settings/notifications', labelKey: 'nav.settings', icon: Settings },
+  { href: '/admin', labelKey: 'nav.admin', icon: Shield },
 ];
 
 export const userMenuItems: UserMenuItem[] = [


### PR DESCRIPTION
## Summary

This PR adds navigation icons to the shared sidebar components by extending the shared navigation configuration with Lucide icons.

Previously, the shared `Sidebar` and `MobileMenu` displayed only labels (or `NavDot` indicators), while other layouts already included visual navigation icons. This change provides a more consistent navigation experience across the application while preserving the existing fallback behavior.

## Changes

* [x] Added optional `icon?: LucideIcon` to the shared `NavigationItem` type
* [x] Assigned Lucide icons to all shared navigation items
* [x] Updated `Sidebar` to render navigation icons with `NavDot` as a fallback
* [x] Updated `MobileMenu` to render navigation icons alongside labels
* [x] Added unit tests covering icon rendering, fallback behavior, collapsed state, and accessibility

## Verification

* [x] Added 5 new Sidebar unit tests
* [x] `pnpm vitest run` — **585/585 tests passed**
* [x] No new TypeScript errors introduced (only pre-existing repository issues remain)
* [x] No new lint issues introduced (repository has pre-existing lint configuration issues)

## Notes

* `NavDot` remains as a fallback for navigation items without an assigned icon.
* Changes are limited to the shared navigation components and configuration. No backend or business logic was modified.


Closes #803