### PR TITLE
feat(jobs): make per-worker max concurrency benchmark-tunable [BE-106]

### DIFF
--- a/BackEnd/src/modules/jobs/processors/dependency.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/dependency.processor.ts
@@ -3,9 +3,13 @@ import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import { DependencyFreshnessCheckPayload } from '../job.types';
 import { DependencyFreshnessService } from '../../../common/services/dependency-freshness.service';
+import { QUEUES } from '../jobs.constants';
+import { resolveWorkerConcurrency } from '../utils/worker-concurrency.util';
 
 @Injectable()
-@Processor('maintenance')
+@Processor(QUEUES.MAINTENANCE, {
+  concurrency: resolveWorkerConcurrency(QUEUES.MAINTENANCE),
+})
 export class DependencyProcessor extends WorkerHost {
   private readonly logger = new Logger(DependencyProcessor.name);
 

--- a/BackEnd/src/modules/jobs/utils/worker-concurrency.util.ts
+++ b/BackEnd/src/modules/jobs/utils/worker-concurrency.util.ts
@@ -1,0 +1,69 @@
+import { JOB_QUEUE_CONFIG } from '../jobs.constants';
+
+/**
+ * Lower bound for worker concurrency. A worker must process at least one job
+ * at a time, so any override below this is treated as a misconfiguration.
+ */
+export const MIN_WORKER_CONCURRENCY = 1;
+
+/**
+ * Upper bound for worker concurrency. This is a safety guardrail: benchmark
+ * results inform the per-queue defaults in {@link JOB_QUEUE_CONFIG}, but an
+ * operator override should never be allowed to exhaust the database pool or
+ * the Redis connection budget. Anything above this is clamped down.
+ */
+export const MAX_WORKER_CONCURRENCY = 100;
+
+/**
+ * Fallback used when a queue has no benchmark-tuned default in
+ * {@link JOB_QUEUE_CONFIG}.
+ */
+export const DEFAULT_WORKER_CONCURRENCY = 5;
+
+/**
+ * Environment variable name that overrides the concurrency for a given queue.
+ * e.g. queue `payouts` is overridden by `QUEUE_PAYOUTS_CONCURRENCY`.
+ */
+export function workerConcurrencyEnvKey(queue: string): string {
+  return `QUEUE_${queue.toUpperCase()}_CONCURRENCY`;
+}
+
+function clampConcurrency(value: number): number {
+  return Math.min(MAX_WORKER_CONCURRENCY, Math.max(MIN_WORKER_CONCURRENCY, value));
+}
+
+/**
+ * Resolve the effective max concurrency for a worker.
+ *
+ * Resolution order:
+ *   1. `QUEUE_<NAME>_CONCURRENCY` environment override (lets ops re-tune from
+ *      benchmark results without a code change or redeploy of new defaults).
+ *   2. The benchmark-tuned default in {@link JOB_QUEUE_CONFIG}.
+ *   3. {@link DEFAULT_WORKER_CONCURRENCY} for queues without a configured value.
+ *
+ * The result is always an integer clamped to
+ * `[MIN_WORKER_CONCURRENCY, MAX_WORKER_CONCURRENCY]`. Non-numeric, fractional,
+ * or out-of-range overrides fall back to the configured default rather than
+ * throwing, so a bad env var degrades safely instead of crashing worker boot.
+ */
+export function resolveWorkerConcurrency(
+  queue: string,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const configured = JOB_QUEUE_CONFIG[queue]?.concurrency;
+  const fallback = clampConcurrency(
+    typeof configured === 'number' ? configured : DEFAULT_WORKER_CONCURRENCY,
+  );
+
+  const raw = env[workerConcurrencyEnvKey(queue)];
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < MIN_WORKER_CONCURRENCY) {
+    return fallback;
+  }
+
+  return clampConcurrency(parsed);
+}

--- a/BackEnd/test/jobs/worker-concurrency.util.spec.ts
+++ b/BackEnd/test/jobs/worker-concurrency.util.spec.ts
@@ -1,0 +1,91 @@
+import {
+  resolveWorkerConcurrency,
+  workerConcurrencyEnvKey,
+  MIN_WORKER_CONCURRENCY,
+  MAX_WORKER_CONCURRENCY,
+  DEFAULT_WORKER_CONCURRENCY,
+} from '#src/modules/jobs/utils/worker-concurrency.util';
+import { JOB_QUEUE_CONFIG, QUEUES } from '#src/modules/jobs/jobs.constants';
+
+describe('worker concurrency tuning', () => {
+  describe('workerConcurrencyEnvKey', () => {
+    it('builds an upper-cased QUEUE_<NAME>_CONCURRENCY key', () => {
+      expect(workerConcurrencyEnvKey('payouts')).toBe('QUEUE_PAYOUTS_CONCURRENCY');
+      expect(workerConcurrencyEnvKey(QUEUES.MAINTENANCE)).toBe(
+        'QUEUE_MAINTENANCE_CONCURRENCY',
+      );
+    });
+  });
+
+  describe('resolveWorkerConcurrency', () => {
+    it('returns the benchmark-tuned default from JOB_QUEUE_CONFIG when no override is set', () => {
+      expect(resolveWorkerConcurrency(QUEUES.PAYOUTS, {})).toBe(
+        JOB_QUEUE_CONFIG[QUEUES.PAYOUTS].concurrency,
+      );
+      expect(resolveWorkerConcurrency(QUEUES.MAINTENANCE, {})).toBe(
+        JOB_QUEUE_CONFIG[QUEUES.MAINTENANCE].concurrency,
+      );
+    });
+
+    it('falls back to DEFAULT_WORKER_CONCURRENCY for a queue with no configured value', () => {
+      expect(resolveWorkerConcurrency('unconfigured-queue', {})).toBe(
+        DEFAULT_WORKER_CONCURRENCY,
+      );
+    });
+
+    it('lets an environment override take precedence over the configured default', () => {
+      const env = { QUEUE_PAYOUTS_CONCURRENCY: '42' };
+      expect(resolveWorkerConcurrency(QUEUES.PAYOUTS, env)).toBe(42);
+    });
+
+    it('clamps an override above the maximum down to MAX_WORKER_CONCURRENCY', () => {
+      const env = { QUEUE_EMAIL_CONCURRENCY: '10000' };
+      expect(resolveWorkerConcurrency(QUEUES.EMAIL, env)).toBe(MAX_WORKER_CONCURRENCY);
+    });
+
+    it('rejects an override below the minimum and uses the configured default', () => {
+      const env = { QUEUE_PAYOUTS_CONCURRENCY: '0' };
+      expect(resolveWorkerConcurrency(QUEUES.PAYOUTS, env)).toBe(
+        JOB_QUEUE_CONFIG[QUEUES.PAYOUTS].concurrency,
+      );
+    });
+
+    it('rejects a negative override and uses the configured default', () => {
+      const env = { QUEUE_PAYOUTS_CONCURRENCY: '-5' };
+      expect(resolveWorkerConcurrency(QUEUES.PAYOUTS, env)).toBe(
+        JOB_QUEUE_CONFIG[QUEUES.PAYOUTS].concurrency,
+      );
+    });
+
+    it.each(['abc', '5.5', '  ', ''])(
+      'ignores the non-integer override %p and uses the configured default',
+      (value) => {
+        const env = { QUEUE_PAYOUTS_CONCURRENCY: value };
+        expect(resolveWorkerConcurrency(QUEUES.PAYOUTS, env)).toBe(
+          JOB_QUEUE_CONFIG[QUEUES.PAYOUTS].concurrency,
+        );
+      },
+    );
+
+    it('always returns an integer within the supported bounds', () => {
+      for (const queue of Object.values(QUEUES)) {
+        const value = resolveWorkerConcurrency(queue, {});
+        expect(Number.isInteger(value)).toBe(true);
+        expect(value).toBeGreaterThanOrEqual(MIN_WORKER_CONCURRENCY);
+        expect(value).toBeLessThanOrEqual(MAX_WORKER_CONCURRENCY);
+      }
+    });
+
+    it('reads from process.env by default', () => {
+      const key = workerConcurrencyEnvKey(QUEUES.WEBHOOKS);
+      const previous = process.env[key];
+      process.env[key] = '7';
+      try {
+        expect(resolveWorkerConcurrency(QUEUES.WEBHOOKS)).toBe(7);
+      } finally {
+        if (previous === undefined) delete process.env[key];
+        else process.env[key] = previous;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`JOB_QUEUE_CONFIG` in `jobs.constants.ts` defines a `concurrency` value per queue, but it was **never consumed** — workers ran on BullMQ's default concurrency, and the values could not be re-tuned without editing and redeploying code. This wires those benchmark-tuned defaults in and makes them overridable per worker at runtime.

## Changes

- **`utils/worker-concurrency.util.ts`** — `resolveWorkerConcurrency(queue)` resolves the effective max concurrency in this order:
  1. `QUEUE_<NAME>_CONCURRENCY` environment override (re-tune from benchmark results without a code change)
  2. the `JOB_QUEUE_CONFIG` default for that queue
  3. a safe fallback for queues with no configured value

  The result is always an integer clamped to `[1, 100]`. Non-integer, negative, or out-of-range overrides fall back to the configured default rather than throwing, so a bad env var degrades safely instead of exhausting the DB pool / Redis connection budget or crashing worker boot.

- **`processors/dependency.processor.ts`** — applies the resolver in the `@Processor` options so the maintenance worker actually honours its configured/overridden concurrency.

## Why per-worker

Queues have very different cost profiles (already reflected in the config: `email: 20`, `maintenance: 1`, `reports: 3`). A single global concurrency can't serve all of them; tuning must be per worker, and benchmark-driven tuning needs an override path that doesn't require a redeploy.

## Testing

`test/jobs/worker-concurrency.util.spec.ts` covers default resolution, env precedence, upper/lower clamping, and rejection of non-integer / out-of-range overrides.

Closes #1133