### PR TITLE
feat: integrate Stellar SDK transaction execution for payout jobs (#1900)

### DIFF
--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -7,13 +7,16 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+
 - Per-job-type retry and backoff policies via `JobRetryPolicy` map (`job-retry-policy.ts`). Every `JobType` enum value now has an explicit policy (attempts, backoff type/delay, non-retryable error patterns, Redis retention limits).
 - `addJob()` accepts an optional `jobType` parameter. When provided, the per-type `JobRetryPolicy` is resolved and merged into BullMQ options before any caller-supplied overrides. Precedence: caller opts > per-type policy > `DEFAULT_JOB_OPTIONS`.
 - Non-retryable error detection in the worker `failed` handler: errors matching a job type's `nonRetryableErrors` patterns bypass remaining retries and are forwarded to the dead-letter queue immediately.
 - `__jobType` is embedded in job data by `addJob()` so the worker can resolve the correct policy at failure time.
 - `DEFAULT_JOB_OPTIONS` is now derived from `DEFAULT_RETRY_POLICY` (5 attempts, exponential backoff starting at 5 s) to keep defaults consistent.
 - `job-scheduler.service.ts`: `startSchedule()` and `triggerScheduleNow()` embed `__jobType` and apply the per-type policy when enqueuing.
+- Stellar SDK transaction execution in `PayoutProcessor` (`payout.processor.ts`): replaces the `// TODO` simulation with a real `StellarService.sendPayment()` call. The processor now builds, signs, and submits a live Stellar payment; `transactionHash` in the job result reflects the on-chain hash.
 
 ### Changed
+
 - `DependencyFreshnessService` now uses `PooledHttpClientService` (keep-alive connection pool, 15 s `long` timeout budget) instead of a raw `axios` call for GitHub API requests. `HttpClientModule` added to `JobsModule` imports.
 - `addJob()` signature extended: `addJob(name, data, opts?, jobType?)` — fully backward-compatible; callers that omit `jobType` continue to use `DEFAULT_JOB_OPTIONS`.

--- a/BackEnd/src/modules/jobs/processors/payout.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/payout.processor.ts
@@ -3,6 +3,7 @@ import { Job } from 'bullmq';
 import { PayoutProcessPayload, JobResult, JobType } from '../job.types';
 import { JobLogService } from '../services/job-log.service';
 import { JobIdempotencyService } from '../services/job-idempotency.service';
+import { StellarService } from '../../stellar/stellar.service';
 
 /**
  * Payout Processor
@@ -33,6 +34,7 @@ export class PayoutProcessor {
   constructor(
     private readonly jobLogService: JobLogService,
     private readonly jobIdempotencyService: JobIdempotencyService,
+    private readonly stellarService: StellarService,
   ) {}
 
   /**
@@ -110,16 +112,12 @@ export class PayoutProcessor {
 
       await job.updateProgress(50);
 
-      // TODO: Integrate with Stellar SDK to execute transaction
-      // This would involve:
-      // 1. Load sender account from Stellar network
-      // 2. Create payment transaction
-      // 3. Sign transaction
-      // 4. Submit to network
-      // 5. Wait for confirmation
-
-      // Simulate payout processing (replace with real Stellar SDK call)
-      const transactionHash = `tx_${payoutId.substring(0, 8)}_${organizationId.substring(0, 4)}`;
+      // Execute the Stellar payment transaction
+      const stellarResult = await this.stellarService.sendPayment(
+        recipientAddress,
+        amount,
+      );
+      const transactionHash = stellarResult.transactionHash;
 
       await job.updateProgress(75);
 

--- a/BackEnd/src/modules/stellar/CHANGELOG.md
+++ b/BackEnd/src/modules/stellar/CHANGELOG.md
@@ -5,3 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+### Added
+
+- `sendPayment(recipientAddress, amount, asset?)` public method on `StellarService` for disbursing XLM (or other Stellar assets) via Horizon. Loads the configured admin keypair from `SOROBAN_SECRET_KEY` / `STELLAR_ADMIN_SECRET`, builds a payment operation with `TransactionBuilder` and `Operation.payment`, signs, and submits. Returns `{ transactionHash, ledger }`.

--- a/BackEnd/src/modules/stellar/stellar.service.ts
+++ b/BackEnd/src/modules/stellar/stellar.service.ts
@@ -585,4 +585,58 @@ export class StellarService implements OnModuleInit {
   getNetworkPassphrase(): string {
     return this.networkPassphrase;
   }
+
+  /**
+   * Send a native XLM (or other asset) payment via Stellar Horizon.
+   *
+   * Uses the configured admin keypair (`SOROBAN_SECRET_KEY` /
+   * `STELLAR_ADMIN_SECRET`) as the source account.  Intended for payout
+   * job execution where the platform wallet disburses funds to a recipient.
+   */
+  async sendPayment(
+    recipientAddress: string,
+    amount: number,
+    asset: string = 'XLM',
+  ): Promise<{ transactionHash: string; ledger: number }> {
+    const secretKey =
+      this.configService.get<string>('SOROBAN_SECRET_KEY') ||
+      this.configService.get<string>('STELLAR_ADMIN_SECRET');
+
+    if (!secretKey) {
+      throw new Error('No Stellar secret key configured for payments');
+    }
+
+    const sourceKeypair = Keypair.fromSecret(secretKey);
+    const sourceAccount = await this.horizonServer.loadAccount(
+      sourceKeypair.publicKey(),
+    );
+
+    const paymentAsset =
+      asset === 'XLM'
+        ? StellarSdk.Asset.native()
+        : new StellarSdk.Asset(asset, sourceKeypair.publicKey());
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: '100',
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: recipientAddress,
+          asset: paymentAsset,
+          amount: amount.toFixed(7),
+        }),
+      )
+      .setTimeout(30)
+      .build();
+
+    tx.sign(sourceKeypair);
+
+    const result = await this.horizonServer.submitTransaction(tx);
+
+    return {
+      transactionHash: result.hash,
+      ledger: (result as any).ledger ?? 0,
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `sendPayment` public method to `StellarService` that builds, signs, and submits a native XLM payment via Stellar Horizon
- Injects `StellarService` into `PayoutProcessor` and replaces the `// TODO` stub with a real Stellar transaction call
- Idempotency lock, validation, and progress reporting are fully preserved

## Changes

- `BackEnd/src/modules/stellar/stellar.service.ts` — new `sendPayment(recipient, amount, asset?)` method using `Keypair`, `TransactionBuilder`, and `Operation.payment`
- `BackEnd/src/modules/jobs/processors/payout.processor.ts` — inject `StellarService`; replace simulated `transactionHash` with live Stellar payment result

closes #1900