### PR TITLE
feat(http): add pooled HTTP client with timeout budgets for third-par…

### DIFF
--- a/BackEnd/package-lock.json
+++ b/BackEnd/package-lock.json
@@ -101,7 +101,7 @@
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.7.3",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.20.0"
       }
     },
@@ -17518,7 +17518,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/BackEnd/package.json
+++ b/BackEnd/package.json
@@ -138,7 +138,7 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.20.0"
   },
   "jest": {

--- a/BackEnd/src/app.module.ts
+++ b/BackEnd/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from './app.service';
 import { AppLoggerService } from './common/logger/logger.service';
 import { SecurityMiddleware } from './common/middleware/security.middleware';
 import { dataSourceOptions } from './database/data-source';
+import { HttpClientModule } from './common/http-client/http-client.module';
 import { LoggerModule } from './common/logger/logger.module';
 import { StartupReadinessService } from './common/services/startup-readiness.service';
 import { FileUploadModule } from './common/upload/file-upload.module';
@@ -70,6 +71,7 @@ const dataSourceProvider = shouldInitializeDatabaseConnection()
     ...typeOrmImports,
     LoggerModule.forRoot(),
     FileUploadModule,
+    HttpClientModule,
     EventsModule,
     AdminModule,
     AnalyticsModule,

--- a/BackEnd/src/common/http-client/CHANGELOG.md
+++ b/BackEnd/src/common/http-client/CHANGELOG.md
@@ -1,0 +1,15 @@
+# http-client changelog
+
+All notable changes to the `http-client` common module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- `PooledHttpClientService` — a global NestJS service backed by keep-alive `http`/`https` agents (`maxSockets=50`, `maxFreeSockets=10`) that vends pre-configured Axios instances for three named timeout budgets:
+  - `short` (3 s) — health checks and fast lookups
+  - `medium` (8 s) — moderation APIs and webhook delivery
+  - `long` (15 s) — GitHub API and other slow third-party calls
+- `HttpClientModule` — `@Global()` NestJS module that exports `PooledHttpClientService`; also imported explicitly by `JobsModule`, `HealthModule`, and `ModerationModule` for isolated test contexts.
+- 12 unit tests covering timeout values, agent reuse across budget instances, and graceful teardown via `onModuleDestroy`.

--- a/BackEnd/src/common/http-client/http-client.module.ts
+++ b/BackEnd/src/common/http-client/http-client.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PooledHttpClientService } from './http-client.service';
+
+@Global()
+@Module({
+  providers: [PooledHttpClientService],
+  exports: [PooledHttpClientService],
+})
+export class HttpClientModule {}

--- a/BackEnd/src/common/http-client/http-client.service.spec.ts
+++ b/BackEnd/src/common/http-client/http-client.service.spec.ts
@@ -1,0 +1,103 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PooledHttpClientService, TIMEOUT_BUDGETS } from './http-client.service';
+import * as http from 'http';
+import * as https from 'https';
+
+describe('PooledHttpClientService', () => {
+  let service: PooledHttpClientService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PooledHttpClientService],
+    }).compile();
+
+    service = module.get<PooledHttpClientService>(PooledHttpClientService);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('returns an axios instance for the short budget', () => {
+      const client = service.create('short');
+      expect(client).toBeDefined();
+      expect(client.defaults.timeout).toBe(TIMEOUT_BUDGETS.short);
+    });
+
+    it('returns an axios instance for the medium budget', () => {
+      const client = service.create('medium');
+      expect(client).toBeDefined();
+      expect(client.defaults.timeout).toBe(TIMEOUT_BUDGETS.medium);
+    });
+
+    it('returns an axios instance for the long budget', () => {
+      const client = service.create('long');
+      expect(client).toBeDefined();
+      expect(client.defaults.timeout).toBe(TIMEOUT_BUDGETS.long);
+    });
+
+    it('returns the same instance on repeated calls for the same budget', () => {
+      expect(service.create('short')).toBe(service.create('short'));
+      expect(service.create('medium')).toBe(service.create('medium'));
+      expect(service.create('long')).toBe(service.create('long'));
+    });
+
+    it('returns distinct instances for different budgets', () => {
+      expect(service.create('short')).not.toBe(service.create('medium'));
+      expect(service.create('medium')).not.toBe(service.create('long'));
+    });
+
+    it('uses a keep-alive http agent', () => {
+      const client = service.create('short');
+      expect(client.defaults.httpAgent).toBeInstanceOf(http.Agent);
+      expect((client.defaults.httpAgent as http.Agent).keepAlive).toBe(true);
+    });
+
+    it('uses a keep-alive https agent', () => {
+      const client = service.create('short');
+      expect(client.defaults.httpsAgent).toBeInstanceOf(https.Agent);
+      expect((client.defaults.httpsAgent as https.Agent).keepAlive).toBe(true);
+    });
+
+    it('shares the same agents across all budget instances', () => {
+      const short = service.create('short');
+      const medium = service.create('medium');
+      const long = service.create('long');
+
+      expect(short.defaults.httpAgent).toBe(medium.defaults.httpAgent);
+      expect(medium.defaults.httpAgent).toBe(long.defaults.httpAgent);
+      expect(short.defaults.httpsAgent).toBe(medium.defaults.httpsAgent);
+    });
+  });
+
+  describe('TIMEOUT_BUDGETS', () => {
+    it('short is less than medium', () => {
+      expect(TIMEOUT_BUDGETS.short).toBeLessThan(TIMEOUT_BUDGETS.medium);
+    });
+
+    it('medium is less than long', () => {
+      expect(TIMEOUT_BUDGETS.medium).toBeLessThan(TIMEOUT_BUDGETS.long);
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('destroys the underlying agents', () => {
+      const short = service.create('short');
+      const httpAgent = short.defaults.httpAgent as http.Agent;
+      const httpsAgent = short.defaults.httpsAgent as https.Agent;
+
+      const destroyHttp = jest.spyOn(httpAgent, 'destroy');
+      const destroyHttps = jest.spyOn(httpsAgent, 'destroy');
+
+      service.onModuleDestroy();
+
+      expect(destroyHttp).toHaveBeenCalledTimes(1);
+      expect(destroyHttps).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/BackEnd/src/common/http-client/http-client.service.ts
+++ b/BackEnd/src/common/http-client/http-client.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import axios, { AxiosInstance } from 'axios';
+import * as http from 'http';
+import * as https from 'https';
+
+export const TIMEOUT_BUDGETS = {
+  short: 3_000,
+  medium: 8_000,
+  long: 15_000,
+} as const;
+
+export type TimeoutBudget = keyof typeof TIMEOUT_BUDGETS;
+
+const POOL_MAX_SOCKETS = 50;
+const POOL_MAX_FREE_SOCKETS = 10;
+
+@Injectable()
+export class PooledHttpClientService implements OnModuleDestroy {
+  private readonly httpAgent: http.Agent;
+  private readonly httpsAgent: https.Agent;
+  private readonly instances = new Map<TimeoutBudget, AxiosInstance>();
+
+  constructor() {
+    this.httpAgent = new http.Agent({
+      keepAlive: true,
+      maxSockets: POOL_MAX_SOCKETS,
+      maxFreeSockets: POOL_MAX_FREE_SOCKETS,
+    });
+    this.httpsAgent = new https.Agent({
+      keepAlive: true,
+      maxSockets: POOL_MAX_SOCKETS,
+      maxFreeSockets: POOL_MAX_FREE_SOCKETS,
+    });
+
+    for (const budget of Object.keys(TIMEOUT_BUDGETS) as TimeoutBudget[]) {
+      this.instances.set(
+        budget,
+        axios.create({
+          timeout: TIMEOUT_BUDGETS[budget],
+          httpAgent: this.httpAgent,
+          httpsAgent: this.httpsAgent,
+        }),
+      );
+    }
+  }
+
+  /** Returns a shared, pre-configured Axios instance for the given timeout budget. */
+  create(budget: TimeoutBudget): AxiosInstance {
+    return this.instances.get(budget)!;
+  }
+
+  onModuleDestroy(): void {
+    this.httpAgent.destroy();
+    this.httpsAgent.destroy();
+  }
+}

--- a/BackEnd/src/common/services/dependency-freshness.service.ts
+++ b/BackEnd/src/common/services/dependency-freshness.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import axios from 'axios';
+import { PooledHttpClientService } from '../http-client/http-client.service';
 
 interface DependencyInfo {
   name: string;
@@ -25,7 +25,10 @@ export class DependencyFreshnessService {
   private readonly logger = new Logger(DependencyFreshnessService.name);
   private readonly githubApiUrl = 'https://api.github.com';
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly httpClient: PooledHttpClientService,
+  ) {}
 
   /**
    * Check dependency freshness and create a GitHub issue with the report
@@ -141,7 +144,8 @@ export class DependencyFreshnessService {
     const issueBody = this.formatReportAsMarkdown(report);
 
     try {
-      const response = await axios.post(
+      const client = this.httpClient.create('long');
+      const response = await client.post(
         `${this.githubApiUrl}/repos/${repositoryOwner}/${repositoryName}/issues`,
         {
           title: issueTitle,

--- a/BackEnd/src/modules/health/CHANGELOG.md
+++ b/BackEnd/src/modules/health/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+- `ExternalHealthService` now uses `PooledHttpClientService` (keep-alive connection pool, 3 s `short` timeout budget) instead of ad-hoc `axios` calls for Stellar Horizon and SendGrid health checks. `HttpClientModule` added to `HealthModule` imports.

--- a/BackEnd/src/modules/health/health.module.ts
+++ b/BackEnd/src/modules/health/health.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { CacheModule } from '../cache/cache.module';
+import { HttpClientModule } from '../../common/http-client/http-client.module';
 import { HealthController } from './health.controller';
 import { DatabaseHealthService } from './services/database-health.service';
 import { CacheHealthService } from './services/cache-health.service';
@@ -10,7 +11,7 @@ import { DatabasePoolMonitorService } from './services/database-pool-monitor.ser
 import { MetricsService } from '../../common/services/metrics.service';
 
 @Module({
-  imports: [TypeOrmModule, ConfigModule, CacheModule],
+  imports: [TypeOrmModule, ConfigModule, CacheModule, HttpClientModule],
   controllers: [HealthController],
   providers: [
     DatabaseHealthService,

--- a/BackEnd/src/modules/health/services/external-health.service.ts
+++ b/BackEnd/src/modules/health/services/external-health.service.ts
@@ -2,8 +2,8 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { HealthCheckResult, ServiceStatus } from '../types/health.types';
+import { PooledHttpClientService } from '../../../common/http-client/http-client.service';
 
-const EXTERNAL_TIMEOUT_MS = 5000;
 const EXTERNAL_DEGRADED_THRESHOLD_MS = 1000;
 
 // SendGrid API endpoint to verify API key (simple GET)
@@ -15,7 +15,10 @@ export class ExternalHealthService implements OnModuleInit {
   private stellarHorizonUrl: string;
   private sendgridApiKey: string | undefined;
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly httpClient: PooledHttpClientService,
+  ) {}
 
   onModuleInit(): void {
     this.stellarHorizonUrl =
@@ -81,10 +84,10 @@ export class ExternalHealthService implements OnModuleInit {
     const startTime = Date.now();
 
     try {
-      const response = await axios.get(
+      const client = this.httpClient.create('short');
+      const response = await client.get(
         `${this.stellarHorizonUrl}/ledgers?order=desc&limit=1`,
         {
-          timeout: EXTERNAL_TIMEOUT_MS,
           headers: {
             'Content-Type': 'application/json',
           },
@@ -138,8 +141,8 @@ export class ExternalHealthService implements OnModuleInit {
     }
 
     try {
-      const response = await axios.get(`${SENDGRID_API_BASE}/user/credits`, {
-        timeout: EXTERNAL_TIMEOUT_MS,
+      const client = this.httpClient.create('short');
+      const response = await client.get(`${SENDGRID_API_BASE}/user/credits`, {
         headers: {
           Authorization: `Bearer ${this.sendgridApiKey}`,
         },

--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+- `DependencyFreshnessService` now uses `PooledHttpClientService` (keep-alive connection pool, 15 s `long` timeout budget) instead of a raw `axios` call for GitHub API requests. `HttpClientModule` added to `JobsModule` imports.

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -1,5 +1,6 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpClientModule } from '../../common/http-client/http-client.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { JobsService } from './jobs.service';
 import { JobsController } from './jobs.controller';
@@ -48,6 +49,7 @@ import { EmailModule } from '../email/email.module';
       User,
     ]),
     EventEmitterModule,
+    HttpClientModule,
     StellarModule,
     AnalyticsModule,
     forwardRef(() => EmailModule),

--- a/BackEnd/src/modules/moderation/CHANGELOG.md
+++ b/BackEnd/src/modules/moderation/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+- `ExternalModerationApiService` now uses `PooledHttpClientService` (keep-alive connection pool, 8 s `medium` timeout budget) instead of a raw `axios` call. `HttpClientModule` added to `ModerationModule` imports.

--- a/BackEnd/src/modules/moderation/filters/external-moderation-api.service.ts
+++ b/BackEnd/src/modules/moderation/filters/external-moderation-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import axios from 'axios';
+import { PooledHttpClientService } from '../../../common/http-client/http-client.service';
 
 export interface ExternalModerationResult {
   score: number;
@@ -11,7 +11,10 @@ export interface ExternalModerationResult {
 export class ExternalModerationApiService {
   private readonly logger = new Logger(ExternalModerationApiService.name);
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly httpClient: PooledHttpClientService,
+  ) {}
 
   async scoreText(text: string): Promise<ExternalModerationResult | null> {
     const url = this.configService.get<string>('moderation.externalApiUrl');
@@ -22,7 +25,8 @@ export class ExternalModerationApiService {
       this.configService.get<string>('moderation.externalApiKey') || '';
 
     try {
-      const { data } = await axios.post<ExternalModerationResult>(
+      const client = this.httpClient.create('medium');
+      const { data } = await client.post<ExternalModerationResult>(
         url,
         { text, language: 'en' },
         {
@@ -32,7 +36,6 @@ export class ExternalModerationApiService {
                 'Content-Type': 'application/json',
               }
             : { 'Content-Type': 'application/json' },
-          timeout: 8000,
         },
       );
       return {

--- a/BackEnd/src/modules/moderation/moderation.module.ts
+++ b/BackEnd/src/modules/moderation/moderation.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpClientModule } from '../../common/http-client/http-client.module';
 import { ModerationItem } from './entities/moderation-item.entity';
 import { ModerationAppeal } from './entities/moderation-appeal.entity';
 import { ModerationService } from './moderation.service';
@@ -10,7 +11,7 @@ import { ImageModerationService } from './filters/image-moderation.service';
 import { ExternalModerationApiService } from './filters/external-moderation-api.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ModerationItem, ModerationAppeal])],
+  imports: [TypeOrmModule.forFeature([ModerationItem, ModerationAppeal]), HttpClientModule],
   controllers: [ModerationController],
   providers: [
     ModerationService,

--- a/BackEnd/src/modules/notifications/CHANGELOG.md
+++ b/BackEnd/src/modules/notifications/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+- `WebhookChannel` now uses `PooledHttpClientService` (keep-alive connection pool, 8 s `medium` timeout budget) instead of an unbounded raw `axios` call for webhook delivery.

--- a/BackEnd/src/modules/notifications/channels/webhook.channel.ts
+++ b/BackEnd/src/modules/notifications/channels/webhook.channel.ts
@@ -5,12 +5,14 @@ import {
   DeliveryResult,
 } from './notification-channel.interface';
 import { Notification } from '../entities/notification.entity';
-import axios from 'axios';
+import { PooledHttpClientService } from '../../../common/http-client/http-client.service';
 
 @Injectable()
 export class WebhookChannel implements NotificationChannel {
   private readonly logger = new Logger(WebhookChannel.name);
   readonly type = ChannelType.WEBHOOK;
+
+  constructor(private readonly httpClient: PooledHttpClientService) {}
 
   async send(
     notification: Notification,
@@ -30,7 +32,8 @@ export class WebhookChannel implements NotificationChannel {
         `Sending webhook notification to ${recipient.webhookUrl}`,
       );
 
-      const response = await axios.post(recipient.webhookUrl, {
+      const client = this.httpClient.create('medium');
+      const response = await client.post(recipient.webhookUrl, {
         id: notification.id,
         type: notification.type,
         title: notification.title,


### PR DESCRIPTION
…ty integrations

Introduces PooledHttpClientService (HttpClientModule) backed by keep-alive http/https agents (maxSockets=50) and three named timeout budgets:
  short 3 s  – health checks (Stellar Horizon, SendGrid)
  medium 8 s – moderation API, webhook delivery
  long  15 s – GitHub API (dependency freshness)

Registers the module globally in AppModule and migrates ExternalModerationApiService, WebhookChannel, ExternalHealthService, and DependencyFreshnessService off ad-hoc axios calls onto the shared client. Adds 12 unit tests covering budget timeouts, agent reuse, and teardown.

Closes #1153

