### PR TITLE
feat: added sitemap.ts, robots.ts, and per-page metadata for SEO

### DIFF
--- a/FrontEnd/my-app/.env.example
+++ b/FrontEnd/my-app/.env.example
@@ -10,6 +10,9 @@ NEXT_PUBLIC_CONTRACT_ID=
 # Backend API
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
 
+# Public frontend URL (used for canonical, sitemap, and social metadata URLs)
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
 # Sentry Error Tracking
 NEXT_PUBLIC_SENTRY_DSN=
 

--- a/FrontEnd/my-app/app/[locale]/dashboard/layout.tsx
+++ b/FrontEnd/my-app/app/[locale]/dashboard/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { createPageMetadata, getLocale } from '@/lib/seo';
+
+const dashboardMetadata = {
+  en: {
+    title: 'Your Dashboard',
+    description:
+      'Review your StellarEarn quest activity, rewards, progress, and active submissions in one place.',
+  },
+  es: {
+    title: 'Tu panel',
+    description:
+      'Consulta tu actividad, recompensas, progreso y misiones activas de StellarEarn en un solo lugar.',
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale: localeParam } = await params;
+  const locale = getLocale(localeParam);
+
+  return createPageMetadata({
+    ...dashboardMetadata[locale],
+    locale,
+    pathname: '/dashboard',
+    index: false,
+  });
+}
+
+export default function DashboardLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/FrontEnd/my-app/app/[locale]/layout.tsx
+++ b/FrontEnd/my-app/app/[locale]/layout.tsx
@@ -11,6 +11,7 @@ import { SkipToContent } from '@/components/a11y/SkipToContent';
 import PerformanceMonitor from '@/components/ui/PerformanceMonitor';
 import { EnvValidator } from '@/components/providers/EnvValidator';
 import { SWRegister } from '@/components/SWRegister';
+import { createPageMetadata, getLocale } from '@/lib/seo';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -22,11 +23,33 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
-export const metadata: Metadata = {
-  title: 'StellarEarn - Quest-Based Earning Platform',
-  description:
-    'Complete quests, earn rewards, and build your on-chain reputation with Stellar',
+const homeMetadata = {
+  en: {
+    title: 'Complete Quests and Earn Stellar Rewards',
+    description:
+      'Discover community quests, earn Stellar rewards, and build your on-chain reputation with StellarEarn.',
+  },
+  es: {
+    title: 'Completa misiones y gana recompensas Stellar',
+    description:
+      'Descubre misiones de la comunidad, gana recompensas Stellar y construye tu reputación on-chain con StellarEarn.',
+  },
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale: localeParam } = await params;
+  const locale = getLocale(localeParam);
+
+  return createPageMetadata({
+    ...homeMetadata[locale],
+    locale,
+    pathname: '/',
+  });
+}
 
 export default async function RootLayout({
   children,

--- a/FrontEnd/my-app/app/[locale]/profile/[address]/layout.tsx
+++ b/FrontEnd/my-app/app/[locale]/profile/[address]/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { createPageMetadata, getLocale } from '@/lib/seo';
+
+function shortenAddress(address: string): string {
+  if (address.length <= 14) return address;
+  return `${address.slice(0, 7)}…${address.slice(-5)}`;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; address: string }>;
+}): Promise<Metadata> {
+  const { locale: localeParam, address } = await params;
+  const locale = getLocale(localeParam);
+  const displayAddress = shortenAddress(address);
+  const descriptions = {
+    en: `View ${displayAddress}'s public quest activity, achievements, and on-chain reputation on StellarEarn.`,
+    es: `Consulta la actividad pública, los logros y la reputación on-chain de ${displayAddress} en StellarEarn.`,
+  };
+
+  return createPageMetadata({
+    title:
+      locale === 'es'
+        ? `Perfil de ${displayAddress}`
+        : `${displayAddress}'s Profile`,
+    description: descriptions[locale],
+    locale,
+    pathname: `/profile/${encodeURIComponent(address)}`,
+  });
+}
+
+export default function ProfileLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/FrontEnd/my-app/app/[locale]/quests/[id]/layout.tsx
+++ b/FrontEnd/my-app/app/[locale]/quests/[id]/layout.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from 'next';
+import { createPageMetadata, getLocale, summarize } from '@/lib/seo';
+
+type QuestMetadataRecord = {
+  title?: string;
+  description?: string;
+};
+
+function unwrapQuest(payload: unknown): QuestMetadataRecord | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const record = payload as Record<string, unknown>;
+  const nestedData = record.data;
+
+  if (nestedData && typeof nestedData === 'object') {
+    const dataRecord = nestedData as Record<string, unknown>;
+    if (dataRecord.data && typeof dataRecord.data === 'object') {
+      return dataRecord.data as QuestMetadataRecord;
+    }
+    return dataRecord as QuestMetadataRecord;
+  }
+
+  return record as QuestMetadataRecord;
+}
+
+async function getQuestMetadata(
+  id: string
+): Promise<QuestMetadataRecord | null> {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!apiBaseUrl) return null;
+
+  try {
+    const response = await fetch(
+      `${apiBaseUrl.replace(/\/$/, '')}/api/v1/quests/${encodeURIComponent(id)}`,
+      { next: { revalidate: 300 }, signal: AbortSignal.timeout(3_000) }
+    );
+
+    if (!response.ok) return null;
+    return unwrapQuest(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; id: string }>;
+}): Promise<Metadata> {
+  const { locale: localeParam, id } = await params;
+  const locale = getLocale(localeParam);
+  const quest = await getQuestMetadata(id);
+  const shortId = id.slice(0, 8);
+  const title =
+    quest?.title?.trim() ||
+    (locale === 'es' ? `Misión ${shortId}` : `Quest ${shortId}`);
+  const fallbackDescription =
+    locale === 'es'
+      ? 'Consulta los requisitos, la recompensa y la fecha límite de esta misión de StellarEarn.'
+      : 'Review this StellarEarn quest’s requirements, reward, and submission deadline.';
+
+  return createPageMetadata({
+    title,
+    description: quest?.description
+      ? summarize(quest.description)
+      : fallbackDescription,
+    locale,
+    pathname: `/quests/${encodeURIComponent(id)}`,
+  });
+}
+
+export default function QuestDetailLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/FrontEnd/my-app/app/[locale]/quests/layout.tsx
+++ b/FrontEnd/my-app/app/[locale]/quests/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { createPageMetadata, getLocale } from '@/lib/seo';
+
+const questBoardMetadata = {
+  en: {
+    title: 'Quest Board',
+    description:
+      'Browse open StellarEarn quests, compare rewards and requirements, and find your next opportunity to earn on Stellar.',
+  },
+  es: {
+    title: 'Tablero de misiones',
+    description:
+      'Explora misiones abiertas de StellarEarn, compara recompensas y requisitos, y encuentra tu próxima oportunidad en Stellar.',
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale: localeParam } = await params;
+  const locale = getLocale(localeParam);
+
+  return createPageMetadata({
+    ...questBoardMetadata[locale],
+    locale,
+    pathname: '/quests',
+  });
+}
+
+export default function QuestsLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/FrontEnd/my-app/app/layout.tsx
+++ b/FrontEnd/my-app/app/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { getSiteUrl } from '@/lib/seo';
 import './globals.css';
 
 const geistSans = Geist({
@@ -14,6 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getSiteUrl()),
   title: 'StellarEarn - Quest-Based Earning Platform',
   description:
     'Complete quests, earn rewards, and build your on-chain reputation with Stellar',

--- a/FrontEnd/my-app/app/robots.test.ts
+++ b/FrontEnd/my-app/app/robots.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import robots from './robots';
+
+describe('robots', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('allows public pages and keeps private application routes out of search', () => {
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://earn.example.com');
+
+    const result = robots();
+
+    expect(result.sitemap).toBe('https://earn.example.com/sitemap.xml');
+    expect(result.host).toBe('https://earn.example.com');
+    expect(result.rules).toMatchObject({
+      userAgent: '*',
+      allow: '/',
+      disallow: expect.arrayContaining([
+        '/*/admin',
+        '/*/dashboard',
+        '/*/settings',
+      ]),
+    });
+  });
+});

--- a/FrontEnd/my-app/app/robots.ts
+++ b/FrontEnd/my-app/app/robots.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+import { getSiteUrl } from '@/lib/seo';
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/api/',
+        '/*/admin',
+        '/*/dashboard',
+        '/*/notifications',
+        '/*/quests/create',
+        '/*/rewards',
+        '/*/settings',
+        '/*/submissions',
+      ],
+    },
+    sitemap: new URL('/sitemap.xml', siteUrl).toString(),
+    host: siteUrl,
+  };
+}

--- a/FrontEnd/my-app/app/sitemap.test.ts
+++ b/FrontEnd/my-app/app/sitemap.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import sitemap from './sitemap';
+
+describe('sitemap', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('always returns localized marketing and quest-listing routes', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://earn.example.com');
+    vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', '');
+
+    const entries = await sitemap();
+
+    expect(entries.map((entry) => entry.url)).toEqual([
+      'https://earn.example.com/en',
+      'https://earn.example.com/en/quests',
+      'https://earn.example.com/es',
+      'https://earn.example.com/es/quests',
+    ]);
+  });
+
+  it('adds public quest details and creator profiles from the API', async () => {
+    const address = `G${'A'.repeat(55)}`;
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://earn.example.com');
+    vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', 'https://api.example.com');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: {
+            data: [
+              {
+                id: 'quest-1',
+                createdBy: address,
+                updatedAt: '2026-07-20T12:00:00.000Z',
+              },
+            ],
+            nextCursor: null,
+          },
+        }),
+      })
+    );
+
+    const urls = (await sitemap()).map((entry) => entry.url);
+
+    expect(urls).toContain('https://earn.example.com/en/quests/quest-1');
+    expect(urls).toContain(`https://earn.example.com/en/profile/${address}`);
+    expect(urls).toContain('https://earn.example.com/es/quests/quest-1');
+    expect(urls).toContain(`https://earn.example.com/es/profile/${address}`);
+  });
+});

--- a/FrontEnd/my-app/app/sitemap.ts
+++ b/FrontEnd/my-app/app/sitemap.ts
@@ -1,0 +1,137 @@
+import type { MetadataRoute } from 'next';
+import { locales } from '@/lib/i18n/config';
+import { getSiteUrl } from '@/lib/seo';
+
+type PublicQuest = {
+  id: string;
+  createdBy?: string;
+  updatedAt?: string;
+};
+
+type QuestPage = {
+  quests: PublicQuest[];
+  nextCursor?: string;
+};
+
+const STELLAR_ADDRESS_PATTERN = /^G[A-Z2-7]{55}$/;
+const MAX_QUEST_PAGES = 50;
+
+function readQuestPage(payload: unknown): QuestPage {
+  if (!payload || typeof payload !== 'object') return { quests: [] };
+
+  const record = payload as Record<string, unknown>;
+  const responseData =
+    record.data &&
+    typeof record.data === 'object' &&
+    !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : record;
+  const quests = Array.isArray(responseData.data)
+    ? responseData.data
+    : Array.isArray(responseData.quests)
+      ? responseData.quests
+      : [];
+
+  return {
+    quests: quests.filter(
+      (quest): quest is PublicQuest =>
+        !!quest &&
+        typeof quest === 'object' &&
+        typeof (quest as PublicQuest).id === 'string'
+    ),
+    nextCursor:
+      typeof responseData.nextCursor === 'string'
+        ? responseData.nextCursor
+        : undefined,
+  };
+}
+
+async function getPublicQuests(): Promise<PublicQuest[]> {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!apiBaseUrl) return [];
+
+  const quests: PublicQuest[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  try {
+    for (let page = 0; page < MAX_QUEST_PAGES; page += 1) {
+      const url = new URL(`${apiBaseUrl.replace(/\/$/, '')}/api/v1/quests`);
+      url.searchParams.set('limit', '100');
+      url.searchParams.set('status', 'ACTIVE');
+      if (cursor) url.searchParams.set('cursor', cursor);
+
+      const response = await fetch(url, {
+        next: { revalidate: 3_600 },
+        signal: AbortSignal.timeout(3_000),
+      });
+      if (!response.ok) break;
+
+      const result = readQuestPage(await response.json());
+      quests.push(...result.quests);
+
+      if (!result.nextCursor || seenCursors.has(result.nextCursor)) break;
+      seenCursors.add(result.nextCursor);
+      cursor = result.nextCursor;
+    }
+  } catch {
+    // Static public routes remain available when the API is offline.
+  }
+
+  return quests;
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const siteUrl = getSiteUrl();
+  const publicQuests = await getPublicQuests();
+  const profileAddresses = new Set(
+    publicQuests
+      .map((quest) => quest.createdBy)
+      .filter(
+        (address): address is string =>
+          typeof address === 'string' && STELLAR_ADDRESS_PATTERN.test(address)
+      )
+  );
+
+  const entries: MetadataRoute.Sitemap = [];
+
+  for (const locale of locales) {
+    entries.push(
+      {
+        url: new URL(`/${locale}`, siteUrl).toString(),
+        changeFrequency: 'weekly',
+        priority: 1,
+      },
+      {
+        url: new URL(`/${locale}/quests`, siteUrl).toString(),
+        changeFrequency: 'hourly',
+        priority: 0.9,
+      }
+    );
+
+    for (const quest of publicQuests) {
+      entries.push({
+        url: new URL(
+          `/${locale}/quests/${encodeURIComponent(quest.id)}`,
+          siteUrl
+        ).toString(),
+        lastModified: quest.updatedAt ? new Date(quest.updatedAt) : undefined,
+        changeFrequency: 'daily',
+        priority: 0.8,
+      });
+    }
+
+    for (const address of profileAddresses) {
+      entries.push({
+        url: new URL(
+          `/${locale}/profile/${encodeURIComponent(address)}`,
+          siteUrl
+        ).toString(),
+        changeFrequency: 'weekly',
+        priority: 0.6,
+      });
+    }
+  }
+
+  return entries;
+}

--- a/FrontEnd/my-app/lib/seo.test.ts
+++ b/FrontEnd/my-app/lib/seo.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createPageMetadata, getSiteUrl, summarize } from './seo';
+
+describe('SEO helpers', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('normalizes the configured public site URL', () => {
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://earn.example.com/path');
+
+    expect(getSiteUrl()).toBe('https://earn.example.com');
+  });
+
+  it('creates canonical, OpenGraph, and Twitter metadata', () => {
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://earn.example.com');
+
+    const metadata = createPageMetadata({
+      title: 'Quest Board',
+      description: 'Browse public quests.',
+      locale: 'en',
+      pathname: '/quests',
+    });
+
+    expect(metadata.title).toBe('Quest Board | StellarEarn');
+    expect(metadata.alternates?.canonical).toBe(
+      'https://earn.example.com/en/quests'
+    );
+    expect(metadata.openGraph).toMatchObject({
+      title: 'Quest Board | StellarEarn',
+      url: 'https://earn.example.com/en/quests',
+      locale: 'en_US',
+    });
+    expect(metadata.twitter).toMatchObject({ card: 'summary' });
+  });
+
+  it('removes markup and limits social descriptions', () => {
+    expect(summarize('<p>A   useful quest</p>', 12)).toBe('A useful qu…');
+  });
+});

--- a/FrontEnd/my-app/lib/seo.ts
+++ b/FrontEnd/my-app/lib/seo.ts
@@ -1,0 +1,95 @@
+import type { Metadata } from 'next';
+import { defaultLocale, locales, type Locale } from '@/lib/i18n/config';
+
+const LOCAL_SITE_URL = 'http://localhost:3000';
+
+export const SITE_NAME = 'StellarEarn';
+
+export function getSiteUrl(): string {
+  const configuredUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ??
+    process.env.VERCEL_URL;
+
+  if (!configuredUrl) return LOCAL_SITE_URL;
+
+  const urlWithProtocol = /^https?:\/\//i.test(configuredUrl)
+    ? configuredUrl
+    : `https://${configuredUrl}`;
+
+  try {
+    return new URL(urlWithProtocol).origin;
+  } catch {
+    return LOCAL_SITE_URL;
+  }
+}
+
+export function getLocale(locale: string): Locale {
+  return locales.includes(locale as Locale)
+    ? (locale as Locale)
+    : defaultLocale;
+}
+
+type PageMetadataOptions = {
+  title: string;
+  description: string;
+  locale: Locale;
+  pathname: string;
+  index?: boolean;
+};
+
+export function createPageMetadata({
+  title,
+  description,
+  locale,
+  pathname,
+  index = true,
+}: PageMetadataOptions): Metadata {
+  const localizedPath = `/${locale}${pathname === '/' ? '' : pathname}`;
+  const canonicalUrl = new URL(localizedPath, getSiteUrl()).toString();
+  const localizedUrls = Object.fromEntries(
+    locales.map((supportedLocale) => [
+      supportedLocale,
+      new URL(
+        `/${supportedLocale}${pathname === '/' ? '' : pathname}`,
+        getSiteUrl()
+      ).toString(),
+    ])
+  );
+  const fullTitle = `${title} | ${SITE_NAME}`;
+
+  return {
+    title: fullTitle,
+    description,
+    alternates: {
+      canonical: canonicalUrl,
+      languages: localizedUrls,
+    },
+    openGraph: {
+      type: 'website',
+      siteName: SITE_NAME,
+      title: fullTitle,
+      description,
+      url: canonicalUrl,
+      locale: locale === 'es' ? 'es_ES' : 'en_US',
+    },
+    twitter: {
+      card: 'summary',
+      title: fullTitle,
+      description,
+    },
+    robots: index
+      ? { index: true, follow: true }
+      : { index: false, follow: false },
+  };
+}
+
+export function summarize(value: string, maxLength = 160): string {
+  const plainText = value
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (plainText.length <= maxLength) return plainText;
+  return `${plainText.slice(0, maxLength - 1).trimEnd()}…`;
+}


### PR DESCRIPTION
closes #1924 


## Title

Add sitemap, robots.txt, and page-specific SEO metadata

## Summary

This PR improves SEO support for the frontend by adding generated sitemap and robots routes, along with distinct metadata for key public pages.

## Changes

- Added `app/sitemap.ts`
  - Includes localized marketing and quest listing routes
  - Includes active quest detail pages when the backend is available
  - Includes public creator profile pages
  - Falls back safely to static routes when the backend is unavailable

- Added `app/robots.ts`
  - Allows public pages to be crawled
  - Excludes admin, dashboard, account, API, and other private routes
  - References the generated sitemap

- Added page-specific metadata for:
  - Marketing homepage
  - Quest board
  - Quest details
  - Public profiles
  - Dashboard, marked as non-indexable

- Added reusable SEO helpers for:
  - Canonical URLs
  - Localized alternate URLs
  - OpenGraph metadata
  - Twitter cards
  - Metadata descriptions

- Added `NEXT_PUBLIC_SITE_URL` to `.env.example`.

- Added focused tests for sitemap, robots, and metadata generation.

## Verification

- [x] SEO unit tests pass — 6 tests
- [x] TypeScript typecheck passes
- [x] ESLint completes with 0 errors
- [x] Prettier formatting passes
- [x] Production build passes
- [x] `/robots.txt` returns HTTP 200
- [x] `/sitemap.xml` returns HTTP 200
- [x] Public pages render distinct title, description, OpenGraph, and Twitter metadata

### Commands

```bash
cd FrontEnd/my-app

npm test -- --run app/sitemap.test.ts app/robots.test.ts lib/seo.test.ts
npm run typecheck
npm run lint
npm run build
npm start