### PR TITLE
feat(frontend): implement real-time quest and submission status updat…

### DIFF
--- a/FrontEnd/my-app/components/quest/QuestCard.tsx
+++ b/FrontEnd/my-app/components/quest/QuestCard.tsx
@@ -93,7 +93,9 @@ export const QuestCard = memo(
     const { deadline, reward, compactReward } = useFormatter();
 
     // Localised deadline label: "Ends in 3 days" | "Expired" | null
-    const timeLabel = localQuest.deadline ? deadline(localQuest.deadline) : null;
+    const timeLabel = localQuest.deadline
+      ? deadline(localQuest.deadline)
+      : null;
 
     // Urgency check is now locale-independent (raw ms comparison)
     const isUrgent = isDeadlineUrgent(localQuest.deadline);

--- a/FrontEnd/my-app/components/quest/QuestCard.tsx
+++ b/FrontEnd/my-app/components/quest/QuestCard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { memo } from 'react';
+import React, { memo, useState, useEffect } from 'react';
 import type { Quest } from '@/lib/types/quest';
 import { QuestDifficulty } from '@/lib/types/quest';
 
 import { useFormatter } from '@/lib/hooks/useFormatter';
 import OptimizedImage from '@/components/ui/OptimizedImage';
+import { useQuestSocket } from '@/lib/hooks/useQuestSocket';
 
 interface QuestCardProps {
   quest: Quest;
@@ -68,43 +69,62 @@ function avatarColor(name: string): string {
 
 export const QuestCard = memo(
   ({ quest, onClick, progress }: QuestCardProps) => {
+    const [localQuest, setLocalQuest] = useState<Quest>(quest);
+
+    useEffect(() => {
+      setLocalQuest(quest);
+    }, [quest]);
+
+    useQuestSocket({
+      questId: localQuest.id,
+      onQuestUpdated: (event) => {
+        if (event.questId === localQuest.id) {
+          import('@/lib/api/quests').then(({ getQuestById }) => {
+            getQuestById(localQuest.id).then((updatedQuest) => {
+              setLocalQuest(updatedQuest as Quest);
+            });
+          });
+        }
+      },
+    });
+
     // useFormatter reads navigator.language once and returns pre-bound,
     // memoised formatting functions — no locale prop drilling needed.
     const { deadline, reward, compactReward } = useFormatter();
 
     // Localised deadline label: "Ends in 3 days" | "Expired" | null
-    const timeLabel = quest.deadline ? deadline(quest.deadline) : null;
+    const timeLabel = localQuest.deadline ? deadline(localQuest.deadline) : null;
 
     // Urgency check is now locale-independent (raw ms comparison)
-    const isUrgent = isDeadlineUrgent(quest.deadline);
+    const isUrgent = isDeadlineUrgent(localQuest.deadline);
 
-    const handleClick = () => onClick?.(quest);
+    const handleClick = () => onClick?.(localQuest);
 
     // ── Accessible card label ────────────────────────────────────────────────
     // Previously: raw `${quest.rewardAmount} ${quest.rewardAsset}` interpolation
     // Now: uses formatReward so screen readers announce "500 XLM" not "500xlm"
     // and the number is formatted with locale-correct separators.
-    const formattedRewardAmount = reward(quest.rewardAmount, {
+    const formattedRewardAmount = reward(localQuest.rewardAmount, {
       type: 'custom',
       label: {
-        singular: quest.rewardAsset ?? 'token',
-        plural: quest.rewardAsset ?? 'tokens',
+        singular: localQuest.rewardAsset ?? 'token',
+        plural: localQuest.rewardAsset ?? 'tokens',
       },
     });
 
-    const rewardLabel = `${formattedRewardAmount} and ${quest.xpReward} XP`;
+    const rewardLabel = `${formattedRewardAmount} and ${localQuest.xpReward} XP`;
     const timeInfo = timeLabel ? `, deadline: ${timeLabel}` : '';
-    const cardLabel = `${quest.title}. Category: ${quest.category ?? 'Uncategorized'}, Difficulty: ${quest.difficulty}, Reward: ${rewardLabel}${timeInfo}`;
+    const cardLabel = `${localQuest.title}. Category: ${localQuest.category ?? 'Uncategorized'}, Difficulty: ${localQuest.difficulty}, Reward: ${rewardLabel}${timeInfo}`;
 
     // ── Compact reward for the badge in tight card space ────────────────────
     // Previously: `{quest.rewardAmount} {quest.rewardAsset}` — no number formatting
     // Now: "1.2K XLM" for large values, "500 XLM" for normal values, all
     //      with locale-correct digit grouping.
-    const compactRewardLabel = compactReward(quest.rewardAmount, {
+    const compactRewardLabel = compactReward(localQuest.rewardAmount, {
       type: 'custom',
       label: {
-        singular: quest.rewardAsset ?? 'token',
-        plural: quest.rewardAsset ?? 'tokens',
+        singular: localQuest.rewardAsset ?? 'token',
+        plural: localQuest.rewardAsset ?? 'tokens',
       },
     });
 
@@ -117,29 +137,29 @@ export const QuestCard = memo(
       >
         <div className="quest-card__top" aria-hidden="true">
           <span
-            className={`quest-card__cat ${categoryStyles[quest.category ?? ''] ?? 'quest-card__cat--default'}`}
+            className={`quest-card__cat ${categoryStyles[localQuest.category ?? ''] ?? 'quest-card__cat--default'}`}
           >
-            {quest.category}
+            {localQuest.category}
           </span>
           <span
-            className={`quest-card__diff ${quest.difficulty ? difficultyStyles[quest.difficulty] : ''}`}
+            className={`quest-card__diff ${localQuest.difficulty ? difficultyStyles[localQuest.difficulty] : ''}`}
           >
-            {quest.difficulty}
+            {localQuest.difficulty}
           </span>
         </div>
 
-        <h3 className="quest-card__title">{quest.title}</h3>
+        <h3 className="quest-card__title">{localQuest.title}</h3>
 
-        <p className="quest-card__desc">{quest.description}</p>
+        <p className="quest-card__desc">{localQuest.description}</p>
 
-        {quest.skills && quest.skills.length > 0 && (
+        {localQuest.skills && localQuest.skills.length > 0 && (
           <div
             className="quest-card__skills"
-            aria-label={`Required skills: ${quest.skills.join(', ')}`}
+            aria-label={`Required skills: ${localQuest.skills.join(', ')}`}
           >
-            {quest.skills.map((skill: string, index: number) => (
+            {localQuest.skills.map((skill: string, index: number) => (
               <span
-                key={`${quest.id}-skill-${skill}-${index}`}
+                key={`${localQuest.id}-skill-${skill}-${index}`}
                 className="quest-card__skill-tag"
                 aria-hidden="true"
               >
@@ -213,7 +233,7 @@ export const QuestCard = memo(
                   clipRule="evenodd"
                 />
               </svg>
-              +{quest.xpReward} XP
+              +{localQuest.xpReward} XP
             </span>
           </div>
 
@@ -250,11 +270,11 @@ export const QuestCard = memo(
         </div>
 
         <div className="quest-card__footer" aria-hidden="true">
-          {quest.creator && (
+          {localQuest.creator && (
             <div className="quest-card__creator">
-              {quest.creator.avatarUrl ? (
+              {localQuest.creator.avatarUrl ? (
                 <OptimizedImage
-                  src={quest.creator.avatarUrl}
+                  src={localQuest.creator.avatarUrl}
                   alt=""
                   width={22}
                   height={22}
@@ -266,16 +286,16 @@ export const QuestCard = memo(
                   className="quest-card__avatar"
                   style={{
                     backgroundColor: avatarColor(
-                      quest.creator.name || 'Unknown'
+                      localQuest.creator.name || 'Unknown'
                     ),
                   }}
                   aria-hidden="true"
                 >
-                  {(quest.creator.name || 'UN').slice(0, 2).toUpperCase()}
+                  {(localQuest.creator.name || 'UN').slice(0, 2).toUpperCase()}
                 </span>
               )}
               <span className="quest-card__creator-name">
-                {quest.creator.name || 'Unknown Creator'}
+                {localQuest.creator.name || 'Unknown Creator'}
               </span>
             </div>
           )}
@@ -303,9 +323,9 @@ export const QuestCard = memo(
           className="quest-card__quick-apply"
           onClick={(e) => {
             e.stopPropagation();
-            onClick?.(quest);
+            onClick?.(localQuest);
           }}
-          aria-label={`Quick apply for ${quest.title}`}
+          aria-label={`Quick apply for ${localQuest.title}`}
           tabIndex={-1}
         >
           Quick Apply →

--- a/FrontEnd/my-app/components/submission/SubmissionDetail.tsx
+++ b/FrontEnd/my-app/components/submission/SubmissionDetail.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { StatusBadge } from './StatusBadge';
 import { StatusTimeline } from './StatusTimeline';
 import type { Submission } from '@/lib/types/submission';
 import { FocusTrap } from '@/components/a11y/FocusTrap';
 import { formatDate } from '@/lib/utils/date';
+import { useQuestSocket } from '@/lib/hooks/useQuestSocket';
 
 interface SubmissionDetailProps {
   submission: Submission | null;
@@ -20,6 +21,33 @@ export function SubmissionDetail({
 }: SubmissionDetailProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
+
+  const [localSubmission, setLocalSubmission] = useState<Submission | null>(null);
+
+  useEffect(() => {
+    if (submission) {
+      setLocalSubmission(submission);
+    } else {
+      setLocalSubmission(null);
+    }
+  }, [submission]);
+
+  useQuestSocket({
+    questId: localSubmission?.questId,
+    onSubmissionUpdated: (event) => {
+      if (event.submissionId === localSubmission?.id) {
+        setLocalSubmission((prev) => {
+          if (!prev) return null;
+          return {
+            ...prev,
+            status: event.status,
+            rejectionReason: event.rejectionReason ?? prev.rejectionReason,
+            updatedAt: new Date().toISOString(),
+          };
+        });
+      }
+    },
+  });
 
   useEffect(() => {
     if (isOpen) {
@@ -54,7 +82,7 @@ export function SubmissionDetail({
     };
   }, [isOpen, onClose]);
 
-  if (!isOpen || !submission) return null;
+  if (!isOpen || !localSubmission) return null;
 
   const handleBackdropClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     // backdrop button covers the container; close when clicked
@@ -117,10 +145,10 @@ export function SubmissionDetail({
               </h3>
               <div className="space-y-2">
                 <h4 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-                  {submission.quest?.title}
+                  {localSubmission.quest?.title}
                 </h4>
                 <p className="text-sm text-zinc-600 dark:text-zinc-400">
-                  {submission.quest?.description}
+                  {localSubmission.quest?.description}
                 </p>
                 <div className="flex items-center gap-4 pt-2">
                   <div>
@@ -128,17 +156,17 @@ export function SubmissionDetail({
                       Reward:
                     </span>
                     <span className="ml-2 text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                      {submission.quest?.rewardAmount}{' '}
-                      {submission.quest?.rewardAsset}
+                      {localSubmission.quest?.rewardAmount}{' '}
+                      {localSubmission.quest?.rewardAsset}
                     </span>
                   </div>
-                  {submission.quest?.deadline && (
+                  {localSubmission.quest?.deadline && (
                     <div>
                       <span className="text-sm text-zinc-500 dark:text-zinc-400">
                         Deadline:
                       </span>
                       <span className="ml-2 text-sm text-zinc-900 dark:text-zinc-50">
-                        {formatDate(submission.quest!.deadline)}
+                        {formatDate(localSubmission.quest.deadline)}
                       </span>
                     </div>
                   )}
@@ -151,11 +179,11 @@ export function SubmissionDetail({
               <h3 className="text-sm font-semibold text-zinc-500 dark:text-zinc-400 mb-2">
                 Status
               </h3>
-              <StatusBadge status={submission.status} />
+              <StatusBadge status={localSubmission.status} />
             </div>
 
             {/* Timeline */}
-            <StatusTimeline submission={submission} />
+            <StatusTimeline submission={localSubmission} />
 
             {/* Submission Details */}
             <div>
@@ -168,7 +196,7 @@ export function SubmissionDetail({
                     Submitted:
                   </span>
                   <span className="ml-2 text-zinc-900 dark:text-zinc-50">
-                    {formatDate(submission.createdAt)}
+                    {formatDate(localSubmission.createdAt)}
                   </span>
                 </div>
                 <div>
@@ -176,7 +204,7 @@ export function SubmissionDetail({
                     Last Updated:
                   </span>
                   <span className="ml-2 text-zinc-900 dark:text-zinc-50">
-                    {formatDate(submission.updatedAt)}
+                    {formatDate(localSubmission.updatedAt)}
                   </span>
                 </div>
               </div>
@@ -188,18 +216,18 @@ export function SubmissionDetail({
                 Proof
               </h3>
               <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-4 text-xs text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
-                {JSON.stringify(submission.proof, null, 2)}
+                {JSON.stringify(localSubmission.proof, null, 2)}
               </pre>
             </div>
 
             {/* Rejection Reason */}
-            {submission.status === 'Rejected' && (
+            {localSubmission.status === 'Rejected' && (
               <div className="rounded-lg bg-red-50 p-4 dark:bg-red-900/20">
                 <h3 className="text-sm font-semibold text-red-900 dark:text-red-400 mb-1">
                   Rejection Reason
                 </h3>
                 <p className="text-sm text-red-800 dark:text-red-300">
-                  {submission.rejectionReason ||
+                  {localSubmission.rejectionReason ||
                     'No reason provided for rejection.'}
                 </p>
               </div>
@@ -213,11 +241,11 @@ export function SubmissionDetail({
               >
                 Close
               </button>
-              {submission.status === 'Approved' && (
+              {localSubmission.status === 'Approved' && (
                 <button
                   onClick={() => {
                     // TODO: Implement claim reward functionality
-                    console.log('Claim reward for submission:', submission.id);
+                    console.log('Claim reward for submission:', localSubmission.id);
                   }}
                   className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
                 >

--- a/FrontEnd/my-app/components/submission/SubmissionDetail.tsx
+++ b/FrontEnd/my-app/components/submission/SubmissionDetail.tsx
@@ -22,7 +22,9 @@ export function SubmissionDetail({
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
 
-  const [localSubmission, setLocalSubmission] = useState<Submission | null>(null);
+  const [localSubmission, setLocalSubmission] = useState<Submission | null>(
+    null
+  );
 
   useEffect(() => {
     if (submission) {
@@ -245,7 +247,10 @@ export function SubmissionDetail({
                 <button
                   onClick={() => {
                     // TODO: Implement claim reward functionality
-                    console.log('Claim reward for submission:', localSubmission.id);
+                    console.log(
+                      'Claim reward for submission:',
+                      localSubmission.id
+                    );
                   }}
                   className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
                 >

--- a/FrontEnd/my-app/lib/hooks/useQuestSocket.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestSocket.test.ts
@@ -49,7 +49,10 @@ describe('useQuestSocket', () => {
       })
     );
 
-    expect(io).toHaveBeenCalledWith('http://localhost:3000', expect.any(Object));
+    expect(io).toHaveBeenCalledWith(
+      'http://localhost:3000',
+      expect.any(Object)
+    );
     expect(mockSocket.connect).toHaveBeenCalled();
     expect(mockSocket.auth).toEqual({ token: 'Bearer test-jwt-token' });
   });

--- a/FrontEnd/my-app/lib/hooks/useQuestSocket.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestSocket.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useQuestSocket } from './useQuestSocket';
+import { io } from 'socket.io-client';
+
+// Mock dependency imports
+vi.mock('@/lib/api/client', () => ({
+  tokenManager: {
+    getAccessToken: vi.fn(() => 'test-jwt-token'),
+  },
+}));
+
+vi.mock('@/lib/config/env', () => ({
+  env: {
+    apiBaseUrl: vi.fn(() => 'http://localhost:3000'),
+  },
+}));
+
+// Create a mock socket object
+const mockSocket = {
+  connect: vi.fn().mockReturnThis(),
+  disconnect: vi.fn().mockReturnThis(),
+  emit: vi.fn().mockReturnThis(),
+  on: vi.fn().mockReturnThis(),
+  off: vi.fn().mockReturnThis(),
+  connected: false,
+  auth: {},
+};
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => mockSocket),
+}));
+
+describe('useQuestSocket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocket.connected = false;
+    mockSocket.auth = {};
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('establishes a connection with auth token', () => {
+    renderHook(() =>
+      useQuestSocket({
+        questId: 'quest-123',
+      })
+    );
+
+    expect(io).toHaveBeenCalledWith('http://localhost:3000', expect.any(Object));
+    expect(mockSocket.connect).toHaveBeenCalled();
+    expect(mockSocket.auth).toEqual({ token: 'Bearer test-jwt-token' });
+  });
+
+  it('subscribes to channels on connect', () => {
+    mockSocket.connected = true;
+
+    renderHook(() =>
+      useQuestSocket({
+        questId: 'quest-123',
+      })
+    );
+
+    // Should emit subscribe for quest:updated and submission:status
+    expect(mockSocket.emit).toHaveBeenCalledWith('subscribe', {
+      channel: 'quest:updated',
+      resourceId: 'quest-123',
+    });
+    expect(mockSocket.emit).toHaveBeenCalledWith('subscribe', {
+      channel: 'submission:status',
+      resourceId: 'quest-123',
+    });
+  });
+
+  it('unsubscribes and cleans up on unmount', () => {
+    mockSocket.connected = true;
+
+    const { unmount } = renderHook(() =>
+      useQuestSocket({
+        questId: 'quest-123',
+      })
+    );
+
+    unmount();
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('unsubscribe', {
+      channel: 'quest:updated',
+      resourceId: 'quest-123',
+    });
+    expect(mockSocket.emit).toHaveBeenCalledWith('unsubscribe', {
+      channel: 'submission:status',
+      resourceId: 'quest-123',
+    });
+    expect(mockSocket.off).toHaveBeenCalled();
+  });
+
+  it('does not connect or subscribe if questId is undefined', () => {
+    renderHook(() =>
+      useQuestSocket({
+        questId: undefined,
+      })
+    );
+
+    expect(mockSocket.connect).not.toHaveBeenCalled();
+    expect(mockSocket.emit).not.toHaveBeenCalled();
+  });
+});

--- a/FrontEnd/my-app/lib/hooks/useQuestSocket.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestSocket.ts
@@ -58,8 +58,14 @@ function setupSharedSocketListeners(socket: Socket) {
   // Automatically subscribe to active rooms on reconnect
   socket.on('connect', () => {
     for (const questId of questCallbackRegistry.keys()) {
-      socket.emit('subscribe', { channel: 'quest:updated', resourceId: questId });
-      socket.emit('subscribe', { channel: 'submission:status', resourceId: questId });
+      socket.emit('subscribe', {
+        channel: 'quest:updated',
+        resourceId: questId,
+      });
+      socket.emit('subscribe', {
+        channel: 'submission:status',
+        resourceId: questId,
+      });
     }
   });
 
@@ -77,7 +83,11 @@ function setupSharedSocketListeners(socket: Socket) {
   });
 
   socket.on('submission:received', (payload: unknown) => {
-    const data = (payload as { data?: { submissionId: string; questId: string; userId: string } })?.data;
+    const data = (
+      payload as {
+        data?: { submissionId: string; questId: string; userId: string };
+      }
+    )?.data;
     const questId = data?.questId;
     if (questId && data) {
       const registries = questCallbackRegistry.get(questId);
@@ -95,7 +105,11 @@ function setupSharedSocketListeners(socket: Socket) {
   });
 
   socket.on('submission:approved', (payload: unknown) => {
-    const data = (payload as { data?: { submissionId: string; questId: string; verifierId: string } })?.data;
+    const data = (
+      payload as {
+        data?: { submissionId: string; questId: string; verifierId: string };
+      }
+    )?.data;
     const questId = data?.questId;
     if (questId && data) {
       const registries = questCallbackRegistry.get(questId);
@@ -113,7 +127,9 @@ function setupSharedSocketListeners(socket: Socket) {
   });
 
   socket.on('submission:rejected', (payload: unknown) => {
-    const data = (payload as { data?: { submissionId: string; reason?: string } })?.data;
+    const data = (
+      payload as { data?: { submissionId: string; reason?: string } }
+    )?.data;
     if (data?.submissionId) {
       const submissionEvent: SubmissionStatusEvent = {
         submissionId: data.submissionId,
@@ -153,7 +169,8 @@ export function useQuestSocket(options: UseQuestSocketOptions): {
     const proxyOptions: UseQuestSocketOptions = {
       questId,
       onQuestUpdated: (data) => callbacksRef.current.onQuestUpdated?.(data),
-      onSubmissionUpdated: (data) => callbacksRef.current.onSubmissionUpdated?.(data),
+      onSubmissionUpdated: (data) =>
+        callbacksRef.current.onSubmissionUpdated?.(data),
     };
 
     let callbacksSet = questCallbackRegistry.get(questId);
@@ -166,8 +183,14 @@ export function useQuestSocket(options: UseQuestSocketOptions): {
 
     if (socket.connected) {
       setIsConnected(true);
-      socket.emit('subscribe', { channel: 'quest:updated', resourceId: questId });
-      socket.emit('subscribe', { channel: 'submission:status', resourceId: questId });
+      socket.emit('subscribe', {
+        channel: 'quest:updated',
+        resourceId: questId,
+      });
+      socket.emit('subscribe', {
+        channel: 'submission:status',
+        resourceId: questId,
+      });
     } else {
       const token = tokenManager.getAccessToken();
       socket.auth = {
@@ -207,8 +230,14 @@ export function useQuestSocket(options: UseQuestSocketOptions): {
         if (callbacks.size === 0) {
           questCallbackRegistry.delete(questId);
           if (socket.connected) {
-            socket.emit('unsubscribe', { channel: 'quest:updated', resourceId: questId });
-            socket.emit('unsubscribe', { channel: 'submission:status', resourceId: questId });
+            socket.emit('unsubscribe', {
+              channel: 'quest:updated',
+              resourceId: questId,
+            });
+            socket.emit('unsubscribe', {
+              channel: 'submission:status',
+              resourceId: questId,
+            });
           }
         }
       }

--- a/FrontEnd/my-app/lib/hooks/useQuestSocket.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestSocket.ts
@@ -1,0 +1,230 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+import { tokenManager } from '@/lib/api/client';
+import { env } from '@/lib/config/env';
+
+export interface QuestUpdatedEvent {
+  questId: string;
+}
+
+export interface SubmissionStatusEvent {
+  submissionId: string;
+  questId?: string;
+  userId?: string;
+  status: 'Pending' | 'Approved' | 'Rejected' | 'Paid' | 'Under Review';
+  rejectionReason?: string;
+  verifierId?: string;
+}
+
+export interface UseQuestSocketOptions {
+  questId: string | undefined;
+  onQuestUpdated?: (payload: QuestUpdatedEvent) => void;
+  onSubmissionUpdated?: (payload: SubmissionStatusEvent) => void;
+}
+
+// Shared, singleton Socket.IO instance
+let sharedSocket: Socket | null = null;
+let activeHooksCount = 0;
+
+// Centralized registries for callbacks to avoid maxListeners warnings and duplicate events
+const questCallbackRegistry = new Map<string, Set<UseQuestSocketOptions>>();
+const globalCallbackRegistry = new Set<UseQuestSocketOptions>();
+
+function getSharedSocket(): Socket {
+  if (!sharedSocket) {
+    const apiBaseUrl = env.apiBaseUrl();
+    const token = tokenManager.getAccessToken();
+
+    sharedSocket = io(apiBaseUrl, {
+      auth: {
+        token: token ? `Bearer ${token}` : undefined,
+      },
+      transports: ['websocket', 'polling'],
+      autoConnect: false,
+      reconnection: true,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
+      reconnectionAttempts: Infinity,
+    });
+
+    setupSharedSocketListeners(sharedSocket);
+  }
+  return sharedSocket;
+}
+
+function setupSharedSocketListeners(socket: Socket) {
+  // Automatically subscribe to active rooms on reconnect
+  socket.on('connect', () => {
+    for (const questId of questCallbackRegistry.keys()) {
+      socket.emit('subscribe', { channel: 'quest:updated', resourceId: questId });
+      socket.emit('subscribe', { channel: 'submission:status', resourceId: questId });
+    }
+  });
+
+  socket.on('quest:updated', (payload: unknown) => {
+    const data = (payload as { data?: { questId?: string } })?.data;
+    const questId = data?.questId;
+    if (questId) {
+      const registries = questCallbackRegistry.get(questId);
+      if (registries) {
+        registries.forEach((options) => {
+          options.onQuestUpdated?.({ questId });
+        });
+      }
+    }
+  });
+
+  socket.on('submission:received', (payload: unknown) => {
+    const data = (payload as { data?: { submissionId: string; questId: string; userId: string } })?.data;
+    const questId = data?.questId;
+    if (questId && data) {
+      const registries = questCallbackRegistry.get(questId);
+      if (registries) {
+        registries.forEach((options) => {
+          options.onSubmissionUpdated?.({
+            submissionId: data.submissionId,
+            questId: data.questId,
+            userId: data.userId,
+            status: 'Pending',
+          });
+        });
+      }
+    }
+  });
+
+  socket.on('submission:approved', (payload: unknown) => {
+    const data = (payload as { data?: { submissionId: string; questId: string; verifierId: string } })?.data;
+    const questId = data?.questId;
+    if (questId && data) {
+      const registries = questCallbackRegistry.get(questId);
+      if (registries) {
+        registries.forEach((options) => {
+          options.onSubmissionUpdated?.({
+            submissionId: data.submissionId,
+            questId: data.questId,
+            verifierId: data.verifierId,
+            status: 'Approved',
+          });
+        });
+      }
+    }
+  });
+
+  socket.on('submission:rejected', (payload: unknown) => {
+    const data = (payload as { data?: { submissionId: string; reason?: string } })?.data;
+    if (data?.submissionId) {
+      const submissionEvent: SubmissionStatusEvent = {
+        submissionId: data.submissionId,
+        status: 'Rejected',
+        rejectionReason: data.reason,
+      };
+
+      globalCallbackRegistry.forEach((options) => {
+        options.onSubmissionUpdated?.(submissionEvent);
+      });
+    }
+  });
+}
+
+export function useQuestSocket(options: UseQuestSocketOptions): {
+  isConnected: boolean;
+  error: Error | null;
+} {
+  const { questId } = options;
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const callbacksRef = useRef<UseQuestSocketOptions>(options);
+
+  useEffect(() => {
+    callbacksRef.current = options;
+  }, [options]);
+
+  useEffect(() => {
+    if (!questId) {
+      return;
+    }
+
+    const socket = getSharedSocket();
+    activeHooksCount++;
+
+    const proxyOptions: UseQuestSocketOptions = {
+      questId,
+      onQuestUpdated: (data) => callbacksRef.current.onQuestUpdated?.(data),
+      onSubmissionUpdated: (data) => callbacksRef.current.onSubmissionUpdated?.(data),
+    };
+
+    let callbacksSet = questCallbackRegistry.get(questId);
+    if (!callbacksSet) {
+      callbacksSet = new Set();
+      questCallbackRegistry.set(questId, callbacksSet);
+    }
+    callbacksSet.add(proxyOptions);
+    globalCallbackRegistry.add(proxyOptions);
+
+    if (socket.connected) {
+      setIsConnected(true);
+      socket.emit('subscribe', { channel: 'quest:updated', resourceId: questId });
+      socket.emit('subscribe', { channel: 'submission:status', resourceId: questId });
+    } else {
+      const token = tokenManager.getAccessToken();
+      socket.auth = {
+        token: token ? `Bearer ${token}` : undefined,
+      };
+      socket.connect();
+    }
+
+    const handleLocalConnect = () => {
+      setIsConnected(true);
+      setError(null);
+    };
+
+    const handleLocalDisconnect = () => {
+      setIsConnected(false);
+    };
+
+    const handleLocalError = (err: unknown) => {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    };
+
+    socket.on('connect', handleLocalConnect);
+    socket.on('disconnect', handleLocalDisconnect);
+    socket.on('connect_error', handleLocalError);
+    socket.on('error', handleLocalError);
+
+    if (socket.connected) {
+      setIsConnected(true);
+    }
+
+    return () => {
+      activeHooksCount--;
+
+      const callbacks = questCallbackRegistry.get(questId);
+      if (callbacks) {
+        callbacks.delete(proxyOptions);
+        if (callbacks.size === 0) {
+          questCallbackRegistry.delete(questId);
+          if (socket.connected) {
+            socket.emit('unsubscribe', { channel: 'quest:updated', resourceId: questId });
+            socket.emit('unsubscribe', { channel: 'submission:status', resourceId: questId });
+          }
+        }
+      }
+      globalCallbackRegistry.delete(proxyOptions);
+
+      socket.off('connect', handleLocalConnect);
+      socket.off('disconnect', handleLocalDisconnect);
+      socket.off('connect_error', handleLocalError);
+      socket.off('error', handleLocalError);
+
+      if (activeHooksCount === 0) {
+        socket.disconnect();
+        sharedSocket = null;
+      }
+    };
+  }, [questId]);
+
+  return { isConnected, error };
+}

--- a/FrontEnd/my-app/package-lock.json
+++ b/FrontEnd/my-app/package-lock.json
@@ -25,6 +25,7 @@
         "next-intl": "^3.26.3",
         "react": "19.2.5",
         "react-dom": "19.2.5",
+        "socket.io-client": "^4.8.3",
         "tailwind-merge": "^3.4.0",
         "web-vitals": "^5.1.0",
         "zod": "^4.4.3",
@@ -4203,6 +4204,11 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
       "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ==",
       "license": "MIT"
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
     },
     "node_modules/@solana-program/compute-budget": {
       "version": "0.8.0",
@@ -10488,6 +10494,26 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.21.6",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
@@ -16709,6 +16735,32 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
@@ -18998,6 +19050,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xrpl": {
       "version": "4.4.3",

--- a/FrontEnd/my-app/package.json
+++ b/FrontEnd/my-app/package.json
@@ -40,6 +40,7 @@
     "next-intl": "^3.26.3",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "socket.io-client": "^4.8.3",
     "tailwind-merge": "^3.4.0",
     "web-vitals": "^5.1.0",
     "zod": "^4.4.3",


### PR DESCRIPTION
## Summary

Closes #1675

This PR adds real-time quest and submission status synchronization by integrating the existing backend Socket.IO gateway with the frontend. A reusable `useQuestSocket` hook has been introduced to manage authenticated WebSocket connections, room subscriptions, reconnection handling, and listener cleanup while reusing the backend's existing event contract.

The hook has been integrated into the relevant quest and submission components so that status updates are reflected immediately without requiring a page refresh.

## Changes

* [x] Added a reusable `useQuestSocket` hook for authenticated Socket.IO communication.
* [x] Reused the backend's existing authentication, subscription protocol, and event contract without introducing new gateway events or room names.
* [x] Implemented a shared Socket.IO client to avoid duplicate connections across multiple hook instances.
* [x] Added automatic room subscription and cleanup for quest and submission channels.
* [x] Added automatic reconnection using Socket.IO's native exponential backoff support.
* [x] Prevented duplicate event listeners through a callback registry and proper listener lifecycle management.
* [x] Integrated real-time quest updates into `QuestCard`.
* [x] Integrated real-time submission status updates into `SubmissionDetail`.
* [x] Added unit tests covering connection setup, authentication, subscriptions, and cleanup behavior.

## Verification

* [x] `npm run typecheck`
* [x] `npm run test:unit`
* [x] `npm run lint`
* [x] `npm run build`

## Result

* [x] Quest status updates are reflected immediately without requiring a page refresh.
* [x] Submission status updates are reflected in real time.
* [x] Socket.IO reconnects automatically after disconnects.
* [x] Room subscriptions are restored after reconnection.
* [x] Event listeners are properly cleaned up on component unmount.
* [x] No duplicate Socket.IO event listeners are registered across re-renders.
