### PR TITLE
feat(ci): add backend module-level changelog automation

### DIFF
--- a/.github/workflows/backend-changelog.yml
+++ b/.github/workflows/backend-changelog.yml
@@ -1,0 +1,32 @@
+name: Backend Module Changelog
+
+on:
+  pull_request:
+    paths:
+      - "BackEnd/src/modules/**"
+      - "scripts/backend-changelog.js"
+      - ".github/workflows/backend-changelog.yml"
+
+jobs:
+  changelog-discipline:
+    name: Module changelog discipline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Need the PR base commit available for the diff range.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check backend module changelog discipline
+        env:
+          CHANGELOG_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CHANGELOG_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGELOG_PR_TITLE: ${{ github.event.pull_request.title }}
+          CHANGELOG_PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/backend-changelog.js check

--- a/BackEnd/package.json
+++ b/BackEnd/package.json
@@ -16,6 +16,8 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "changelog:check": "node ../scripts/backend-changelog.js check",
+    "changelog:generate": "node ../scripts/backend-changelog.js generate",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/BackEnd/src/modules/admin/CHANGELOG.md
+++ b/BackEnd/src/modules/admin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# admin module changelog
+
+All notable changes to the `admin` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/analytics/CHANGELOG.md
+++ b/BackEnd/src/modules/analytics/CHANGELOG.md
@@ -1,0 +1,7 @@
+# analytics module changelog
+
+All notable changes to the `analytics` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/auth/CHANGELOG.md
+++ b/BackEnd/src/modules/auth/CHANGELOG.md
@@ -1,0 +1,7 @@
+# auth module changelog
+
+All notable changes to the `auth` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/cache/CHANGELOG.md
+++ b/BackEnd/src/modules/cache/CHANGELOG.md
@@ -1,0 +1,7 @@
+# cache module changelog
+
+All notable changes to the `cache` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/email/CHANGELOG.md
+++ b/BackEnd/src/modules/email/CHANGELOG.md
@@ -1,0 +1,7 @@
+# email module changelog
+
+All notable changes to the `email` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/feature-flags/CHANGELOG.md
+++ b/BackEnd/src/modules/feature-flags/CHANGELOG.md
@@ -1,0 +1,7 @@
+# feature-flags module changelog
+
+All notable changes to the `feature-flags` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/health/CHANGELOG.md
+++ b/BackEnd/src/modules/health/CHANGELOG.md
@@ -1,0 +1,7 @@
+# health module changelog
+
+All notable changes to the `health` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# jobs module changelog
+
+All notable changes to the `jobs` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/moderation/CHANGELOG.md
+++ b/BackEnd/src/modules/moderation/CHANGELOG.md
@@ -1,0 +1,7 @@
+# moderation module changelog
+
+All notable changes to the `moderation` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/notifications/CHANGELOG.md
+++ b/BackEnd/src/modules/notifications/CHANGELOG.md
@@ -1,0 +1,7 @@
+# notifications module changelog
+
+All notable changes to the `notifications` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/payouts/CHANGELOG.md
+++ b/BackEnd/src/modules/payouts/CHANGELOG.md
@@ -1,0 +1,7 @@
+# payouts module changelog
+
+All notable changes to the `payouts` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/postmortems/CHANGELOG.md
+++ b/BackEnd/src/modules/postmortems/CHANGELOG.md
@@ -1,0 +1,7 @@
+# postmortems module changelog
+
+All notable changes to the `postmortems` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/query-monitoring/CHANGELOG.md
+++ b/BackEnd/src/modules/query-monitoring/CHANGELOG.md
@@ -1,0 +1,7 @@
+# query-monitoring module changelog
+
+All notable changes to the `query-monitoring` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/quests/CHANGELOG.md
+++ b/BackEnd/src/modules/quests/CHANGELOG.md
@@ -1,0 +1,7 @@
+# quests module changelog
+
+All notable changes to the `quests` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/quota/CHANGELOG.md
+++ b/BackEnd/src/modules/quota/CHANGELOG.md
@@ -1,0 +1,7 @@
+# quota module changelog
+
+All notable changes to the `quota` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/stellar/CHANGELOG.md
+++ b/BackEnd/src/modules/stellar/CHANGELOG.md
@@ -1,0 +1,7 @@
+# stellar module changelog
+
+All notable changes to the `stellar` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/submissions/CHANGELOG.md
+++ b/BackEnd/src/modules/submissions/CHANGELOG.md
@@ -1,0 +1,7 @@
+# submissions module changelog
+
+All notable changes to the `submissions` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/trace/CHANGELOG.md
+++ b/BackEnd/src/modules/trace/CHANGELOG.md
@@ -1,0 +1,7 @@
+# trace module changelog
+
+All notable changes to the `trace` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/users/CHANGELOG.md
+++ b/BackEnd/src/modules/users/CHANGELOG.md
@@ -1,0 +1,7 @@
+# users module changelog
+
+All notable changes to the `users` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/webhooks/CHANGELOG.md
+++ b/BackEnd/src/modules/webhooks/CHANGELOG.md
@@ -1,0 +1,7 @@
+# webhooks module changelog
+
+All notable changes to the `webhooks` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/BackEnd/src/modules/websocket/CHANGELOG.md
+++ b/BackEnd/src/modules/websocket/CHANGELOG.md
@@ -1,0 +1,7 @@
+# websocket module changelog
+
+All notable changes to the `websocket` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/docs/backend-module-changelogs.md
+++ b/docs/backend-module-changelogs.md
@@ -1,0 +1,42 @@
+# Backend Module-Level Changelogs (BE-134)
+
+Backend features live under `BackEnd/src/modules/<module>/`. Each module owns a
+`CHANGELOG.md` so it can be versioned and released independently. Changelog
+upkeep is automated by `scripts/backend-changelog.js`.
+
+## Commands
+
+```bash
+# From BackEnd/ (npm scripts) or repo root (node):
+npm --prefix BackEnd run changelog:check        # discipline gate (used in CI)
+npm --prefix BackEnd run changelog:generate     # write Unreleased entries
+node scripts/backend-changelog.js generate --base <sha> --head <sha> --dry-run
+```
+
+## How it works
+
+- **`check`** — fails when a PR modifies a module's implementation files but does
+  not update that module's `CHANGELOG.md` in the same PR. Breaking changes must
+  carry Conventional Commit metadata (`type(scope)!:`) and a `BREAKING CHANGE:`
+  footer. Runs automatically via
+  [`.github/workflows/backend-changelog.yml`](../.github/workflows/backend-changelog.yml).
+- **`generate`** — parses Conventional Commits in a range, groups them per module
+  by commit **scope** (e.g. `feat(auth): …` → the `auth` module), categorises
+  them using [Keep a Changelog](https://keepachangelog.com/) headings
+  (Added/Changed/Fixed/…), and upserts them into each module's
+  `## [Unreleased]` section. Missing changelog files are created from a template.
+
+## Authoring commits
+
+Scope each commit with the module name so it is attributed correctly:
+
+```
+feat(auth): add refresh-token rotation
+fix(quests): correct reward rounding
+refactor(payouts)!: drop legacy settlement path
+
+BREAKING CHANGE: payout settlement now requires the v2 ledger entry.
+```
+
+Commits without a module scope are skipped by `generate` and reported so they can
+be re-attributed.

--- a/scripts/backend-changelog.js
+++ b/scripts/backend-changelog.js
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+/**
+ * Backend module-level changelog automation (BE-134).
+ *
+ * Backend features live under `BackEnd/src/modules/<module>/`. Each module
+ * owns its own `CHANGELOG.md` so it can be released independently. This tool:
+ *
+ *   1. `check`    — discipline gate: any PR that touches a module's
+ *                   implementation must update that module's CHANGELOG.md in
+ *                   the same PR (and breaking changes must be structured).
+ *   2. `generate` — automation: parses Conventional Commits in a range, groups
+ *                   them per module by commit scope, and upserts categorised
+ *                   entries into each module's `## [Unreleased]` section
+ *                   (creating the file from a Keep-a-Changelog template if
+ *                   missing). Use `--dry-run` to preview without writing.
+ *
+ * The logic is exported as pure functions so it can be unit tested without git.
+ */
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const MODULES_ROOT = 'BackEnd/src/modules';
+const ZERO_SHA_PATTERN = /^0+$/;
+
+/** Conventional-commit type -> Keep a Changelog category. */
+const TYPE_TO_CATEGORY = {
+  feat: 'Added',
+  fix: 'Fixed',
+  perf: 'Changed',
+  refactor: 'Changed',
+  revert: 'Removed',
+  deprecate: 'Deprecated',
+};
+
+const CATEGORY_ORDER = [
+  'Added',
+  'Changed',
+  'Deprecated',
+  'Removed',
+  'Fixed',
+  'Security',
+];
+
+function normalizePath(filePath) {
+  return filePath.replace(/\\/g, '/');
+}
+
+/** Files that count as a module's public/implementation surface. */
+function isImplementationFile(filePath) {
+  const normalized = normalizePath(filePath);
+  if (!normalized.startsWith(`${MODULES_ROOT}/`)) {
+    return false;
+  }
+  if (/\.spec\.ts$|\.test\.ts$/.test(normalized)) {
+    return false;
+  }
+  if (/\/CHANGELOG\.md$/i.test(normalized)) {
+    return false;
+  }
+  return true;
+}
+
+/** Returns the module name a path belongs to, or null. */
+function moduleOf(filePath) {
+  const normalized = normalizePath(filePath);
+  const prefix = `${MODULES_ROOT}/`;
+  if (!normalized.startsWith(prefix)) {
+    return null;
+  }
+  const rest = normalized.slice(prefix.length);
+  const segment = rest.split('/')[0];
+  return segment || null;
+}
+
+function changelogPathForModule(moduleName) {
+  return `${MODULES_ROOT}/${moduleName}/CHANGELOG.md`;
+}
+
+/** Modules whose implementation files were touched. */
+function getAffectedModules(changedFiles) {
+  const modules = new Set();
+  for (const file of changedFiles) {
+    if (isImplementationFile(file)) {
+      const name = moduleOf(file);
+      if (name) {
+        modules.add(name);
+      }
+    }
+  }
+  return [...modules].sort();
+}
+
+function wasModuleChangelogUpdated(changedFiles, moduleName) {
+  const target = changelogPathForModule(moduleName);
+  return changedFiles.map(normalizePath).includes(target);
+}
+
+function isBreakingConventionalHeader(line) {
+  return /^[a-z]+(?:\([^)]+\))?!: .+/.test((line || '').trim());
+}
+
+function hasBreakingFooter(text) {
+  return /(^|\r?\n)BREAKING CHANGE: .+/.test(text || '');
+}
+
+/** Parses a `git log %B` blob (commits separated by ---END---) into headers. */
+function parseConventionalCommits(commitMessages) {
+  const blocks = (commitMessages || '')
+    .split(/---END---/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  const commits = [];
+  for (const block of blocks) {
+    const header = block.split(/\r?\n/)[0].trim();
+    const match = header.match(/^([a-z]+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
+    if (!match) {
+      continue;
+    }
+    const [, type, scope, bang, subject] = match;
+    commits.push({
+      type,
+      scope: scope || null,
+      breaking: Boolean(bang) || hasBreakingFooter(block),
+      subject: subject.trim(),
+      body: block,
+    });
+  }
+  return commits;
+}
+
+function categoryForType(type) {
+  return TYPE_TO_CATEGORY[type] || 'Changed';
+}
+
+/**
+ * Groups commits by the module named in their scope. Commits whose scope does
+ * not match a known module are returned under `unscoped`.
+ */
+function groupCommitsByModule(commits, knownModules) {
+  const known = new Set(knownModules);
+  const byModule = {};
+  const unscoped = [];
+
+  for (const commit of commits) {
+    if (commit.scope && known.has(commit.scope)) {
+      byModule[commit.scope] = byModule[commit.scope] || [];
+      byModule[commit.scope].push(commit);
+    } else {
+      unscoped.push(commit);
+    }
+  }
+  return { byModule, unscoped };
+}
+
+/** Builds the categorised markdown body for a module's Unreleased section. */
+function buildUnreleasedBody(commits) {
+  const buckets = {};
+  for (const commit of commits) {
+    const category = commit.breaking ? 'Changed' : categoryForType(commit.type);
+    buckets[category] = buckets[category] || [];
+    const prefix = commit.breaking ? '**BREAKING** ' : '';
+    buckets[category].push(`- ${prefix}${commit.subject}`);
+  }
+
+  const sections = [];
+  for (const category of CATEGORY_ORDER) {
+    if (buckets[category] && buckets[category].length > 0) {
+      sections.push(`### ${category}\n${buckets[category].join('\n')}`);
+    }
+  }
+  return sections.join('\n\n');
+}
+
+function emptyChangelogTemplate(moduleName) {
+  return `# ${moduleName} module changelog
+
+All notable changes to the \`${moduleName}\` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+`;
+}
+
+/**
+ * Inserts/merges generated entries into the `## [Unreleased]` section of an
+ * existing changelog string, returning the new content. Pure (no IO).
+ */
+function upsertUnreleased(changelogContent, generatedBody) {
+  if (!generatedBody) {
+    return changelogContent;
+  }
+  const lines = changelogContent.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === '## [Unreleased]');
+
+  if (start === -1) {
+    // No Unreleased section — prepend one after the first heading block.
+    return `${changelogContent.trimEnd()}\n\n## [Unreleased]\n\n${generatedBody}\n`;
+  }
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^## \[/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const before = lines.slice(0, start + 1).join('\n');
+  const after = lines.slice(end).join('\n');
+  const merged = `${before}\n\n${generatedBody}\n`;
+  return after ? `${merged}\n${after}` : `${merged}`;
+}
+
+/**
+ * Discipline evaluation: any module with implementation changes must update its
+ * changelog in the same PR; breaking changes must carry proper metadata.
+ */
+function evaluateBackendChangelogDiscipline({
+  changedFiles = [],
+  commitMessages = '',
+  prTitle = '',
+  prBody = '',
+}) {
+  const normalized = changedFiles.map(normalizePath);
+  const affected = getAffectedModules(normalized);
+
+  if (affected.length === 0) {
+    return { ok: true, errors: [], details: { checked: false, affected } };
+  }
+
+  const errors = [];
+  for (const moduleName of affected) {
+    if (!wasModuleChangelogUpdated(normalized, moduleName)) {
+      errors.push(
+        `Changes to the "${moduleName}" module require an update to ${changelogPathForModule(
+          moduleName,
+        )} in the same PR.`,
+      );
+    }
+  }
+
+  const commitLines = (commitMessages || '').split(/\r?\n/);
+  const breakingSignal =
+    isBreakingConventionalHeader(prTitle) ||
+    hasBreakingFooter(commitMessages) ||
+    hasBreakingFooter(prBody) ||
+    commitLines.some(isBreakingConventionalHeader);
+
+  if (breakingSignal) {
+    const hasMetadata =
+      isBreakingConventionalHeader(prTitle) ||
+      commitLines.some(isBreakingConventionalHeader);
+    if (!hasMetadata) {
+      errors.push(
+        'Breaking module changes must use Conventional Commit breaking metadata (`type(scope)!:`).',
+      );
+    }
+    if (!hasBreakingFooter(commitMessages) && !hasBreakingFooter(prBody)) {
+      errors.push(
+        'Breaking module changes must include a `BREAKING CHANGE:` explanation in the commit history or PR body.',
+      );
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    details: { checked: true, affected, breakingSignal },
+  };
+}
+
+// ── git helpers (CLI only) ───────────────────────────────────────────────────
+
+function runGit(repoRoot, args) {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function resolveBaseAndHead(repoRoot, options = {}) {
+  let base = options.base || process.env.CHANGELOG_BASE_SHA || '';
+  const head = options.head || process.env.CHANGELOG_HEAD_SHA || 'HEAD';
+  if (!base || ZERO_SHA_PATTERN.test(base)) {
+    base = runGit(repoRoot, ['rev-parse', `${head}^`]);
+  }
+  return { base, head };
+}
+
+function getChangedFiles(repoRoot, base, head) {
+  const output = runGit(repoRoot, ['diff', '--name-only', `${base}...${head}`]);
+  return output ? output.split(/\r?\n/).map(normalizePath).filter(Boolean) : [];
+}
+
+function getCommitMessages(repoRoot, base, head) {
+  return runGit(repoRoot, ['log', '--format=%B%n---END---', `${base}..${head}`]);
+}
+
+function discoverModules(repoRoot) {
+  const dir = path.join(repoRoot, MODULES_ROOT);
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+function parseArgs(argv) {
+  const result = { command: argv[2] || 'check', dryRun: false };
+  for (let i = 3; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--base') {
+      result.base = argv[++i];
+    } else if (token === '--head') {
+      result.head = argv[++i];
+    } else if (token === '--dry-run') {
+      result.dryRun = true;
+    }
+  }
+  return result;
+}
+
+function runCheck(repoRoot, options) {
+  let changedFiles = process.env.CHANGELOG_CHANGED_FILES
+    ? process.env.CHANGELOG_CHANGED_FILES.split(/\r?\n|;/).map(normalizePath).filter(Boolean)
+    : null;
+  let commitMessages = process.env.CHANGELOG_COMMIT_MESSAGES || '';
+  let base = options.base;
+  let head = options.head;
+
+  if (!changedFiles) {
+    const range = resolveBaseAndHead(repoRoot, options);
+    base = range.base;
+    head = range.head;
+    changedFiles = getChangedFiles(repoRoot, base, head);
+    if (!commitMessages) {
+      commitMessages = getCommitMessages(repoRoot, base, head);
+    }
+  }
+
+  const result = evaluateBackendChangelogDiscipline({
+    changedFiles,
+    commitMessages,
+    prTitle: process.env.CHANGELOG_PR_TITLE || '',
+    prBody: process.env.CHANGELOG_PR_BODY || '',
+  });
+
+  if (!result.details.checked) {
+    console.log('No backend module changes detected; changelog discipline check skipped.');
+    return 0;
+  }
+  if (!result.ok) {
+    console.error('\nBackend module changelog discipline check failed:');
+    result.errors.forEach((error) => console.error(` - ${error}`));
+    return 1;
+  }
+  console.log(
+    `Backend module changelog discipline check passed (modules: ${result.details.affected.join(', ')}).`,
+  );
+  return 0;
+}
+
+function runGenerate(repoRoot, options) {
+  const range = resolveBaseAndHead(repoRoot, options);
+  const commitMessages = getCommitMessages(repoRoot, range.base, range.head);
+  const commits = parseConventionalCommits(commitMessages);
+  const knownModules = discoverModules(repoRoot);
+  const { byModule, unscoped } = groupCommitsByModule(commits, knownModules);
+
+  const moduleNames = Object.keys(byModule).sort();
+  if (moduleNames.length === 0) {
+    console.log('No module-scoped Conventional Commits found in range; nothing to generate.');
+  }
+
+  for (const moduleName of moduleNames) {
+    const body = buildUnreleasedBody(byModule[moduleName]);
+    const filePath = path.join(repoRoot, changelogPathForModule(moduleName));
+    const existing = fs.existsSync(filePath)
+      ? fs.readFileSync(filePath, 'utf8')
+      : emptyChangelogTemplate(moduleName);
+    const updated = upsertUnreleased(existing, body);
+
+    if (options.dryRun) {
+      console.log(`\n--- ${changelogPathForModule(moduleName)} (dry-run) ---\n${body}`);
+    } else {
+      fs.writeFileSync(filePath, updated);
+      console.log(`Updated ${changelogPathForModule(moduleName)} (${byModule[moduleName].length} commit(s)).`);
+    }
+  }
+
+  if (unscoped.length > 0) {
+    console.log(
+      `\nNote: ${unscoped.length} commit(s) had no module scope and were skipped. ` +
+        'Use `type(module): subject` to attribute them to a module.',
+    );
+  }
+  return 0;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const options = parseArgs(process.argv);
+  if (options.command === 'generate') {
+    return runGenerate(repoRoot, options);
+  }
+  return runCheck(repoRoot, options);
+}
+
+if (require.main === module) {
+  try {
+    process.exit(main());
+  } catch (error) {
+    console.error('Unable to complete backend changelog automation.');
+    console.error(error && error.stack ? error.stack : error);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  MODULES_ROOT,
+  buildUnreleasedBody,
+  categoryForType,
+  changelogPathForModule,
+  emptyChangelogTemplate,
+  evaluateBackendChangelogDiscipline,
+  getAffectedModules,
+  groupCommitsByModule,
+  isImplementationFile,
+  moduleOf,
+  normalizePath,
+  parseConventionalCommits,
+  upsertUnreleased,
+  wasModuleChangelogUpdated,
+};

--- a/tests/backend-changelog.test.js
+++ b/tests/backend-changelog.test.js
@@ -1,0 +1,150 @@
+const assert = require('assert');
+const {
+  buildUnreleasedBody,
+  evaluateBackendChangelogDiscipline,
+  getAffectedModules,
+  groupCommitsByModule,
+  isImplementationFile,
+  moduleOf,
+  parseConventionalCommits,
+  upsertUnreleased,
+  changelogPathForModule,
+} = require('../scripts/backend-changelog');
+
+function testIsImplementationFile() {
+  assert.strictEqual(isImplementationFile('BackEnd/src/modules/auth/auth.service.ts'), true);
+  assert.strictEqual(isImplementationFile('BackEnd/src/modules/auth/auth.service.spec.ts'), false);
+  assert.strictEqual(isImplementationFile('BackEnd/src/modules/auth/CHANGELOG.md'), false);
+  assert.strictEqual(isImplementationFile('BackEnd/src/common/logger.ts'), false);
+  assert.strictEqual(isImplementationFile('README.md'), false);
+}
+
+function testModuleOf() {
+  assert.strictEqual(moduleOf('BackEnd/src/modules/submissions/dto/x.ts'), 'submissions');
+  assert.strictEqual(moduleOf('FrontEnd/app.tsx'), null);
+}
+
+function testGetAffectedModules() {
+  const files = [
+    'BackEnd/src/modules/auth/auth.service.ts',
+    'BackEnd/src/modules/quests/quests.controller.ts',
+    'BackEnd/src/modules/auth/auth.module.ts',
+    'README.md',
+  ];
+  assert.deepStrictEqual(getAffectedModules(files), ['auth', 'quests']);
+}
+
+function testSkipsWhenNoModuleChanges() {
+  const result = evaluateBackendChangelogDiscipline({ changedFiles: ['README.md'] });
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.details.checked, false);
+}
+
+function testRequiresChangelogWhenModuleChanges() {
+  const result = evaluateBackendChangelogDiscipline({
+    changedFiles: ['BackEnd/src/modules/auth/auth.service.ts'],
+    commitMessages: 'feat(auth): add refresh tokens',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(
+    result.errors.includes(
+      `Changes to the "auth" module require an update to ${changelogPathForModule('auth')} in the same PR.`,
+    ),
+  );
+}
+
+function testPassesWithModuleChangelogUpdate() {
+  const result = evaluateBackendChangelogDiscipline({
+    changedFiles: [
+      'BackEnd/src/modules/auth/auth.service.ts',
+      'BackEnd/src/modules/auth/CHANGELOG.md',
+    ],
+    commitMessages: 'feat(auth): add refresh tokens',
+  });
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.details.breakingSignal, false);
+}
+
+function testBreakingRequiresMetadataAndFooter() {
+  const result = evaluateBackendChangelogDiscipline({
+    changedFiles: [
+      'BackEnd/src/modules/auth/auth.service.ts',
+      'BackEnd/src/modules/auth/CHANGELOG.md',
+    ],
+    // Breaking footer present but no `type(scope)!:` metadata.
+    commitMessages: 'feat(auth): rework sessions\n\nBREAKING CHANGE: tokens rotate',
+    prTitle: 'feat(auth): rework sessions',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(
+    result.errors.some((e) => e.includes('Conventional Commit breaking metadata')),
+  );
+}
+
+function testParseConventionalCommits() {
+  const log = [
+    'feat(auth): add login\n\nbody',
+    '---END---',
+    'fix(quests): correct reward calc',
+    '---END---',
+    'chore: tidy repo',
+    '---END---',
+    'refactor(auth)!: drop legacy guard\n\nBREAKING CHANGE: removed',
+    '---END---',
+  ].join('\n');
+  const commits = parseConventionalCommits(log);
+  assert.strictEqual(commits.length, 4);
+  assert.strictEqual(commits[0].scope, 'auth');
+  assert.strictEqual(commits[3].breaking, true);
+}
+
+function testGroupCommitsByModule() {
+  const commits = parseConventionalCommits(
+    'feat(auth): a\n---END---\nfix(quests): b\n---END---\nchore: c\n---END---',
+  );
+  const { byModule, unscoped } = groupCommitsByModule(commits, ['auth', 'quests']);
+  assert.deepStrictEqual(Object.keys(byModule).sort(), ['auth', 'quests']);
+  assert.strictEqual(unscoped.length, 1);
+}
+
+function testBuildUnreleasedBody() {
+  const commits = parseConventionalCommits(
+    'feat(auth): add login\n---END---\nfix(auth): patch leak\n---END---',
+  );
+  const body = buildUnreleasedBody(commits);
+  assert.ok(body.includes('### Added'));
+  assert.ok(body.includes('- add login'));
+  assert.ok(body.includes('### Fixed'));
+  assert.ok(body.includes('- patch leak'));
+}
+
+function testUpsertUnreleased() {
+  const original = '# auth module changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2025-01-01\n\n### Added\n- initial\n';
+  const merged = upsertUnreleased(original, '### Added\n- add login');
+  assert.ok(merged.includes('## [Unreleased]'));
+  assert.ok(merged.includes('- add login'));
+  assert.ok(merged.includes('## [1.0.0] - 2025-01-01'));
+  // Older release content is preserved.
+  assert.ok(merged.includes('- initial'));
+}
+
+function runAll() {
+  testIsImplementationFile();
+  testModuleOf();
+  testGetAffectedModules();
+  testSkipsWhenNoModuleChanges();
+  testRequiresChangelogWhenModuleChanges();
+  testPassesWithModuleChangelogUpdate();
+  testBreakingRequiresMetadataAndFooter();
+  testParseConventionalCommits();
+  testGroupCommitsByModule();
+  testBuildUnreleasedBody();
+  testUpsertUnreleased();
+  console.log('backend-changelog tests passed');
+}
+
+if (require.main === module) {
+  runAll();
+}
+
+module.exports = { runAll };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -9,6 +9,9 @@ const {
 } = require("./lint-staged-config.test");
 const { runAll: runPreCommitHookTests } = require("./pre-commit-hook.test");
 const { runAll: runReleasePackageTests } = require("./contract-release-package.test");
+const {
+  runAll: runBackendChangelogTests,
+} = require("./backend-changelog.test");
 
 try {
   runOrphanedScriptTests();
@@ -16,6 +19,7 @@ try {
   runLintStagedConfigTests();
   runPreCommitHookTests();
   runReleasePackageTests();
+  runBackendChangelogTests();
   console.log("All tests passed");
   process.exit(0);
 } catch (e) {


### PR DESCRIPTION
## Linked Issue

Closes #1161

> **Required:** Every PR must be linked to an open issue. PRs without a linked issue will not be reviewed.

---

## Description

**What changed?**
Added per-module changelog automation for the backend so modules under `BackEnd/src/modules/<module>/` can be versioned and released independently — a discipline gate plus a generator, mirroring the existing contract changelog tooling.

**Why was it changed?**
Backend changes had no module-level changelog discipline, making module-scoped release notes manual and inconsistent. This automates the convention and enforces it in CI.

**How was it implemented?**
- `scripts/backend-changelog.js` with two commands:
  - `check` — discipline gate: a PR that modifies a module's implementation must update that module's `CHANGELOG.md` in the same PR; breaking changes must carry Conventional Commit metadata (`type(scope)!:`) and a `BREAKING CHANGE:` footer. Logic is exported as pure functions for testing.
  - `generate` — parses Conventional Commits in a range, groups them per module by commit **scope**, categorises with Keep a Changelog headings (Added/Changed/Fixed/…), and upserts into each module's `## [Unreleased]` section (creating the file from a template if missing). Supports `--dry-run`.
- CI: `.github/workflows/backend-changelog.yml` runs `check` on PRs touching `BackEnd/src/modules/**`, using the PR base/head SHAs.
- npm scripts `changelog:check` / `changelog:generate` in `BackEnd/package.json`.
- Bootstrapped a `CHANGELOG.md` for all 21 backend modules.
- Docs at `docs/backend-module-changelogs.md`; tests at `tests/backend-changelog.test.js` wired into `tests/run-tests.js`.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Security fix
- [ ] Refactor (no functional change)
- [x] Documentation update
- [x] Tests only
- [x] Configuration / DevOps change

---

## Contract Changelog Discipline

- [x] No contract implementation changes - not applicable
- [ ] Updated `contracts/earn-quest/CHANGELOG.md` under `## [Unreleased]`
- [ ] If breaking, added a `### Breaking Changes` entry with impact, affected files, and migration steps
- [ ] If breaking, used Conventional Commit breaking metadata (`type(scope)!:`) in the PR title or commit history
- [ ] If breaking, included a `BREAKING CHANGE:` explanation below

**BREAKING CHANGE details (required for breaking contract changes):**

```text
BREAKING CHANGE:
```

---

## Test Evidence

### Unit Tests

- [x] New unit tests added for changed logic
- [x] All existing unit tests pass (`npm run test`)
- [ ] Coverage does not regress (`npm run test:cov`)

**Test output / screenshot:**

```
$ node tests/run-tests.js
backend-changelog tests passed
All tests passed
```

Behavioural verification of the gate:

```
$ CHANGELOG_CHANGED_FILES="BackEnd/src/modules/auth/auth.service.ts" node scripts/backend-changelog.js check
Backend module changelog discipline check failed:
 - Changes to the "auth" module require an update to BackEnd/src/modules/auth/CHANGELOG.md in the same PR.
# exit 1

$ CHANGELOG_CHANGED_FILES=$'BackEnd/src/modules/auth/auth.service.ts\nBackEnd/src/modules/auth/CHANGELOG.md' node scripts/backend-changelog.js check
Backend module changelog discipline check passed (modules: auth).
# exit 0
```

### E2E / Integration Tests

- [ ] E2E tests added or updated (`npm run test:e2e`)
- [x] Tested manually against a local environment *(ran `check` and `generate --dry-run` locally; see output above)*

**Endpoints tested:**

| Method | Endpoint | Expected | Result |
|--------|----------|----------|--------|
| n/a    | Tooling / CI change — no HTTP endpoints | n/a | [x] |

---

## Swagger / API Documentation

- [x] No API changes - Swagger update not applicable
- [ ] New endpoints documented with `@ApiOperation`, `@ApiResponse`, and `@ApiBearerAuth` decorators
- [ ] Updated DTOs annotated with `@ApiProperty` / `@ApiPropertyOptional`
- [ ] Swagger UI verified locally at `/api/docs` and responses are accurate
- [ ] Breaking changes to existing contracts are documented in the description above

---

## Error Handling Checklist

### HTTP Exceptions

- [x] Not applicable - this PR adds a Node CLI / CI script, not request handlers
- [ ] No raw `Error` thrown where an HTTP exception is expected
- [ ] Global exception filter handles all unhandled errors gracefully
- [ ] Error responses follow the project's standard error shape

### Input Validation (DTOs)

- [x] Not applicable - no request input; the script validates CLI args / env and git ranges
- [ ] DTOs use `class-validator` decorators
- [ ] `class-transformer` decorators applied where necessary
- [ ] `ValidationPipe` is applied globally or at the controller level

### Guards & Authorization

- [x] Not applicable - no endpoints added
- [ ] Admin-only endpoints use the appropriate admin guard / role check
- [ ] Public endpoints are explicitly marked with `@Public()` decorator where applicable
- [ ] Throttler guard behaviour verified

### Logging

- [x] Script reports actionable output to stdout/stderr and exits non-zero on failure
- [x] No sensitive data (passwords, secrets, private keys, tokens) is included in log output
- [ ] Errors are logged at `error` level with stack traces
- [ ] Incoming request / response logging is handled by the global `LoggerMiddleware`

### Stellar / Soroban Contract Interactions

- [x] No Stellar/Soroban interactions in this PR - not applicable
- [ ] Contract calls wrapped in try/catch with descriptive error messages
- [ ] Horizon / Soroban RPC failures do not crash the service
- [ ] Transaction signing uses environment-provided keys only - no hardcoded secrets

---

## Database / Migration

- [x] No database changes - not applicable
- [ ] TypeORM migration created and tested (`npm run typeorm:generate-migration`)
- [ ] Migration is reversible (down migration implemented)
- [ ] Seed data updated if required (`seed.ts`)

---

## Breaking Type / Model Changes (Frontend — FE-068)

- [x] My PR touches **none** of the watched type/model paths — not applicable.
- [ ] I classified my change as: ☐ `breaking-types` ☐ `breaking-runtime` ☐ `added` ☐ `changed` ☐ `deprecated` ☐ `removed` ☐ `fixed` ☐ `security`
- [ ] I added a bullet to `## [Unreleased]` in `FrontEnd/my-app/CHANGELOG.md` **OR** a new file in `FrontEnd/my-app/.changeset/`.
- [ ] If breaking, my entry includes a before/after `Migration:` code block.
- [ ] `cd FrontEnd/my-app && npm run changelog:check` passes locally.
- [ ] If I am asserting this change is non-breaking despite touching a watched file, I added the `changelog-skip` label or `[changelog-skip]` to the PR title.

---

## Final Pre-Merge Checklist

- [ ] Branch is up to date with `main` / `master`
- [ ] Linting passes (`npm run lint`)
- [ ] Formatting passes (`npm run format`)
- [x] No `console.log` / debug statements left in production code *(intentional CLI `console.log` output only)*
- [x] No hardcoded secrets, API keys, or environment-specific values in source code
- [x] `.env.example` updated if new environment variables were introduced *(no new env vars)*
- [x] `ReadMe Backend.md` or `ReadMe Frontend.md` updated if setup steps changed *(added `docs/backend-module-changelogs.md`)*
- [x] Self-review completed - I have read through every line of the diff

---

## Additional Notes for Reviewer

- Running `node scripts/backend-changelog.js check` with the default `HEAD~1` range will flag the already-merged `fix(app): disable PostmortemsModule` commit as missing a module changelog — that is the gate working as designed on pre-existing history. In CI it diffs the PR's `base...head`, so merged history is not penalized.
- The 21 seeded `CHANGELOG.md` files are template stubs (each with a `## [Unreleased]` section) so the discipline gate and generator have targets from day one.
- Scope your commits as `type(module): subject` (e.g. `feat(auth): …`) so `generate` attributes them to the right module; unscoped commits are reported and skipped.