### PR TITLE
feat(fe-027): Add fallback behavior for offline mode when API base URL unreachable

### DIFF
--- a/FrontEnd/my-app/app/providers/RootProviders.tsx
+++ b/FrontEnd/my-app/app/providers/RootProviders.tsx
@@ -9,6 +9,7 @@ import { WalletProvider } from '@/context/WalletContext';
 import { ToastProvider } from '@/components/notifications/Toast';
 import { AppErrorBoundary } from '@/components/error/ErrorBoundary';
 import { A11yAnnouncerProvider } from '@/components/a11y/A11yAnnouncer';
+import { OfflineModeProvider } from '@/components/providers/OfflineModeProvider';
 
 /**
  * RootProviders Component
@@ -46,7 +47,9 @@ export function RootProviders({ children }: RootProvidersProps) {
             <WalletProvider>
               <AuthProvider>
                 <AnalyticsProvider>
-                  <A11yAnnouncerProvider>{children}</A11yAnnouncerProvider>
+                  <OfflineModeProvider>
+                    <A11yAnnouncerProvider>{children}</A11yAnnouncerProvider>
+                  </OfflineModeProvider>
                 </AnalyticsProvider>
               </AuthProvider>
             </WalletProvider>

--- a/FrontEnd/my-app/components/error/ApiUnreachableFallback.test.tsx
+++ b/FrontEnd/my-app/components/error/ApiUnreachableFallback.test.tsx
@@ -43,14 +43,18 @@ describe('ApiUnreachableFallback', () => {
 
   it('renders a retry button with the correct label', () => {
     render(<ApiUnreachableFallback onRetry={() => {}} />);
-    const btn = screen.getByRole('button', { name: /retry server connection/i });
+    const btn = screen.getByRole('button', {
+      name: /retry server connection/i,
+    });
     expect(btn).toBeDefined();
   });
 
   it('calls onRetry when the button is clicked', () => {
     const onRetry = vi.fn();
     render(<ApiUnreachableFallback onRetry={onRetry} />);
-    fireEvent.click(screen.getByRole('button', { name: /retry server connection/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /retry server connection/i })
+    );
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 

--- a/FrontEnd/my-app/components/error/ApiUnreachableFallback.test.tsx
+++ b/FrontEnd/my-app/components/error/ApiUnreachableFallback.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for ApiUnreachableFallback – FE-027
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ApiUnreachableFallback } from './ApiUnreachableFallback';
+
+// Minimal button stub so we don't need the full UI library in unit tests.
+vi.mock('../ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    'aria-label': ariaLabel,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    'aria-label'?: string;
+  }) => (
+    <button onClick={onClick} disabled={disabled} aria-label={ariaLabel}>
+      {children}
+    </button>
+  ),
+}));
+
+describe('ApiUnreachableFallback', () => {
+  it('renders a heading about the server being unreachable', () => {
+    render(<ApiUnreachableFallback onRetry={() => {}} />);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'Server unreachable'
+    );
+  });
+
+  it('renders descriptive text about the situation', () => {
+    render(<ApiUnreachableFallback onRetry={() => {}} />);
+    expect(
+      screen.getByText(/could not reach the StellarEarn API/i)
+    ).toBeDefined();
+  });
+
+  it('renders a retry button with the correct label', () => {
+    render(<ApiUnreachableFallback onRetry={() => {}} />);
+    const btn = screen.getByRole('button', { name: /retry server connection/i });
+    expect(btn).toBeDefined();
+  });
+
+  it('calls onRetry when the button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<ApiUnreachableFallback onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: /retry server connection/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button and shows "Checking…" when isChecking is true', () => {
+    render(<ApiUnreachableFallback onRetry={() => {}} isChecking />);
+    const btn = screen.getByRole('button', { name: /checking server/i });
+    expect(btn).toBeDefined();
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('has a status role for accessibility', () => {
+    render(<ApiUnreachableFallback onRetry={() => {}} />);
+    expect(screen.getByRole('status')).toBeDefined();
+  });
+
+  it('has aria-live="polite" on the container', () => {
+    render(<ApiUnreachableFallback onRetry={() => {}} />);
+    const container = screen.getByRole('status');
+    expect(container.getAttribute('aria-live')).toBe('polite');
+  });
+});

--- a/FrontEnd/my-app/components/error/ApiUnreachableFallback.tsx
+++ b/FrontEnd/my-app/components/error/ApiUnreachableFallback.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { RefreshCw, ServerCrash } from 'lucide-react';
+import { Button } from '../ui/button';
+
+interface ApiUnreachableFallbackProps {
+  /** Called when the user clicks "Try Again". */
+  onRetry: () => void;
+  /** Whether a recheck is currently in progress. */
+  isChecking?: boolean;
+}
+
+/**
+ * Shown when the browser has internet access but the API base URL is
+ * unreachable (server down, misconfigured URL, CORS pre-flight blocked, etc.).
+ *
+ * This is distinct from {@link OfflineFallback} which is shown when the
+ * device has no internet connection at all.
+ */
+export const ApiUnreachableFallback: React.FC<ApiUnreachableFallbackProps> = ({
+  onRetry,
+  isChecking = false,
+}) => {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center min-h-[400px] p-6 text-center bg-gray-50 dark:bg-gray-900 rounded-lg"
+    >
+      <div className="p-4 mb-4 bg-yellow-100 dark:bg-yellow-900/30 rounded-full">
+        <ServerCrash
+          className="w-12 h-12 text-yellow-600 dark:text-yellow-400"
+          aria-hidden="true"
+        />
+      </div>
+
+      <h2 className="text-2xl font-semibold mb-2 text-gray-900 dark:text-gray-100">
+        Server unreachable
+      </h2>
+
+      <p className="text-gray-600 dark:text-gray-300 mb-2 max-w-md">
+        We could not reach the StellarEarn API. You might still be able to
+        browse cached content, but actions like submitting quests or claiming
+        rewards are unavailable until the connection is restored.
+      </p>
+
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 max-w-md">
+        If this persists, please check your network settings or contact support.
+      </p>
+
+      <Button
+        onClick={onRetry}
+        disabled={isChecking}
+        variant="default"
+        className="flex items-center gap-2"
+        aria-label={isChecking ? 'Checking server…' : 'Retry server connection'}
+      >
+        <RefreshCw
+          className={`w-4 h-4 ${isChecking ? 'animate-spin' : ''}`}
+          aria-hidden="true"
+        />
+        {isChecking ? 'Checking…' : 'Try Again'}
+      </Button>
+    </div>
+  );
+};

--- a/FrontEnd/my-app/components/error/OfflineFallback.tsx
+++ b/FrontEnd/my-app/components/error/OfflineFallback.tsx
@@ -6,13 +6,27 @@ interface OfflineFallbackProps {
   onRetry: () => void;
 }
 
+/**
+ * Shown when the device has no internet connection (`navigator.onLine === false`
+ * or an `offline` browser event has fired).
+ *
+ * For the case where the device is online but the API is unreachable, see
+ * {@link ApiUnreachableFallback}.
+ */
 export const OfflineFallback: React.FC<OfflineFallbackProps> = ({
   onRetry,
 }) => {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[400px] p-6 text-center bg-gray-50 dark:bg-gray-900 rounded-lg">
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center min-h-[400px] p-6 text-center bg-gray-50 dark:bg-gray-900 rounded-lg"
+    >
       <div className="p-4 mb-4 bg-gray-200 dark:bg-gray-800 rounded-full">
-        <WifiOff className="w-12 h-12 text-gray-500 dark:text-gray-400" />
+        <WifiOff
+          className="w-12 h-12 text-gray-500 dark:text-gray-400"
+          aria-hidden="true"
+        />
       </div>
       <h2 className="text-2xl font-semibold mb-2 text-gray-900 dark:text-gray-100">
         You are offline
@@ -28,7 +42,7 @@ export const OfflineFallback: React.FC<OfflineFallbackProps> = ({
         className="flex items-center gap-2"
         aria-label="Retry connection"
       >
-        <RefreshCw className="w-4 h-4" />
+        <RefreshCw className="w-4 h-4" aria-hidden="true" />
         Try Again
       </Button>
     </div>

--- a/FrontEnd/my-app/components/error/index.ts
+++ b/FrontEnd/my-app/components/error/index.ts
@@ -20,3 +20,5 @@ export {
 } from './APIBootstrapErrorBoundary';
 export { ErrorMessage } from './ErrorMessage';
 export { BootstrapErrorFallback } from './BootstrapErrorFallback';
+export { OfflineFallback } from './OfflineFallback';
+export { ApiUnreachableFallback } from './ApiUnreachableFallback';

--- a/FrontEnd/my-app/components/providers/OfflineModeProvider.test.tsx
+++ b/FrontEnd/my-app/components/providers/OfflineModeProvider.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for OfflineModeProvider – FE-027
+ *
+ * Verifies that the provider renders the correct fallback depending on the
+ * network / API reachability state returned by useNetworkStatus.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { OfflineModeProvider } from './OfflineModeProvider';
+
+// ---------------------------------------------------------------------------
+// Mock useNetworkStatus so we control the network state in each test.
+// ---------------------------------------------------------------------------
+
+const mockRecheckApi = vi.fn().mockResolvedValue(undefined);
+
+const networkStatusMock = {
+  isOnline: true,
+  isApiReachable: true,
+  recheckApi: mockRecheckApi,
+};
+
+vi.mock('@/lib/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => networkStatusMock,
+}));
+
+// Minimal stubs for fallback components.
+vi.mock('@/components/error/OfflineFallback', () => ({
+  OfflineFallback: ({ onRetry }: { onRetry: () => void }) => (
+    <div data-testid="offline-fallback">
+      <button onClick={onRetry}>Retry</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/error/ApiUnreachableFallback', () => ({
+  ApiUnreachableFallback: ({
+    onRetry,
+    isChecking,
+  }: {
+    onRetry: () => void;
+    isChecking?: boolean;
+  }) => (
+    <div data-testid="api-unreachable-fallback">
+      <button onClick={onRetry} disabled={isChecking}>
+        {isChecking ? 'Checking…' : 'Try Again'}
+      </button>
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OfflineModeProvider', () => {
+  beforeEach(() => {
+    mockRecheckApi.mockClear();
+    networkStatusMock.isOnline = true;
+    networkStatusMock.isApiReachable = true;
+  });
+
+  it('renders children when online and API is reachable', () => {
+    render(
+      <OfflineModeProvider>
+        <span data-testid="child">content</span>
+      </OfflineModeProvider>
+    );
+    expect(screen.getByTestId('child')).toBeDefined();
+    expect(screen.queryByTestId('offline-fallback')).toBeNull();
+    expect(screen.queryByTestId('api-unreachable-fallback')).toBeNull();
+  });
+
+  it('renders OfflineFallback when the device is offline', () => {
+    networkStatusMock.isOnline = false;
+    networkStatusMock.isApiReachable = false;
+
+    render(
+      <OfflineModeProvider>
+        <span data-testid="child">content</span>
+      </OfflineModeProvider>
+    );
+
+    expect(screen.getByTestId('offline-fallback')).toBeDefined();
+    expect(screen.queryByTestId('child')).toBeNull();
+  });
+
+  it('renders ApiUnreachableFallback when online but API is unreachable', () => {
+    networkStatusMock.isOnline = true;
+    networkStatusMock.isApiReachable = false;
+
+    render(
+      <OfflineModeProvider>
+        <span data-testid="child">content</span>
+      </OfflineModeProvider>
+    );
+
+    expect(screen.getByTestId('api-unreachable-fallback')).toBeDefined();
+    expect(screen.queryByTestId('child')).toBeNull();
+  });
+
+  it('calls recheckApi when retry is clicked on the API fallback', async () => {
+    networkStatusMock.isOnline = true;
+    networkStatusMock.isApiReachable = false;
+
+    render(
+      <OfflineModeProvider>
+        <span>content</span>
+      </OfflineModeProvider>
+    );
+
+    await act(async () => {
+      screen.getByRole('button', { name: /try again/i }).click();
+    });
+
+    expect(mockRecheckApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders children when enabled is false regardless of network state', () => {
+    networkStatusMock.isOnline = false;
+    networkStatusMock.isApiReachable = false;
+
+    render(
+      <OfflineModeProvider enabled={false}>
+        <span data-testid="child">content</span>
+      </OfflineModeProvider>
+    );
+
+    expect(screen.getByTestId('child')).toBeDefined();
+  });
+});

--- a/FrontEnd/my-app/components/providers/OfflineModeProvider.tsx
+++ b/FrontEnd/my-app/components/providers/OfflineModeProvider.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+/**
+ * OfflineModeProvider – FE-027
+ *
+ * Wraps children with network-aware fallback behaviour:
+ *
+ *  • Device offline  → renders `<OfflineFallback />`
+ *  • Online but API unreachable → renders `<ApiUnreachableFallback />`
+ *  • Both reachable  → renders children normally
+ *
+ * The provider mounts `useNetworkStatus` exactly once at the top of the tree
+ * so all descendant hooks that read `isOnline` / `isApiReachable` from the
+ * store stay in sync automatically.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { useNetworkStatus } from '@/lib/hooks/useNetworkStatus';
+import { OfflineFallback } from '@/components/error/OfflineFallback';
+import { ApiUnreachableFallback } from '@/components/error/ApiUnreachableFallback';
+
+interface OfflineModeProviderProps {
+  children: React.ReactNode;
+  /**
+   * When `true` (default) the provider gates all children behind connectivity
+   * checks and renders the appropriate fallback.
+   *
+   * Set to `false` to disable the gate (useful in tests or storybook).
+   */
+  enabled?: boolean;
+}
+
+export function OfflineModeProvider({
+  children,
+  enabled = true,
+}: OfflineModeProviderProps) {
+  const { isOnline, isApiReachable, recheckApi } = useNetworkStatus();
+  const [isChecking, setIsChecking] = useState(false);
+
+  const handleRetry = useCallback(async () => {
+    setIsChecking(true);
+    try {
+      await recheckApi();
+    } finally {
+      setIsChecking(false);
+    }
+  }, [recheckApi]);
+
+  if (!enabled) {
+    return <>{children}</>;
+  }
+
+  // Device has no internet connection at all.
+  if (!isOnline) {
+    return <OfflineFallback onRetry={handleRetry} />;
+  }
+
+  // Device is online but the API base URL is not responding.
+  if (!isApiReachable) {
+    return (
+      <ApiUnreachableFallback onRetry={handleRetry} isChecking={isChecking} />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/FrontEnd/my-app/lib/hooks/useNetworkStatus.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useNetworkStatus.test.ts
@@ -123,7 +123,7 @@ describe('useNetworkStatus', () => {
   it('fires an API health probe immediately when online', async () => {
     renderHook(() => useNetworkStatus());
     await act(async () => {
-      await vi.runAllTimersAsync();
+      await vi.runOnlyPendingTimersAsync();
     });
     expect(mockGet).toHaveBeenCalledWith(
       '/health',
@@ -135,7 +135,7 @@ describe('useNetworkStatus', () => {
     mockGet.mockResolvedValue({ data: { status: 'ok' } });
     renderHook(() => useNetworkStatus());
     await act(async () => {
-      await vi.runAllTimersAsync();
+      await vi.runOnlyPendingTimersAsync();
     });
     expect(mockState.setApiReachable).toHaveBeenCalledWith(true);
   });
@@ -144,7 +144,7 @@ describe('useNetworkStatus', () => {
     mockGet.mockRejectedValue(new Error('Network Error'));
     renderHook(() => useNetworkStatus());
     await act(async () => {
-      await vi.runAllTimersAsync();
+      await vi.runOnlyPendingTimersAsync();
     });
     expect(mockState.setApiReachable).toHaveBeenCalledWith(false);
   });
@@ -154,7 +154,7 @@ describe('useNetworkStatus', () => {
     mockGet.mockClear();
     renderHook(() => useNetworkStatus());
     await act(async () => {
-      await vi.runAllTimersAsync();
+      await vi.runOnlyPendingTimersAsync();
     });
     // Periodic effect only runs when storeIsOnline is true.
     expect(mockGet).not.toHaveBeenCalled();

--- a/FrontEnd/my-app/lib/hooks/useNetworkStatus.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useNetworkStatus.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for useNetworkStatus – FE-027
+ *
+ * Covers:
+ * - Initial state synchronisation
+ * - Browser online / offline events
+ * - API health probe logic
+ * - `network-unreachable` custom-event handling
+ * - `recheckApi` on-demand probe
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useNetworkStatus } from './useNetworkStatus';
+import { useStore } from '@/lib/store';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/store', () => ({
+  useStore: vi.fn(),
+}));
+
+vi.mock('../api/client', () => ({
+  getApiClient: vi.fn(() => ({
+    get: vi.fn().mockResolvedValue({ data: { status: 'ok' } }),
+  })),
+}));
+
+import { getApiClient } from '../api/client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildStoreMock(overrides?: Partial<ReturnType<typeof buildStoreMock>>) {
+  const mock = {
+    isOnline: true,
+    isApiReachable: true,
+    setOnlineStatus: vi.fn(),
+    setApiReachable: vi.fn(),
+    ...overrides,
+  };
+  (useStore as any).mockImplementation((selector: any) => selector(mock));
+  return mock;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('useNetworkStatus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'addEventListener');
+    vi.spyOn(window, 'removeEventListener');
+    buildStoreMock();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  // ── initial state ─────────────────────────────────────────────────────────
+
+  it('sets initial online status from navigator.onLine on mount', () => {
+    const { setOnlineStatus } = buildStoreMock();
+    renderHook(() => useNetworkStatus());
+    expect(setOnlineStatus).toHaveBeenCalledWith(navigator.onLine);
+  });
+
+  it('returns isOnline and isApiReachable from the store', () => {
+    buildStoreMock({ isOnline: true, isApiReachable: false });
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.isOnline).toBe(true);
+    expect(result.current.isApiReachable).toBe(false);
+  });
+
+  // ── online / offline events ───────────────────────────────────────────────
+
+  it('registers online and offline event listeners', () => {
+    renderHook(() => useNetworkStatus());
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'online',
+      expect.any(Function)
+    );
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'offline',
+      expect.any(Function)
+    );
+  });
+
+  it('removes event listeners on unmount', () => {
+    const { unmount } = renderHook(() => useNetworkStatus());
+    unmount();
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'online',
+      expect.any(Function)
+    );
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'offline',
+      expect.any(Function)
+    );
+  });
+
+  it('calls setOnlineStatus(true) when the online event fires', () => {
+    const { setOnlineStatus } = buildStoreMock();
+    renderHook(() => useNetworkStatus());
+
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(setOnlineStatus).toHaveBeenCalledWith(true);
+  });
+
+  it('calls setOnlineStatus(false) and setApiReachable(false) when the offline event fires', () => {
+    const { setOnlineStatus, setApiReachable } = buildStoreMock();
+    renderHook(() => useNetworkStatus());
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(setOnlineStatus).toHaveBeenCalledWith(false);
+    expect(setApiReachable).toHaveBeenCalledWith(false);
+  });
+
+  // ── API health probe ──────────────────────────────────────────────────────
+
+  it('fires an API health probe immediately when online', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
+    (getApiClient as any).mockReturnValue({ get: mockGet });
+
+    renderHook(() => useNetworkStatus());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/health', expect.objectContaining({ timeout: 5000 }));
+  });
+
+  it('sets isApiReachable(true) when the health probe succeeds', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
+    (getApiClient as any).mockReturnValue({ get: mockGet });
+    const { setApiReachable } = buildStoreMock();
+
+    renderHook(() => useNetworkStatus());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(setApiReachable).toHaveBeenCalledWith(true);
+  });
+
+  it('sets isApiReachable(false) when the health probe fails', async () => {
+    const mockGet = vi.fn().mockRejectedValue(new Error('Network Error'));
+    (getApiClient as any).mockReturnValue({ get: mockGet });
+    const { setApiReachable } = buildStoreMock();
+
+    renderHook(() => useNetworkStatus());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(setApiReachable).toHaveBeenCalledWith(false);
+  });
+
+  it('does NOT probe the API when offline', async () => {
+    buildStoreMock({ isOnline: false });
+    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
+    (getApiClient as any).mockReturnValue({ get: mockGet });
+
+    renderHook(() => useNetworkStatus());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // The periodic effect only runs when isOnline is true – so get should
+    // never be called when starting offline.
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  // ── network-unreachable custom event ──────────────────────────────────────
+
+  it('registers a network-unreachable event listener', () => {
+    renderHook(() => useNetworkStatus());
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'network-unreachable',
+      expect.any(Function)
+    );
+  });
+
+  it('sets isApiReachable(false) when network-unreachable fires', () => {
+    const { setApiReachable } = buildStoreMock();
+    renderHook(() => useNetworkStatus());
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('network-unreachable'));
+    });
+
+    expect(setApiReachable).toHaveBeenCalledWith(false);
+  });
+
+  it('removes network-unreachable listener on unmount', () => {
+    const { unmount } = renderHook(() => useNetworkStatus());
+    unmount();
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'network-unreachable',
+      expect.any(Function)
+    );
+  });
+
+  // ── recheckApi ────────────────────────────────────────────────────────────
+
+  it('exposes recheckApi as a function', () => {
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(typeof result.current.recheckApi).toBe('function');
+  });
+
+  it('recheckApi triggers an API probe and resolves', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
+    (getApiClient as any).mockReturnValue({ get: mockGet });
+
+    const { result } = renderHook(() => useNetworkStatus());
+
+    await act(async () => {
+      await result.current.recheckApi();
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/health', expect.objectContaining({ timeout: 5000 }));
+  });
+});

--- a/FrontEnd/my-app/lib/hooks/useNetworkStatus.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useNetworkStatus.test.ts
@@ -10,41 +10,31 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useNetworkStatus } from './useNetworkStatus';
-import { useStore } from '@/lib/store';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
+// Stable mock state object – mutate fields per test instead of recreating
+// the mock on every selector call (which would cause infinite re-renders).
+const mockState = {
+  isOnline: true,
+  isApiReachable: true,
+  setOnlineStatus: vi.fn(),
+  setApiReachable: vi.fn(),
+};
+
 vi.mock('@/lib/store', () => ({
-  useStore: vi.fn(),
+  useStore: (selector: (s: typeof mockState) => unknown) => selector(mockState),
 }));
+
+const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
 
 vi.mock('../api/client', () => ({
-  getApiClient: vi.fn(() => ({
-    get: vi.fn().mockResolvedValue({ data: { status: 'ok' } }),
-  })),
+  getApiClient: () => ({ get: mockGet }),
 }));
-
-import { getApiClient } from '../api/client';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function buildStoreMock(overrides?: Partial<ReturnType<typeof buildStoreMock>>) {
-  const mock = {
-    isOnline: true,
-    isApiReachable: true,
-    setOnlineStatus: vi.fn(),
-    setApiReachable: vi.fn(),
-    ...overrides,
-  };
-  (useStore as any).mockImplementation((selector: any) => selector(mock));
-  return mock;
-}
 
 // ---------------------------------------------------------------------------
 // Test suite
@@ -55,7 +45,13 @@ describe('useNetworkStatus', () => {
     vi.useFakeTimers();
     vi.spyOn(window, 'addEventListener');
     vi.spyOn(window, 'removeEventListener');
-    buildStoreMock();
+
+    // Reset mock state to defaults
+    mockState.isOnline = true;
+    mockState.isApiReachable = true;
+    mockState.setOnlineStatus = vi.fn();
+    mockState.setApiReachable = vi.fn();
+    mockGet.mockResolvedValue({ data: { status: 'ok' } });
   });
 
   afterEach(() => {
@@ -66,13 +62,13 @@ describe('useNetworkStatus', () => {
   // ── initial state ─────────────────────────────────────────────────────────
 
   it('sets initial online status from navigator.onLine on mount', () => {
-    const { setOnlineStatus } = buildStoreMock();
     renderHook(() => useNetworkStatus());
-    expect(setOnlineStatus).toHaveBeenCalledWith(navigator.onLine);
+    expect(mockState.setOnlineStatus).toHaveBeenCalledWith(navigator.onLine);
   });
 
   it('returns isOnline and isApiReachable from the store', () => {
-    buildStoreMock({ isOnline: true, isApiReachable: false });
+    mockState.isOnline = true;
+    mockState.isApiReachable = false;
     const { result } = renderHook(() => useNetworkStatus());
     expect(result.current.isOnline).toBe(true);
     expect(result.current.isApiReachable).toBe(false);
@@ -106,84 +102,61 @@ describe('useNetworkStatus', () => {
   });
 
   it('calls setOnlineStatus(true) when the online event fires', () => {
-    const { setOnlineStatus } = buildStoreMock();
     renderHook(() => useNetworkStatus());
-
     act(() => {
       window.dispatchEvent(new Event('online'));
     });
-
-    expect(setOnlineStatus).toHaveBeenCalledWith(true);
+    expect(mockState.setOnlineStatus).toHaveBeenCalledWith(true);
   });
 
-  it('calls setOnlineStatus(false) and setApiReachable(false) when the offline event fires', () => {
-    const { setOnlineStatus, setApiReachable } = buildStoreMock();
+  it('calls setOnlineStatus(false) and setApiReachable(false) when offline event fires', () => {
     renderHook(() => useNetworkStatus());
-
     act(() => {
       window.dispatchEvent(new Event('offline'));
     });
-
-    expect(setOnlineStatus).toHaveBeenCalledWith(false);
-    expect(setApiReachable).toHaveBeenCalledWith(false);
+    expect(mockState.setOnlineStatus).toHaveBeenCalledWith(false);
+    expect(mockState.setApiReachable).toHaveBeenCalledWith(false);
   });
 
   // ── API health probe ──────────────────────────────────────────────────────
 
   it('fires an API health probe immediately when online', async () => {
-    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
-    (getApiClient as any).mockReturnValue({ get: mockGet });
-
     renderHook(() => useNetworkStatus());
-
     await act(async () => {
       await vi.runAllTimersAsync();
     });
-
-    expect(mockGet).toHaveBeenCalledWith('/health', expect.objectContaining({ timeout: 5000 }));
+    expect(mockGet).toHaveBeenCalledWith(
+      '/health',
+      expect.objectContaining({ timeout: 5000 })
+    );
   });
 
   it('sets isApiReachable(true) when the health probe succeeds', async () => {
-    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
-    (getApiClient as any).mockReturnValue({ get: mockGet });
-    const { setApiReachable } = buildStoreMock();
-
+    mockGet.mockResolvedValue({ data: { status: 'ok' } });
     renderHook(() => useNetworkStatus());
-
     await act(async () => {
       await vi.runAllTimersAsync();
     });
-
-    expect(setApiReachable).toHaveBeenCalledWith(true);
+    expect(mockState.setApiReachable).toHaveBeenCalledWith(true);
   });
 
   it('sets isApiReachable(false) when the health probe fails', async () => {
-    const mockGet = vi.fn().mockRejectedValue(new Error('Network Error'));
-    (getApiClient as any).mockReturnValue({ get: mockGet });
-    const { setApiReachable } = buildStoreMock();
-
+    mockGet.mockRejectedValue(new Error('Network Error'));
     renderHook(() => useNetworkStatus());
-
     await act(async () => {
       await vi.runAllTimersAsync();
     });
-
-    expect(setApiReachable).toHaveBeenCalledWith(false);
+    expect(mockState.setApiReachable).toHaveBeenCalledWith(false);
   });
 
   it('does NOT probe the API when offline', async () => {
-    buildStoreMock({ isOnline: false });
-    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
-    (getApiClient as any).mockReturnValue({ get: mockGet });
-
+    mockState.isOnline = false;
+    mockGet.mockClear();
     renderHook(() => useNetworkStatus());
-
     await act(async () => {
       await vi.runAllTimersAsync();
     });
-
-    // The periodic effect only runs when isOnline is true – so get should
-    // never be called when starting offline.
+    // Periodic effect only runs when storeIsOnline is true.
     expect(mockGet).not.toHaveBeenCalled();
   });
 
@@ -198,14 +171,11 @@ describe('useNetworkStatus', () => {
   });
 
   it('sets isApiReachable(false) when network-unreachable fires', () => {
-    const { setApiReachable } = buildStoreMock();
     renderHook(() => useNetworkStatus());
-
     act(() => {
       window.dispatchEvent(new CustomEvent('network-unreachable'));
     });
-
-    expect(setApiReachable).toHaveBeenCalledWith(false);
+    expect(mockState.setApiReachable).toHaveBeenCalledWith(false);
   });
 
   it('removes network-unreachable listener on unmount', () => {
@@ -225,15 +195,13 @@ describe('useNetworkStatus', () => {
   });
 
   it('recheckApi triggers an API probe and resolves', async () => {
-    const mockGet = vi.fn().mockResolvedValue({ data: { status: 'ok' } });
-    (getApiClient as any).mockReturnValue({ get: mockGet });
-
     const { result } = renderHook(() => useNetworkStatus());
-
     await act(async () => {
       await result.current.recheckApi();
     });
-
-    expect(mockGet).toHaveBeenCalledWith('/health', expect.objectContaining({ timeout: 5000 }));
+    expect(mockGet).toHaveBeenCalledWith(
+      '/health',
+      expect.objectContaining({ timeout: 5000 })
+    );
   });
 });

--- a/FrontEnd/my-app/lib/hooks/useNetworkStatus.ts
+++ b/FrontEnd/my-app/lib/hooks/useNetworkStatus.ts
@@ -1,20 +1,75 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { getApiClient } from '../api/client';
+/**
+ * useNetworkStatus – FE-027
+ *
+ * Provides a unified view of:
+ *  1. Browser connectivity  (`isOnline`)
+ *  2. API base-URL reachability (`isApiReachable`)
+ *
+ * Both values are kept in sync with the global Zustand store so any
+ * component can subscribe without re-mounting this hook.
+ *
+ * Behaviour:
+ * - While offline, the API reachability check is skipped.
+ * - When the browser comes back online, an immediate API probe is fired.
+ * - A periodic health check runs every HEALTH_CHECK_INTERVAL_MS while online.
+ * - Consumers can call `recheckApi()` to trigger an on-demand probe.
+ */
 
-export function useNetworkStatus() {
-  const [isOnline, setIsOnline] = useState<boolean>(
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getApiClient } from '../api/client';
+import { useStore } from '@/lib/store';
+
+const HEALTH_CHECK_INTERVAL_MS = 30_000;
+const HEALTH_CHECK_TIMEOUT_MS = 5_000;
+
+export interface NetworkStatus {
+  /** True when `navigator.onLine` is true and no offline event has fired. */
+  isOnline: boolean;
+  /**
+   * True when the API `/health` endpoint responded successfully.
+   * Remains `true` on the first render until the first probe completes, to
+   * avoid a flash of the offline banner.
+   */
+  isApiReachable: boolean;
+  /** Fire an on-demand API reachability probe. */
+  recheckApi: () => Promise<void>;
+}
+
+export function useNetworkStatus(): NetworkStatus {
+  const setOnlineStatus = useStore((s) => s.setOnlineStatus);
+  const setApiReachable = useStore((s) => s.setApiReachable);
+
+  const storeIsOnline = useStore((s) => s.isOnline);
+  const storeIsApiReachable = useStore((s) => s.isApiReachable);
+
+  // Local shadow of `isOnline` so we can read it synchronously inside
+  // callbacks without stale closure issues.
+  const isOnlineRef = useRef<boolean>(
     typeof navigator !== 'undefined' ? navigator.onLine : true
   );
-  const [isApiReachable, setIsApiReachable] = useState<boolean>(true);
+
+  // -----------------------------------------------------------------------
+  // Browser online / offline events
+  // -----------------------------------------------------------------------
 
   useEffect(() => {
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => {
-      setIsOnline(false);
-      setIsApiReachable(false);
+    const handleOnline = () => {
+      isOnlineRef.current = true;
+      setOnlineStatus(true);
     };
+
+    const handleOffline = () => {
+      isOnlineRef.current = false;
+      setOnlineStatus(false);
+      // When we go offline the API is immediately unreachable.
+      setApiReachable(false);
+    };
+
+    // Sync initial state in case it changed before mount.
+    isOnlineRef.current = navigator.onLine;
+    setOnlineStatus(navigator.onLine);
 
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
@@ -23,25 +78,60 @@ export function useNetworkStatus() {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, []);
+  }, [setOnlineStatus, setApiReachable]);
+
+  // -----------------------------------------------------------------------
+  // API health probe
+  // -----------------------------------------------------------------------
+
+  const probeApi = useCallback(async () => {
+    if (!isOnlineRef.current) return;
+
+    try {
+      await getApiClient().get('/health', {
+        timeout: HEALTH_CHECK_TIMEOUT_MS,
+      });
+      setApiReachable(true);
+    } catch {
+      setApiReachable(false);
+    }
+  }, [setApiReachable]);
+
+  // -----------------------------------------------------------------------
+  // Periodic health checks + immediate probe when coming back online
+  // -----------------------------------------------------------------------
 
   useEffect(() => {
-    if (!isOnline) return;
+    if (!storeIsOnline) return;
 
-    const checkApiHealth = async () => {
-      try {
-        await getApiClient().get('/health', { timeout: 5000 });
-        setIsApiReachable(true);
-      } catch (err) {
-        setIsApiReachable(false);
-      }
+    // Fire immediately when we (re-)go online.
+    probeApi();
+
+    const interval = setInterval(probeApi, HEALTH_CHECK_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [storeIsOnline, probeApi]);
+
+  // -----------------------------------------------------------------------
+  // network-unreachable custom event emitted by the Axios client
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    const handleNetworkUnreachable = () => {
+      setApiReachable(false);
     };
 
-    checkApiHealth();
-    const interval = setInterval(checkApiHealth, 30000);
+    window.addEventListener('network-unreachable', handleNetworkUnreachable);
+    return () => {
+      window.removeEventListener(
+        'network-unreachable',
+        handleNetworkUnreachable
+      );
+    };
+  }, [setApiReachable]);
 
-    return () => clearInterval(interval);
-  }, [isOnline]);
-
-  return { isOnline, isApiReachable };
+  return {
+    isOnline: storeIsOnline,
+    isApiReachable: storeIsApiReachable,
+    recheckApi: probeApi,
+  };
 }

--- a/FrontEnd/my-app/lib/hooks/useNetworkStatus.ts
+++ b/FrontEnd/my-app/lib/hooks/useNetworkStatus.ts
@@ -17,7 +17,7 @@
  * - Consumers can call `recheckApi()` to trigger an on-demand probe.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { getApiClient } from '../api/client';
 import { useStore } from '@/lib/store';
 
@@ -40,12 +40,16 @@ export interface NetworkStatus {
 export function useNetworkStatus(): NetworkStatus {
   const setOnlineStatus = useStore((s) => s.setOnlineStatus);
   const setApiReachable = useStore((s) => s.setApiReachable);
-
   const storeIsOnline = useStore((s) => s.isOnline);
   const storeIsApiReachable = useStore((s) => s.isApiReachable);
 
-  // Local shadow of `isOnline` so we can read it synchronously inside
-  // callbacks without stale closure issues.
+  // Keep a stable ref to the store setters so probeApi never needs to be
+  // recreated just because the selector reference changed.
+  const setApiReachableRef = useRef(setApiReachable);
+  setApiReachableRef.current = setApiReachable;
+
+  // isOnlineRef lets us read the current value synchronously inside callbacks
+  // without a stale-closure issue.
   const isOnlineRef = useRef<boolean>(
     typeof navigator !== 'undefined' ? navigator.onLine : true
   );
@@ -64,7 +68,7 @@ export function useNetworkStatus(): NetworkStatus {
       isOnlineRef.current = false;
       setOnlineStatus(false);
       // When we go offline the API is immediately unreachable.
-      setApiReachable(false);
+      setApiReachableRef.current(false);
     };
 
     // Sync initial state in case it changed before mount.
@@ -78,10 +82,10 @@ export function useNetworkStatus(): NetworkStatus {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, [setOnlineStatus, setApiReachable]);
+  }, [setOnlineStatus]);
 
   // -----------------------------------------------------------------------
-  // API health probe
+  // API health probe — stable, never recreated
   // -----------------------------------------------------------------------
 
   const probeApi = useCallback(async () => {
@@ -91,11 +95,11 @@ export function useNetworkStatus(): NetworkStatus {
       await getApiClient().get('/health', {
         timeout: HEALTH_CHECK_TIMEOUT_MS,
       });
-      setApiReachable(true);
+      setApiReachableRef.current(true);
     } catch {
-      setApiReachable(false);
+      setApiReachableRef.current(false);
     }
-  }, [setApiReachable]);
+  }, []); // intentionally empty — stable for the lifetime of the hook
 
   // -----------------------------------------------------------------------
   // Periodic health checks + immediate probe when coming back online
@@ -117,7 +121,7 @@ export function useNetworkStatus(): NetworkStatus {
 
   useEffect(() => {
     const handleNetworkUnreachable = () => {
-      setApiReachable(false);
+      setApiReachableRef.current(false);
     };
 
     window.addEventListener('network-unreachable', handleNetworkUnreachable);
@@ -127,7 +131,7 @@ export function useNetworkStatus(): NetworkStatus {
         handleNetworkUnreachable
       );
     };
-  }, [setApiReachable]);
+  }, []);
 
   return {
     isOnline: storeIsOnline,

--- a/FrontEnd/my-app/lib/store/slices/uiSlice.ts
+++ b/FrontEnd/my-app/lib/store/slices/uiSlice.ts
@@ -5,6 +5,8 @@ export interface UISlice {
   sidebarOpen: boolean;
   modal: string | null;
   isOnline: boolean;
+  /** Whether the backend API base URL is currently reachable. */
+  isApiReachable: boolean;
   hasRetryableError: boolean;
   retryFunction: (() => Promise<void>) | null;
 
@@ -13,6 +15,7 @@ export interface UISlice {
   openModal: (modal: string) => void;
   closeModal: () => void;
   setOnlineStatus: (isOnline: boolean) => void;
+  setApiReachable: (reachable: boolean) => void;
   setRetryableError: (hasError: boolean, retryFn?: () => Promise<void>) => void;
   clearRetryableError: () => void;
 }
@@ -22,6 +25,7 @@ export const createUISlice: StateCreator<UISlice> = (set) => ({
   sidebarOpen: false,
   modal: null,
   isOnline: typeof navigator !== 'undefined' ? navigator.onLine : true,
+  isApiReachable: true,
   hasRetryableError: false,
   retryFunction: null,
 
@@ -33,6 +37,8 @@ export const createUISlice: StateCreator<UISlice> = (set) => ({
   closeModal: () => set({ modal: null }),
 
   setOnlineStatus: (isOnline) => set({ isOnline }),
+
+  setApiReachable: (isApiReachable) => set({ isApiReachable }),
 
   setRetryableError: (hasError, retryFn) =>
     set({


### PR DESCRIPTION
## Summary

Closes #816

This PR implements [FE-027] — proper fallback behaviour when the application is offline or the API base URL is unreachable, replacing the previous no-op state with a fully wired, store-backed solution.

---

## Problem

Previously the app had no cohesive handling for the two distinct connectivity failure modes:

1. **Device offline** — `navigator.onLine === false`
2. **Device online but API unreachable** — network request fails with `ERR_NETWORK` / timeout

The existing `useNetworkStatus` hook tracked these states locally but never synced them to the global store, so no UI could react to them. The `OfflineFallback` component existed but was never mounted anywhere.

---

## Changes

### `lib/store/slices/uiSlice.ts`
- Added `isApiReachable: boolean` field and `setApiReachable()` action to the Zustand store so any component tree can subscribe to API reachability without prop drilling.

### `lib/hooks/useNetworkStatus.ts` (rewritten)
- Syncs both `isOnline` and `isApiReachable` into the global store.
- Listens to the `network-unreachable` custom event already dispatched by the Axios client interceptor.
- Runs a periodic `/health` probe (every 30 s) when online; fires immediately on reconnect.
- Skips probing entirely when offline to avoid noise.
- Exposes `recheckApi()` for on-demand probing (used by retry buttons).

### `components/error/ApiUnreachableFallback.tsx` *(new)*
- Full-page fallback shown when the device has internet but the API is unreachable.
- Distinct from `OfflineFallback` — different icon, copy, and user guidance.
- Accessible: `role="status"`, `aria-live="polite"`, spinner state on retry button.

### `components/error/OfflineFallback.tsx`
- Added `role="status"` and `aria-live="polite"` for screen-reader compatibility.
- Added `aria-hidden` on decorative icons.

### `components/providers/OfflineModeProvider.tsx` *(new)*
- Mounts `useNetworkStatus` once at the provider level.
- Gates children: renders `OfflineFallback` when offline, `ApiUnreachableFallback` when online-but-unreachable, children otherwise.
- Accepts an `enabled` prop (defaults `true`) to opt out in tests/Storybook.

### `app/providers/RootProviders.tsx`
- Wraps `<A11yAnnouncerProvider>` (and therefore all page content) with `<OfflineModeProvider>`.

### `components/error/index.ts`
- Exports `OfflineFallback` and `ApiUnreachableFallback`.

### Tests
- `lib/hooks/useNetworkStatus.test.ts` — covers initial sync, online/offline events, API probe success/failure, `network-unreachable` event, skipping probe when offline, and `recheckApi()`.
- `components/error/ApiUnreachableFallback.test.tsx` — rendering, retry callback, checking state, accessibility attributes.
- `components/providers/OfflineModeProvider.test.tsx` — all three render paths (children / offline fallback / API fallback), retry wiring, `enabled=false` bypass.

---

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Offline device shows `OfflineFallback` | ✅ |
| Online but API unreachable shows `ApiUnreachableFallback` | ✅ |
| Both reachable renders app normally | ✅ |
| Retry button triggers re-probe | ✅ |
| `isApiReachable` persisted in global store | ✅ |
| Axios `network-unreachable` event consumed | ✅ |
| Accessibility (roles, aria-live, aria-hidden) | ✅ |
| Unit tests added | ✅ |
| No regression to existing functionality | ✅ |
| Code follows project conventions (Zustand slices, hooks, providers) | ✅ |