### PR TITLE
fix(fe-028): wrap FeaturedQuests with resilient API bootstrap error boundary

### DIFF
--- a/FrontEnd/my-app/app/[locale]/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/page.tsx
@@ -2,6 +2,10 @@
 
 import HeroSection from '@/components/homepage/HeroSection';
 import { ComponentErrorBoundary } from '@/components/error/ErrorBoundary';
+import {
+  WithAPIBootstrapErrorBoundary,
+  BootstrapErrorFallback,
+} from '@/components/error';
 import LazyLoad from '@/components/ui/LazyLoad';
 import {
   DynamicHowItWorks,
@@ -10,15 +14,42 @@ import {
   DynamicCTASection,
 } from '@/lib/dynamic-imports';
 
+/**
+ * Homepage composition.
+ *
+ * Widgets are wrapped on a per-section basis so that a single failure does
+ * not blank the entire page. Two kinds of boundary are used:
+ *
+ * - `WithAPIBootstrapErrorBoundary` for widgets whose initial render
+ *   depends on API bootstrap (FeaturedQuests fetches from the API at mount).
+ *   In addition to catching render errors, this boundary listens for
+ *   offline / online / network-unreachable events and shows the resilient
+ *   `BootstrapErrorFallback` UI (retry, Go Home, network diagnostics,
+ *   retry counter, automatic reset on reconnect).
+ *
+ * - `ComponentErrorBoundary` for widgets that are static (no API call) but
+ *   are loaded through `next/dynamic`, where they could still fail to
+ *   bootstrap if their JS chunk fails to load. We intentionally do not use
+ *   the API-bootstrap-aware boundary for these widgets: their offline
+ *   fallback UI would mislead the user (they have no network dependency)
+ *   and would stack across every section if the user ever went offline.
+ *
+ * `FeaturedQuests` is also wrapped internally (see the component file)
+ * with a specialized `APIBootstrapErrorBoundary` that renders a
+ * timeout-specific UI for slow requests. The two boundaries are not
+ * redundant: the outer one catches chunk-load and dynamic-import failures
+ * that the inner one cannot see; the inner one catches API-call failures
+ * during mount and provides the specialized timeout UX.
+ */
 export default function Home() {
   return (
     <main id="main-content" className="flex flex-col">
-      {/* Hero - Above the fold, loaded eagerly */}
+      {/* HeroSection - Above the fold, eagerly loaded, no API calls. */}
       <ComponentErrorBoundary componentName="HeroSection">
         <HeroSection />
       </ComponentErrorBoundary>
 
-      {/* How It Works - Below the fold */}
+      {/* HowItWorks - Dynamic chunk, no API. Catches render and chunk-load errors. */}
       <ComponentErrorBoundary componentName="HowItWorks">
         <LazyLoad
           placeholder={
@@ -29,8 +60,13 @@ export default function Home() {
         </LazyLoad>
       </ComponentErrorBoundary>
 
-      {/* Featured Quests - Below the fold */}
-      <ComponentErrorBoundary componentName="FeaturedQuests">
+      {/* FeaturedQuests - Dynamic chunk AND API bootstrap. Outer boundary
+          catches chunk-load errors; the inner boundary handles API-specific
+          failures with the timeout-specialized UI. */}
+      <WithAPIBootstrapErrorBoundary
+        componentName="Featured Quests — Page Loader"
+        fallback={BootstrapErrorFallback}
+      >
         <LazyLoad
           placeholder={
             <div className="min-h-[600px] w-full animate-pulse bg-slate-800/20" />
@@ -39,25 +75,29 @@ export default function Home() {
         >
           <DynamicFeaturedQuests />
         </LazyLoad>
+      </WithAPIBootstrapErrorBoundary>
+
+      {/* CTASection - Dynamic chunk, no API. */}
+      <ComponentErrorBoundary componentName="CTASection">
+        <LazyLoad
+          placeholder={
+            <div className="min-h-[300px] w-full animate-pulse bg-slate-800/20" />
+          }
+        >
+          <DynamicCTASection />
+        </LazyLoad>
       </ComponentErrorBoundary>
 
-      {/* CTA - Below the fold */}
-      <LazyLoad
-        placeholder={
-          <div className="min-h-[300px] w-full animate-pulse bg-slate-800/20" />
-        }
-      >
-        <DynamicCTASection />
-      </LazyLoad>
-
-      {/* FAQ - Below the fold */}
-      <LazyLoad
-        placeholder={
-          <div className="min-h-[400px] w-full animate-pulse bg-slate-800/20" />
-        }
-      >
-        <DynamicFAQAccordion />
-      </LazyLoad>
+      {/* FAQAccordion - Dynamic chunk, no API. */}
+      <ComponentErrorBoundary componentName="FAQAccordion">
+        <LazyLoad
+          placeholder={
+            <div className="min-h-[400px] w-full animate-pulse bg-slate-800/20" />
+          }
+        >
+          <DynamicFAQAccordion />
+        </LazyLoad>
+      </ComponentErrorBoundary>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Resolves #817 by ensuring the homepage composition uses the resilient API bootstrap error boundary for the one widget that actually has an API bootstrap dependency (`FeaturedQuests`), and gives every other homepage widget a per-section error boundary so a single bootstrap failure no longer blanks an entire section.

### Changes

- `FrontEnd/my-app/app/[locale]/page.tsx`
  - **`FeaturedQuests`** is now wrapped with `WithAPIBootstrapErrorBoundary` + `BootstrapErrorFallback`. This catches chunk-load failures from `next/dynamic` that the inner specialized boundary cannot see, and exposes the resilient recovery UI (retry, Go Home, retry counter, automatic reset on `online` event).
  - **`HeroSection`, `HowItWorks`, `CTASection`, `FAQAccordion`** keep the generic `ComponentErrorBoundary`. They have no API dependency, so applying the offline-aware boundary would mislead the user with a stacked "Network Error" / "Offline" fallback UI across every section while they were simply browsing cached hero/FAQ content.
  - `CTASection` and `FAQAccordion` were previously **unwrapped**; both are now wrapped to give them the same chunk-load resilience as the eagerly-loaded sections.

### Why per-widget and why two boundaries on `FeaturedQuests`

- Per-widget wrapping: a single failure is contained and the rest of the homepage stays usable.
- Inner vs outer boundary on `FeaturedQuests`: the inner (existing) `APIBootstrapErrorBoundary` inside `FeaturedQuests.tsx` catches errors during the component render / API call and surfaces the specialized timeout-specific UI; the outer one catches errors thrown at the `next/dynamic` loader level (chunk download failures) that the inner one cannot see. They protect different surfaces and are not redundant.

### Validation

- `pnpm vitest run components/error/APIBootstrapErrorBoundary.test.tsx components/homepage/FeaturedQuests.test.tsx` → **23/23 passing** (16 in boundary suite, 7 in `FeaturedQuests` suite).
- Typecheck pre-existing failure: `app/providers/I18nProvider.tsx` references `use-intl` but `use-intl` is not declared in `package.json` and is therefore not installed. This is **pre-existing and unrelated** to this PR. Out of scope here; happy to file a separate issue/PR if the maintainer wants.

### Risk & roll-back

- Behavioral change is limited to error UI on failure paths; healthy render paths render identically.
- Per-section wrapping means a single widget failing will show its boundary UI rather than crashing the page.
- Roll-back is a single-commit revert with no data model impact.

Closes #817