### PR TITLE
fix(quota): eliminate TOCTOU race in quest-creation and payout quota checks

### DIFF
--- a/BackEnd/src/modules/quota/CHANGELOG.md
+++ b/BackEnd/src/modules/quota/CHANGELOG.md
@@ -5,3 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+### Fixed
+
+- Eliminated TOCTOU race condition in `enforceQuestCreationQuota` and `enforcePayoutQuota`. The separate check and increment operations are now wrapped in a database transaction with a `SELECT FOR UPDATE` (pessimistic write) row lock, ensuring concurrent requests cannot both pass the quota check before either increments the counter.

--- a/BackEnd/src/modules/quota/quota.service.spec.ts
+++ b/BackEnd/src/modules/quota/quota.service.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { ForbiddenException } from '@nestjs/common';
 import { QuotaService } from './quota.service';
 import { QuotaConfig } from './entities/quota-config.entity';
 import { QuotaUsage, QuotaResourceType } from './entities/quota-usage.entity';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const makeConfig = (overrides: Partial<QuotaConfig> = {}): QuotaConfig => ({
   id: 'cfg-1',
@@ -28,6 +30,27 @@ const makeUsage = (overrides: Partial<QuotaUsage> = {}): QuotaUsage => ({
   ...overrides,
 });
 
+// ─── Mock factories ───────────────────────────────────────────────────────────
+
+/** Returns a fully chainable query builder mock. */
+const makeQb = () => {
+  const qb: Record<string, jest.Mock> = {} as Record<string, jest.Mock>;
+  const self = () => qb;
+  for (const m of [
+    'insert',
+    'into',
+    'values',
+    'orIgnore',
+    'update',
+    'set',
+    'where',
+  ]) {
+    qb[m] = jest.fn().mockReturnValue(qb);
+  }
+  qb['execute'] = jest.fn().mockResolvedValue(undefined);
+  return qb;
+};
+
 const mockConfigRepo = () => ({
   findOne: jest.fn(),
   save: jest.fn(),
@@ -42,20 +65,40 @@ const mockUsageRepo = () => ({
   createQueryBuilder: jest.fn(),
 });
 
+/** EntityManager mock passed to the transaction callback. */
+const makeMockManager = () => ({
+  createQueryBuilder: jest.fn(() => makeQb()),
+  findOne: jest.fn(),
+  increment: jest.fn().mockResolvedValue(undefined),
+});
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
 describe('QuotaService', () => {
   let service: QuotaService;
   let configRepo: ReturnType<typeof mockConfigRepo>;
   let usageRepo: ReturnType<typeof mockUsageRepo>;
+  let mockManager: ReturnType<typeof makeMockManager>;
+  let mockDataSource: { transaction: jest.Mock };
 
   beforeEach(async () => {
     configRepo = mockConfigRepo();
     usageRepo = mockUsageRepo();
+    mockManager = makeMockManager();
+    mockDataSource = {
+      transaction: jest
+        .fn()
+        .mockImplementation((cb: (m: typeof mockManager) => Promise<unknown>) =>
+          cb(mockManager),
+        ),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         QuotaService,
         { provide: getRepositoryToken(QuotaConfig), useValue: configRepo },
         { provide: getRepositoryToken(QuotaUsage), useValue: usageRepo },
+        { provide: getDataSourceToken(), useValue: mockDataSource },
       ],
     }).compile();
 
@@ -64,7 +107,7 @@ describe('QuotaService', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  // ─── getPeriodStart ────────────────────────────────────────────────────────
+  // ─── getPeriodStart ──────────────────────────────────────────────────────
 
   describe('getPeriodStart', () => {
     it('returns the floored period start for a daily period', () => {
@@ -82,7 +125,7 @@ describe('QuotaService', () => {
     });
   });
 
-  // ─── getConfig ────────────────────────────────────────────────────────────
+  // ─── getConfig ───────────────────────────────────────────────────────────
 
   describe('getConfig', () => {
     it('returns config when found', async () => {
@@ -99,7 +142,7 @@ describe('QuotaService', () => {
     });
   });
 
-  // ─── setConfig ────────────────────────────────────────────────────────────
+  // ─── setConfig ───────────────────────────────────────────────────────────
 
   describe('setConfig', () => {
     it('creates a new config when none exists', async () => {
@@ -135,7 +178,7 @@ describe('QuotaService', () => {
     });
   });
 
-  // ─── enforceQuestCreationQuota ────────────────────────────────────────────
+  // ─── enforceQuestCreationQuota ───────────────────────────────────────────
 
   describe('enforceQuestCreationQuota', () => {
     it('does nothing when no config exists', async () => {
@@ -143,7 +186,7 @@ describe('QuotaService', () => {
       await expect(
         service.enforceQuestCreationQuota('TENANT_A'),
       ).resolves.toBeUndefined();
-      expect(usageRepo.findOne).not.toHaveBeenCalled();
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
     it('does nothing when maxQuestsPerPeriod is null (unlimited)', async () => {
@@ -153,53 +196,120 @@ describe('QuotaService', () => {
       await expect(
         service.enforceQuestCreationQuota('TENANT_A'),
       ).resolves.toBeUndefined();
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
-    it('increments quest count when under limit', async () => {
-      configRepo.findOne.mockResolvedValue(
-        makeConfig({ maxQuestsPerPeriod: 5 }),
-      );
-      const usage = makeUsage({ questCount: 3 });
-      usageRepo.findOne.mockResolvedValue(usage);
-      usageRepo.increment.mockResolvedValue(undefined);
+    it('runs check-and-increment inside a transaction', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 5 }));
+      mockManager.findOne.mockResolvedValue(makeUsage({ questCount: 3 }));
 
       await service.enforceQuestCreationQuota('TENANT_A');
-      expect(usageRepo.increment).toHaveBeenCalledWith(
+
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('increments quest count inside the transaction when under limit', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 5 }));
+      const usage = makeUsage({ questCount: 3 });
+      mockManager.findOne.mockResolvedValue(usage);
+
+      await service.enforceQuestCreationQuota('TENANT_A');
+
+      expect(mockManager.increment).toHaveBeenCalledWith(
+        QuotaUsage,
         { id: usage.id },
         'questCount',
         1,
       );
     });
 
-    it('throws ForbiddenException when quest limit is reached', async () => {
-      configRepo.findOne.mockResolvedValue(
-        makeConfig({ maxQuestsPerPeriod: 5 }),
+    it('acquires a pessimistic_write lock on the usage row', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 5 }));
+      mockManager.findOne.mockResolvedValue(makeUsage({ questCount: 0 }));
+
+      await service.enforceQuestCreationQuota('TENANT_A');
+
+      expect(mockManager.findOne).toHaveBeenCalledWith(
+        QuotaUsage,
+        expect.objectContaining({ lock: { mode: 'pessimistic_write' } }),
       );
-      usageRepo.findOne.mockResolvedValue(makeUsage({ questCount: 5 }));
+    });
+
+    it('throws ForbiddenException when quest limit is reached', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 5 }));
+      mockManager.findOne.mockResolvedValue(makeUsage({ questCount: 5 }));
 
       await expect(
         service.enforceQuestCreationQuota('TENANT_A'),
       ).rejects.toThrow(ForbiddenException);
-      expect(usageRepo.increment).not.toHaveBeenCalled();
+      expect(mockManager.increment).not.toHaveBeenCalled();
     });
 
-    it('creates a new usage record when none exists for the period', async () => {
-      configRepo.findOne.mockResolvedValue(
-        makeConfig({ maxQuestsPerPeriod: 5 }),
-      );
-      usageRepo.findOne.mockResolvedValue(null);
-      const newUsage = makeUsage({ questCount: 0 });
-      usageRepo.create.mockReturnValue(newUsage);
-      usageRepo.save.mockResolvedValue(newUsage);
-      usageRepo.increment.mockResolvedValue(undefined);
+    it('throws ForbiddenException when quest limit is exceeded', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 5 }));
+      mockManager.findOne.mockResolvedValue(makeUsage({ questCount: 6 }));
+
+      await expect(
+        service.enforceQuestCreationQuota('TENANT_A'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('creates a new usage row before locking (orIgnore insert)', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 5 }));
+      mockManager.findOne.mockResolvedValue(makeUsage({ questCount: 0 }));
 
       await service.enforceQuestCreationQuota('TENANT_A');
-      expect(usageRepo.save).toHaveBeenCalled();
-      expect(usageRepo.increment).toHaveBeenCalled();
+
+      const qb = mockManager.createQueryBuilder.mock.results[0].value;
+      expect(qb.insert).toHaveBeenCalled();
+      expect(qb.orIgnore).toHaveBeenCalled();
+    });
+
+    // ── Concurrency regression ──────────────────────────────────────────────
+    //
+    // True concurrency safety is guaranteed by the DB-level SELECT FOR UPDATE
+    // lock (pessimistic_write). The tests below verify that every call runs
+    // inside its own transaction and that the boundary condition is enforced
+    // within the locked read, so no concurrent request can slip past a stale
+    // questCount.
+
+    it('issues each concurrent call through a separate transaction', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 10 }));
+      mockManager.findOne.mockResolvedValue(makeUsage({ questCount: 0 }));
+
+      const N = 5;
+      await Promise.all(
+        Array.from({ length: N }, () =>
+          service.enforceQuestCreationQuota('TENANT_A'),
+        ),
+      );
+
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(N);
+    });
+
+    it('rejects requests that see a locked row already at the limit', async () => {
+      configRepo.findOne.mockResolvedValue(makeConfig({ maxQuestsPerPeriod: 5 }));
+
+      let served = 0;
+      mockManager.findOne.mockImplementation(async () =>
+        makeUsage({ questCount: served++ < 5 ? served - 1 : 5 }),
+      );
+
+      const results = await Promise.allSettled(
+        Array.from({ length: 6 }, () =>
+          service.enforceQuestCreationQuota('TENANT_A'),
+        ),
+      );
+
+      const rejected = results.filter((r) => r.status === 'rejected');
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+        ForbiddenException,
+      );
     });
   });
 
-  // ─── enforcePayoutQuota ───────────────────────────────────────────────────
+  // ─── enforcePayoutQuota ──────────────────────────────────────────────────
 
   describe('enforcePayoutQuota', () => {
     it('does nothing when no config exists', async () => {
@@ -207,16 +317,17 @@ describe('QuotaService', () => {
       await expect(
         service.enforcePayoutQuota('TENANT_A', 100),
       ).resolves.toBeUndefined();
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
     it('throws ForbiddenException when single payout exceeds limit', async () => {
       configRepo.findOne.mockResolvedValue(
         makeConfig({ maxSinglePayoutAmount: 200 }),
       );
-
-      await expect(service.enforcePayoutQuota('TENANT_A', 201)).rejects.toThrow(
-        ForbiddenException,
-      );
+      await expect(
+        service.enforcePayoutQuota('TENANT_A', 201),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
     it('does nothing when maxPayoutAmountPerPeriod is null (unlimited)', async () => {
@@ -229,75 +340,112 @@ describe('QuotaService', () => {
       await expect(
         service.enforcePayoutQuota('TENANT_A', 9999),
       ).resolves.toBeUndefined();
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('runs period check-and-increment inside a transaction', async () => {
+      configRepo.findOne.mockResolvedValue(
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
+      );
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 500 }),
+      );
+
+      await service.enforcePayoutQuota('TENANT_A', 300);
+
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('acquires a pessimistic_write lock on the payout usage row', async () => {
+      configRepo.findOne.mockResolvedValue(
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
+      );
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 0 }),
+      );
+
+      await service.enforcePayoutQuota('TENANT_A', 100);
+
+      expect(mockManager.findOne).toHaveBeenCalledWith(
+        QuotaUsage,
+        expect.objectContaining({ lock: { mode: 'pessimistic_write' } }),
+      );
     });
 
     it('increments payout amount when under period limit', async () => {
       configRepo.findOne.mockResolvedValue(
-        makeConfig({
-          maxSinglePayoutAmount: null,
-          maxPayoutAmountPerPeriod: 1000,
-        }),
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
       );
-      const usage = makeUsage({
-        resourceType: QuotaResourceType.PAYOUT,
-        payoutAmount: 500,
-      });
-      usageRepo.findOne.mockResolvedValue(usage);
-
-      const qb = {
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        execute: jest.fn().mockResolvedValue(undefined),
-      };
-      usageRepo.createQueryBuilder.mockReturnValue(qb);
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 500 }),
+      );
 
       await service.enforcePayoutQuota('TENANT_A', 300);
-      expect(qb.execute).toHaveBeenCalled();
+
+      const qb = mockManager.createQueryBuilder.mock.results.find(
+        (r) => r.value.update.mock?.calls?.length > 0,
+      )?.value;
+      expect(qb?.execute).toHaveBeenCalled();
     });
 
     it('throws ForbiddenException when period payout limit would be exceeded', async () => {
       configRepo.findOne.mockResolvedValue(
-        makeConfig({
-          maxSinglePayoutAmount: null,
-          maxPayoutAmountPerPeriod: 1000,
-        }),
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
       );
-      usageRepo.findOne.mockResolvedValue(
-        makeUsage({
-          resourceType: QuotaResourceType.PAYOUT,
-          payoutAmount: 800,
-        }),
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 800 }),
       );
 
-      await expect(service.enforcePayoutQuota('TENANT_A', 300)).rejects.toThrow(
-        ForbiddenException,
-      );
+      await expect(
+        service.enforcePayoutQuota('TENANT_A', 300),
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('allows payout exactly at the period limit', async () => {
       configRepo.findOne.mockResolvedValue(
-        makeConfig({
-          maxSinglePayoutAmount: null,
-          maxPayoutAmountPerPeriod: 1000,
-        }),
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
       );
-      const usage = makeUsage({
-        resourceType: QuotaResourceType.PAYOUT,
-        payoutAmount: 700,
-      });
-      usageRepo.findOne.mockResolvedValue(usage);
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 700 }),
+      );
 
-      const qb = {
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        execute: jest.fn().mockResolvedValue(undefined),
-      };
-      usageRepo.createQueryBuilder.mockReturnValue(qb);
+      await expect(
+        service.enforcePayoutQuota('TENANT_A', 300),
+      ).resolves.toBeUndefined();
+    });
 
-      await service.enforcePayoutQuota('TENANT_A', 300);
-      expect(qb.execute).toHaveBeenCalled();
+    // ── Concurrency regression ──────────────────────────────────────────────
+
+    it('issues each concurrent payout call through a separate transaction', async () => {
+      configRepo.findOne.mockResolvedValue(
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 10000 }),
+      );
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 0 }),
+      );
+
+      const N = 5;
+      await Promise.all(
+        Array.from({ length: N }, () =>
+          service.enforcePayoutQuota('TENANT_A', 100),
+        ),
+      );
+
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(N);
+    });
+
+    it('rejects a payout that would exceed the period limit under the lock', async () => {
+      configRepo.findOne.mockResolvedValue(
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
+      );
+      // Simulate the locked row showing the period already full
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 900 }),
+      );
+
+      await expect(
+        service.enforcePayoutQuota('TENANT_A', 200),
+      ).rejects.toThrow(ForbiddenException);
     });
   });
 });

--- a/BackEnd/src/modules/quota/quota.service.spec.ts
+++ b/BackEnd/src/modules/quota/quota.service.spec.ts
@@ -35,7 +35,6 @@ const makeUsage = (overrides: Partial<QuotaUsage> = {}): QuotaUsage => ({
 /** Returns a fully chainable query builder mock. */
 const makeQb = () => {
   const qb: Record<string, jest.Mock> = {} as Record<string, jest.Mock>;
-  const self = () => qb;
   for (const m of [
     'insert',
     'into',

--- a/BackEnd/src/modules/quota/quota.service.ts
+++ b/BackEnd/src/modules/quota/quota.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { QuotaConfig } from './entities/quota-config.entity';
 import { QuotaUsage, QuotaResourceType } from './entities/quota-usage.entity';
 
@@ -13,6 +13,8 @@ export class QuotaService {
     private readonly configRepo: Repository<QuotaConfig>,
     @InjectRepository(QuotaUsage)
     private readonly usageRepo: Repository<QuotaUsage>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
 
   /** Returns the quota config for a tenant, or null if none configured. */
@@ -46,24 +48,11 @@ export class QuotaService {
     return periodStart;
   }
 
-  /** Gets or creates the usage record for the current period. */
-  private async getOrCreateUsage(
-    tenantId: string,
-    resourceType: QuotaResourceType,
-    periodStart: Date,
-  ): Promise<QuotaUsage> {
-    const existing = await this.usageRepo.findOne({
-      where: { tenantId, resourceType, periodStart },
-    });
-    if (existing) return existing;
-
-    return this.usageRepo.save(
-      this.usageRepo.create({ tenantId, resourceType, periodStart }),
-    );
-  }
-
   /**
-   * Checks and increments the quest creation quota for a tenant.
+   * Atomically checks and increments the quest creation quota for a tenant.
+   *
+   * Uses a database transaction with a pessimistic write lock (SELECT FOR UPDATE)
+   * to eliminate the TOCTOU race between the quota check and the increment.
    * Throws ForbiddenException if the limit is exceeded.
    */
   async enforceQuestCreationQuota(tenantId: string): Promise<void> {
@@ -71,26 +60,46 @@ export class QuotaService {
     if (!config || config.maxQuestsPerPeriod === null) return;
 
     const periodStart = this.getPeriodStart(config);
-    const usage = await this.getOrCreateUsage(
-      tenantId,
-      QuotaResourceType.QUEST,
-      periodStart,
-    );
+    const limit = config.maxQuestsPerPeriod;
 
-    if (usage.questCount >= config.maxQuestsPerPeriod) {
-      this.logger.warn(
-        `Tenant ${tenantId} exceeded quest quota: ${usage.questCount}/${config.maxQuestsPerPeriod}`,
-      );
-      throw new ForbiddenException(
-        `Quest creation quota exceeded (${config.maxQuestsPerPeriod} per period)`,
-      );
-    }
+    await this.dataSource.transaction(async (manager) => {
+      // Ensure the usage row exists before acquiring the lock.
+      // ON CONFLICT DO NOTHING is safe under concurrent inserts.
+      await manager
+        .createQueryBuilder()
+        .insert()
+        .into(QuotaUsage)
+        .values({ tenantId, resourceType: QuotaResourceType.QUEST, periodStart })
+        .orIgnore()
+        .execute();
 
-    await this.usageRepo.increment({ id: usage.id }, 'questCount', 1);
+      // Acquire a row-level write lock. Concurrent transactions block here
+      // until this transaction commits, closing the check-then-increment gap.
+      const usage = await manager.findOne(QuotaUsage, {
+        where: { tenantId, resourceType: QuotaResourceType.QUEST, periodStart },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (usage.questCount >= limit) {
+        this.logger.warn(
+          `Tenant ${tenantId} exceeded quest quota: ${usage.questCount}/${limit}`,
+        );
+        throw new ForbiddenException(
+          `Quest creation quota exceeded (${limit} per period)`,
+        );
+      }
+
+      await manager.increment(QuotaUsage, { id: usage.id }, 'questCount', 1);
+    });
   }
 
   /**
-   * Checks and increments the payout quota for a tenant.
+   * Atomically checks and increments the payout quota for a tenant.
+   *
+   * The single-payout check is stateless and runs outside the transaction.
+   * The period-total check and increment are wrapped in a transaction with a
+   * pessimistic write lock to prevent concurrent requests from both passing
+   * the same stale balance check.
    * Throws ForbiddenException if any limit is exceeded.
    */
   async enforcePayoutQuota(tenantId: string, amount: number): Promise<void> {
@@ -109,27 +118,46 @@ export class QuotaService {
     if (config.maxPayoutAmountPerPeriod === null) return;
 
     const periodStart = this.getPeriodStart(config);
-    const usage = await this.getOrCreateUsage(
-      tenantId,
-      QuotaResourceType.PAYOUT,
-      periodStart,
-    );
+    const limit = config.maxPayoutAmountPerPeriod;
 
-    const currentTotal = Number(usage.payoutAmount);
-    if (currentTotal + amount > config.maxPayoutAmountPerPeriod) {
-      this.logger.warn(
-        `Tenant ${tenantId} exceeded payout quota: ${currentTotal + amount}/${config.maxPayoutAmountPerPeriod}`,
-      );
-      throw new ForbiddenException(
-        `Payout quota exceeded (period limit: ${config.maxPayoutAmountPerPeriod})`,
-      );
-    }
+    await this.dataSource.transaction(async (manager) => {
+      await manager
+        .createQueryBuilder()
+        .insert()
+        .into(QuotaUsage)
+        .values({
+          tenantId,
+          resourceType: QuotaResourceType.PAYOUT,
+          periodStart,
+        })
+        .orIgnore()
+        .execute();
 
-    await this.usageRepo
-      .createQueryBuilder()
-      .update(QuotaUsage)
-      .set({ payoutAmount: () => `"payoutAmount" + ${amount}` })
-      .where('id = :id', { id: usage.id })
-      .execute();
+      const usage = await manager.findOne(QuotaUsage, {
+        where: {
+          tenantId,
+          resourceType: QuotaResourceType.PAYOUT,
+          periodStart,
+        },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      const currentTotal = Number(usage.payoutAmount);
+      if (currentTotal + amount > limit) {
+        this.logger.warn(
+          `Tenant ${tenantId} exceeded payout quota: ${currentTotal + amount}/${limit}`,
+        );
+        throw new ForbiddenException(
+          `Payout quota exceeded (period limit: ${limit})`,
+        );
+      }
+
+      await manager
+        .createQueryBuilder()
+        .update(QuotaUsage)
+        .set({ payoutAmount: () => `"payoutAmount" + ${amount}` })
+        .where('id = :id', { id: usage.id })
+        .execute();
+    });
   }
 }

--- a/BackEnd/src/modules/quota/quota.service.ts
+++ b/BackEnd/src/modules/quota/quota.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  ForbiddenException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { QuotaConfig } from './entities/quota-config.entity';
@@ -79,6 +84,11 @@ export class QuotaService {
         where: { tenantId, resourceType: QuotaResourceType.QUEST, periodStart },
         lock: { mode: 'pessimistic_write' },
       });
+      if (!usage) {
+        throw new InternalServerErrorException(
+          'Failed to lock quota usage row after insert',
+        );
+      }
 
       if (usage.questCount >= limit) {
         this.logger.warn(
@@ -141,6 +151,11 @@ export class QuotaService {
         },
         lock: { mode: 'pessimistic_write' },
       });
+      if (!usage) {
+        throw new InternalServerErrorException(
+          'Failed to lock quota usage row after insert',
+        );
+      }
 
       const currentTotal = Number(usage.payoutAmount);
       if (currentTotal + amount > limit) {


### PR DESCRIPTION
## Summary

`enforceQuestCreationQuota` and `enforcePayoutQuota` previously ran the quota check and the subsequent increment as separate, unsynchronized operations. Two concurrent requests could both read the same stale usage row, both pass the check, and both increment, silently exceeding the configured limit.

The fix wraps the entire check-and-increment path for both methods inside a `dataSource.transaction` with a `pessimistic_write` (SELECT FOR UPDATE) row lock:

1. `INSERT ... ON CONFLICT DO NOTHING` ensures the usage row exists before we try to lock it (safe under concurrent first-request races)
2. `SELECT ... FOR UPDATE` via `lock: { mode: 'pessimistic_write' }` acquires an exclusive row lock; any concurrent transaction blocks at this point until the holder commits
3. The check and increment execute against the freshly locked row within the same transaction, leaving no window for another request to slip through

The `DataSource` is injected via `@InjectDataSource()` - no module changes required since TypeORM provides it automatically.

## Changes

- `quota.service.ts`: inject `DataSource`; replace separate check/increment with transactional `SELECT FOR UPDATE` pattern in both `enforceQuestCreationQuota` and `enforcePayoutQuota`; remove now-redundant `getOrCreateUsage` helper
- `quota.service.spec.ts`: introduce `EntityManager` mock passed through the `dataSource.transaction` callback; add `pessimistic_write` lock assertions; add concurrency regression tests using `Promise.all` at quota boundaries

## Test plan

- [x] `backend-ci` passes (lint, build, unit tests)
- [ ] `enforceQuestCreationQuota` concurrency test: 6 parallel calls with limit=5 rejects exactly 1
- [ ] `enforcePayoutQuota` concurrency test: parallel calls each run in their own transaction
- [ ] All existing quota unit tests continue to pass
- [ ] `pessimistic_write` lock assertion passes for both methods

Closes #1902