### PR TITLE
feat(BE-027): Add startup readiness checklist log (DB/Redis/queue/keys)

### DIFF
--- a/BackEnd/src/app.module.ts
+++ b/BackEnd/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppLoggerService } from './common/logger/logger.service';
 import { SecurityMiddleware } from './common/middleware/security.middleware';
 import { dataSourceOptions } from './database/data-source';
 import { LoggerModule } from './common/logger/logger.module';
+import { StartupReadinessService } from './common/services/startup-readiness.service';
 
 import { AdminModule } from './modules/admin/admin.module';
 import { AnalyticsModule } from './modules/analytics/analytics.module';
@@ -72,6 +73,7 @@ import { EventsModule } from './events/events.module';
     AppService,
     AppLoggerService,
     SecurityMiddleware,
+    StartupReadinessService,
     {
       provide: APP_INTERCEPTOR,
       useClass: TraceInterceptor,

--- a/BackEnd/src/common/services/startup-readiness.service.spec.ts
+++ b/BackEnd/src/common/services/startup-readiness.service.spec.ts
@@ -1,0 +1,281 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StartupReadinessService } from './startup-readiness.service';
+import { DataSource } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { Cache } from 'cache-manager';
+
+describe('StartupReadinessService', () => {
+  let service: StartupReadinessService;
+  let mockDataSource: jest.Mocked<DataSource>;
+  let mockCacheManager: jest.Mocked<Cache>;
+  let mockConfigService: jest.Mocked<ConfigService>;
+
+  beforeEach(async () => {
+    mockDataSource = {
+      query: jest.fn(),
+    } as any;
+
+    mockCacheManager = {
+      stores: [
+        {
+          getClient: jest.fn(() => ({
+            ping: jest.fn().mockResolvedValue('PONG'),
+          })),
+        },
+      ],
+    } as any;
+
+    mockConfigService = {
+      get: jest.fn((key: string) => {
+        if (key === 'NODE_ENV') return 'test';
+        return undefined;
+      }),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StartupReadinessService,
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<StartupReadinessService>(StartupReadinessService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('checkEnvironmentVariables', () => {
+    it('should return ok when all required keys are present', async () => {
+    process.env.DATABASE_URL = 'postgres://localhost/test';
+    process.env.JWT_SECRET = 'test-secret';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    process.env.STELLAR_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+    const result = await service['checkEnvironmentVariables']();
+
+    expect(result.component).toBe('Environment Variables (Keys)');
+    expect(result.status).toBe('ok');
+    expect(result.details?.requiredKeys).toBe(2);
+
+    delete process.env.REDIS_URL;
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+  });
+
+    it('should return down when required keys are missing', async () => {
+      delete process.env.DATABASE_URL;
+      delete process.env.JWT_SECRET;
+
+      const result = await service['checkEnvironmentVariables']();
+
+      expect(result.component).toBe('Environment Variables (Keys)');
+      expect(result.status).toBe('down');
+      expect(result.error).toContain('Missing required keys');
+    });
+
+    it('should return degraded when only optional keys are missing', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      process.env.JWT_SECRET = 'test-secret-key';
+      delete process.env.REDIS_URL;
+
+      const result = await service['checkEnvironmentVariables']();
+
+      expect(result.component).toBe('Environment Variables (Keys)');
+      expect(result.status).toBe('degraded');
+      expect(result.error).toContain('Missing optional keys');
+    });
+  });
+
+  describe('checkDatabase', () => {
+    it('should return ok when database is accessible', async () => {
+      mockDataSource.query.mockResolvedValue([{ result: 1 }]);
+
+      const result = await service['checkDatabase']();
+
+      expect(result.component).toBe('Database (PostgreSQL)');
+      expect(result.status).toBe('ok');
+      expect(mockDataSource.query).toHaveBeenCalledWith('SELECT 1');
+    });
+
+    it('should return down when database query times out', async () => {
+      mockDataSource.query.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 10000)),
+      );
+
+      const result = await service['checkDatabase']();
+
+      expect(result.component).toBe('Database (PostgreSQL)');
+      expect(result.status).toBe('down');
+      expect(result.error).toContain('timeout');
+    }, 6000);
+
+    it('should return down when database query fails', async () => {
+      mockDataSource.query.mockRejectedValue(new Error('Connection failed'));
+
+      const result = await service['checkDatabase']();
+
+      expect(result.component).toBe('Database (PostgreSQL)');
+      expect(result.status).toBe('down');
+      expect(result.error).toBe('Connection failed');
+    });
+  });
+
+  describe('checkCache', () => {
+    it('should return ok when Redis is accessible', async () => {
+      const result = await service['checkCache']();
+
+      expect(result.component).toBe('Redis/Cache');
+      expect(result.status).toBe('ok');
+    });
+
+    it('should return degraded when Redis client is not available', async () => {
+      mockCacheManager.stores = [];
+
+      const result = await service['checkCache']();
+
+      expect(result.component).toBe('Redis/Cache');
+      expect(result.status).toBe('degraded');
+      expect(result.error).toContain('Redis client not available');
+    });
+
+    it('should return degraded when Redis ping times out', async () => {
+      (mockCacheManager as any).stores = [
+        {
+          getClient: jest.fn(() => ({
+            ping: jest.fn(
+              () => new Promise((resolve) => setTimeout(resolve, 10000)),
+            ),
+          })),
+        },
+      ];
+
+      const result = await service['checkCache']();
+
+      expect(result.component).toBe('Redis/Cache');
+      expect(result.status).toBe('degraded');
+      expect(result.error).toContain('timeout');
+    }, 6000);
+  });
+
+  describe('checkQueue', () => {
+    it('should return ok when queue backend is accessible', async () => {
+      const result = await service['checkQueue']();
+
+      expect(result.component).toBe('Queue (BullMQ)');
+      expect(result.status).toBe('ok');
+      expect(result.details?.backend).toBe('Redis');
+    });
+
+    it('should return degraded when Redis client is not available', async () => {
+      mockCacheManager.stores = [];
+
+      const result = await service['checkQueue']();
+
+      expect(result.component).toBe('Queue (BullMQ)');
+      expect(result.status).toBe('degraded');
+      expect(result.error).toContain('Redis client not available');
+    });
+  });
+
+  describe('runStartupReadinessCheck', () => {
+    it('should return ready status when all checks pass', async () => {
+      process.env.DATABASE_URL = 'postgres://localhost/test';
+      process.env.JWT_SECRET = 'test-secret';
+      process.env.REDIS_URL = 'redis://localhost:6379';
+      process.env.STELLAR_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+      const report = await service.runStartupReadinessCheck();
+
+      expect(report.overallStatus).toBe('ready');
+      expect(report.checks).toHaveLength(4);
+      expect(report.checks.every((c) => c.status === 'ok')).toBe(true);
+
+      delete process.env.REDIS_URL;
+      delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    });
+
+    it('should return degraded status when some checks are degraded', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      process.env.JWT_SECRET = 'test-secret-key';
+      mockDataSource.query.mockResolvedValue([{ result: 1 }]);
+      mockCacheManager.stores = [];
+
+      const report = await service.runStartupReadinessCheck();
+
+      expect(report.overallStatus).toBe('degraded');
+      expect(report.checks.some((c) => c.status === 'degraded')).toBe(true);
+    });
+
+    it('should throw error when critical checks fail', async () => {
+      delete process.env.DATABASE_URL;
+      delete process.env.JWT_SECRET;
+
+      await expect(service.runStartupReadinessCheck()).rejects.toThrow(
+        'Startup readiness check failed',
+      );
+    });
+
+    it('should include all required fields in report', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      process.env.JWT_SECRET = 'test-secret-key';
+      mockDataSource.query.mockResolvedValue([{ result: 1 }]);
+
+      const report = await service.runStartupReadinessCheck();
+
+      expect(report).toHaveProperty('timestamp');
+      expect(report).toHaveProperty('environment');
+      expect(report).toHaveProperty('overallStatus');
+      expect(report).toHaveProperty('checks');
+      expect(report).toHaveProperty('totalDurationMs');
+    });
+  });
+
+  describe('calculateOverallStatus', () => {
+    it('should return ready when all checks are ok', () => {
+      const checks = [
+        { component: 'Test', status: 'ok' as const },
+        { component: 'Test2', status: 'ok' as const },
+      ];
+
+      const status = service['calculateOverallStatus'](checks);
+      expect(status).toBe('ready');
+    });
+
+    it('should return degraded when some checks are degraded', () => {
+      const checks = [
+        { component: 'Test', status: 'ok' as const },
+        { component: 'Test2', status: 'degraded' as const },
+      ];
+
+      const status = service['calculateOverallStatus'](checks);
+      expect(status).toBe('degraded');
+    });
+
+    it('should return not_ready when any check is down', () => {
+      const checks = [
+        { component: 'Test', status: 'ok' as const },
+        { component: 'Test2', status: 'down' as const },
+      ];
+
+      const status = service['calculateOverallStatus'](checks);
+      expect(status).toBe('not_ready');
+    });
+  });
+});

--- a/BackEnd/src/common/services/startup-readiness.service.ts
+++ b/BackEnd/src/common/services/startup-readiness.service.ts
@@ -1,0 +1,363 @@
+import { Injectable, Logger, OnModuleInit, Inject } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { ConfigService } from '@nestjs/config';
+
+export interface ReadinessCheckResult {
+  component: string;
+  status: 'ok' | 'degraded' | 'down';
+  latency?: number;
+  error?: string;
+  details?: Record<string, any>;
+}
+
+export interface StartupReadinessReport {
+  timestamp: string;
+  environment: string;
+  overallStatus: 'ready' | 'degraded' | 'not_ready';
+  checks: ReadinessCheckResult[];
+  totalDurationMs: number;
+}
+
+@Injectable()
+export class StartupReadinessService implements OnModuleInit {
+  private readonly logger = new Logger(StartupReadinessService.name);
+
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async onModuleInit() {
+    await this.runStartupReadinessCheck();
+  }
+
+  async runStartupReadinessCheck(): Promise<StartupReadinessReport> {
+    const startTime = Date.now();
+    this.logger.log('🚀 Starting startup readiness checklist...');
+
+    const checks: ReadinessCheckResult[] = [];
+
+    // Check 1: Environment Variables (Keys)
+    checks.push(await this.checkEnvironmentVariables());
+
+    // Check 2: Database
+    checks.push(await this.checkDatabase());
+
+    // Check 3: Redis/Cache
+    checks.push(await this.checkCache());
+
+    // Check 4: Queue (Redis connection for BullMQ)
+    checks.push(await this.checkQueue());
+
+    const totalDurationMs = Date.now() - startTime;
+    const overallStatus = this.calculateOverallStatus(checks);
+
+    const report: StartupReadinessReport = {
+      timestamp: new Date().toISOString(),
+      environment: this.configService.get('NODE_ENV') || 'development',
+      overallStatus,
+      checks,
+      totalDurationMs,
+    };
+
+    this.logReadinessReport(report);
+
+    // If not ready, throw error to prevent startup
+    if (overallStatus === 'not_ready') {
+      const criticalFailures = checks
+        .filter((c) => c.status === 'down')
+        .map((c) => `${c.component}: ${c.error}`)
+        .join(', ');
+      throw new Error(
+        `Startup readiness check failed. Critical dependencies unavailable: ${criticalFailures}`,
+      );
+    }
+
+    return report;
+  }
+
+  private async checkEnvironmentVariables(): Promise<ReadinessCheckResult> {
+    const startTime = Date.now();
+    const requiredKeys = ['DATABASE_URL', 'JWT_SECRET'];
+    const optionalKeys = ['REDIS_URL', 'STELLAR_NETWORK_PASSPHRASE'];
+
+    try {
+      const missing: string[] = [];
+      const warnings: string[] = [];
+
+      for (const key of requiredKeys) {
+        if (!process.env[key]) {
+          missing.push(key);
+        }
+      }
+
+      for (const key of optionalKeys) {
+        if (!process.env[key]) {
+          warnings.push(key);
+        }
+      }
+
+      const latency = Date.now() - startTime;
+
+      if (missing.length > 0) {
+        return {
+          component: 'Environment Variables (Keys)',
+          status: 'down',
+          latency,
+          error: `Missing required keys: ${missing.join(', ')}`,
+          details: { missing, warnings },
+        };
+      }
+
+      if (warnings.length > 0) {
+        return {
+          component: 'Environment Variables (Keys)',
+          status: 'degraded',
+          latency,
+          error: `Missing optional keys: ${warnings.join(', ')}`,
+          details: { warnings },
+        };
+      }
+
+      return {
+        component: 'Environment Variables (Keys)',
+        status: 'ok',
+        latency,
+        details: { requiredKeys: requiredKeys.length, optionalKeys: optionalKeys.length },
+      };
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      return {
+        component: 'Environment Variables (Keys)',
+        status: 'down',
+        latency,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async checkDatabase(): Promise<ReadinessCheckResult> {
+    const startTime = Date.now();
+    const timeoutMs = 5000;
+
+    try {
+      const result = await Promise.race([
+        this.dataSource.query('SELECT 1'),
+        this.timeoutPromise(timeoutMs),
+      ]);
+
+      if (result === null) {
+        const latency = Date.now() - startTime;
+        return {
+          component: 'Database (PostgreSQL)',
+          status: 'down',
+          latency,
+          error: `Connection timeout after ${timeoutMs}ms`,
+        };
+      }
+
+      const latency = Date.now() - startTime;
+      return {
+        component: 'Database (PostgreSQL)',
+        status: 'ok',
+        latency,
+        details: { query: 'SELECT 1' },
+      };
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      return {
+        component: 'Database (PostgreSQL)',
+        status: 'down',
+        latency,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async checkCache(): Promise<ReadinessCheckResult> {
+    const startTime = Date.now();
+    const timeoutMs = 3000;
+
+    try {
+      const client = await this.getRedisClient();
+
+      if (!client) {
+        const latency = Date.now() - startTime;
+        return {
+          component: 'Redis/Cache',
+          status: 'degraded',
+          latency,
+          error: 'Redis client not available (using memory store)',
+        };
+      }
+
+      const result = await Promise.race([
+        client.ping ? client.ping() : Promise.resolve('PONG'),
+        this.timeoutPromise(timeoutMs),
+      ]);
+
+      if (result === null) {
+        const latency = Date.now() - startTime;
+        return {
+          component: 'Redis/Cache',
+          status: 'degraded',
+          latency,
+          error: `Ping timeout after ${timeoutMs}ms`,
+        };
+      }
+
+      const latency = Date.now() - startTime;
+      return {
+        component: 'Redis/Cache',
+        status: 'ok',
+        latency,
+        details: { ping: result },
+      };
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      return {
+        component: 'Redis/Cache',
+        status: 'degraded',
+        latency,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async checkQueue(): Promise<ReadinessCheckResult> {
+    const startTime = Date.now();
+    const timeoutMs = 3000;
+
+    try {
+      const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+
+      // Try to connect to Redis to verify queue backend
+      const client = await this.getRedisClient();
+
+      if (!client) {
+        const latency = Date.now() - startTime;
+        return {
+          component: 'Queue (BullMQ)',
+          status: 'degraded',
+          latency,
+          error: 'Redis client not available for queue operations',
+          details: { redisUrl },
+        };
+      }
+
+      const result = await Promise.race([
+        client.ping ? client.ping() : Promise.resolve('PONG'),
+        this.timeoutPromise(timeoutMs),
+      ]);
+
+      if (result === null) {
+        const latency = Date.now() - startTime;
+        return {
+          component: 'Queue (BullMQ)',
+          status: 'degraded',
+          latency,
+          error: `Queue backend timeout after ${timeoutMs}ms`,
+          details: { redisUrl },
+        };
+      }
+
+      const latency = Date.now() - startTime;
+      return {
+        component: 'Queue (BullMQ)',
+        status: 'ok',
+        latency,
+        details: { redisUrl, backend: 'Redis' },
+      };
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      return {
+        component: 'Queue (BullMQ)',
+        status: 'degraded',
+        latency,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private getRedisClient(): any {
+    try {
+      const store =
+        (this.cacheManager as any).stores?.[0] ?? (this.cacheManager as any).store;
+      const client = store?.getClient
+        ? store.getClient()
+        : store?.client
+          ? store.client
+          : null;
+
+      if (client && typeof client.ping === 'function') {
+        return client;
+      }
+    } catch (e) {
+      // Ignore errors
+    }
+
+    return null;
+  }
+
+  private timeoutPromise(ms: number): Promise<null> {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(null), ms);
+    });
+  }
+
+  private calculateOverallStatus(checks: ReadinessCheckResult[]): 'ready' | 'degraded' | 'not_ready' {
+    const hasDown = checks.some((c) => c.status === 'down');
+    const hasDegraded = checks.some((c) => c.status === 'degraded');
+
+    if (hasDown) {
+      return 'not_ready';
+    }
+
+    if (hasDegraded) {
+      return 'degraded';
+    }
+
+    return 'ready';
+  }
+
+  private logReadinessReport(report: StartupReadinessReport): void {
+    const statusEmoji = report.overallStatus === 'ready' ? '✅' : report.overallStatus === 'degraded' ? '⚠️' : '❌';
+
+    this.logger.log(
+      `${statusEmoji} Startup Readiness Check Complete`,
+      'StartupReadiness',
+    );
+
+    this.logger.log(
+      `Overall Status: ${report.overallStatus.toUpperCase()} (${report.totalDurationMs}ms)`,
+      'StartupReadiness',
+    );
+
+    for (const check of report.checks) {
+      const emoji = check.status === 'ok' ? '✅' : check.status === 'degraded' ? '⚠️' : '❌';
+      const latency = check.latency ? `${check.latency}ms` : 'N/A';
+      const error = check.error ? ` - ${check.error}` : '';
+
+      this.logger.log(
+        `${emoji} ${check.component}: ${check.status.toUpperCase()} (${latency})${error}`,
+        'StartupReadiness',
+      );
+    }
+
+    if (report.overallStatus === 'ready') {
+      this.logger.log(
+        '🎉 All critical dependencies are ready. Application is starting up.',
+        'StartupReadiness',
+      );
+    } else if (report.overallStatus === 'degraded') {
+      this.logger.warn(
+        '⚠️ Application is starting in degraded mode. Some non-critical dependencies are unavailable.',
+        'StartupReadiness',
+      );
+    }
+  }
+}

--- a/BackEnd/src/common/services/startup-readiness.service.ts
+++ b/BackEnd/src/common/services/startup-readiness.service.ts
@@ -127,7 +127,10 @@ export class StartupReadinessService implements OnModuleInit {
         component: 'Environment Variables (Keys)',
         status: 'ok',
         latency,
-        details: { requiredKeys: requiredKeys.length, optionalKeys: optionalKeys.length },
+        details: {
+          requiredKeys: requiredKeys.length,
+          optionalKeys: optionalKeys.length,
+        },
       };
     } catch (error) {
       const latency = Date.now() - startTime;
@@ -286,7 +289,8 @@ export class StartupReadinessService implements OnModuleInit {
   private getRedisClient(): any {
     try {
       const store =
-        (this.cacheManager as any).stores?.[0] ?? (this.cacheManager as any).store;
+        (this.cacheManager as any).stores?.[0] ??
+        (this.cacheManager as any).store;
       const client = store?.getClient
         ? store.getClient()
         : store?.client
@@ -296,9 +300,9 @@ export class StartupReadinessService implements OnModuleInit {
       if (client && typeof client.ping === 'function') {
         return client;
       }
-    } catch (e) {
-      // Ignore errors
-    }
+    } catch (_e) {
+  // Ignore errors
+}
 
     return null;
   }
@@ -309,7 +313,9 @@ export class StartupReadinessService implements OnModuleInit {
     });
   }
 
-  private calculateOverallStatus(checks: ReadinessCheckResult[]): 'ready' | 'degraded' | 'not_ready' {
+  private calculateOverallStatus(
+    checks: ReadinessCheckResult[],
+  ): 'ready' | 'degraded' | 'not_ready' {
     const hasDown = checks.some((c) => c.status === 'down');
     const hasDegraded = checks.some((c) => c.status === 'degraded');
 
@@ -325,7 +331,12 @@ export class StartupReadinessService implements OnModuleInit {
   }
 
   private logReadinessReport(report: StartupReadinessReport): void {
-    const statusEmoji = report.overallStatus === 'ready' ? '✅' : report.overallStatus === 'degraded' ? '⚠️' : '❌';
+    const statusEmoji =
+      report.overallStatus === 'ready'
+        ? '✅'
+        : report.overallStatus === 'degraded'
+          ? '⚠️'
+          : '❌';
 
     this.logger.log(
       `${statusEmoji} Startup Readiness Check Complete`,
@@ -338,7 +349,12 @@ export class StartupReadinessService implements OnModuleInit {
     );
 
     for (const check of report.checks) {
-      const emoji = check.status === 'ok' ? '✅' : check.status === 'degraded' ? '⚠️' : '❌';
+      const emoji =
+        check.status === 'ok'
+          ? '✅'
+          : check.status === 'degraded'
+            ? '⚠️'
+            : '❌';
       const latency = check.latency ? `${check.latency}ms` : 'N/A';
       const error = check.error ? ` - ${check.error}` : '';
 


### PR DESCRIPTION
## Summary
Implements startup readiness checklist that verifies all critical 
dependencies before the application accepts requests.

## Changes
- Added StartupReadinessService with checks for DB, Redis, queues, and env keys
- Status levels: ready / degraded / not_ready
- 19/19 tests passing
- Registered in AppModule via OnModuleInit

## Closes
#938 [BE-027]