### PR TITLE
fix(quota): replace raw SQL string interpolation with parameterized q…

### DIFF
--- a/BackEnd/src/modules/quota/quota.service.spec.ts
+++ b/BackEnd/src/modules/quota/quota.service.spec.ts
@@ -43,6 +43,8 @@ const makeQb = () => {
     'update',
     'set',
     'where',
+    'setParameter',
+    'setParameters',
   ]) {
     qb[m] = jest.fn().mockReturnValue(qb);
   }
@@ -445,6 +447,52 @@ describe('QuotaService', () => {
       await expect(
         service.enforcePayoutQuota('TENANT_A', 200),
       ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('uses bound parameters and does not interpolate amount into SQL string with adversarial/boundary values', async () => {
+      configRepo.findOne.mockResolvedValue(
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
+      );
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 100 }),
+      );
+
+      const adversarialAmount = '1 OR 1=1' as unknown as number;
+      await service.enforcePayoutQuota('TENANT_A', adversarialAmount);
+
+      const qb = mockManager.createQueryBuilder.mock.results.find(
+        (r) => r.value.update.mock?.calls?.length > 0,
+      )?.value;
+
+      expect(qb).toBeDefined();
+      expect(qb.set).toHaveBeenCalledTimes(1);
+
+      const setArg = qb.set.mock.calls[0][0];
+      expect(typeof setArg.payoutAmount).toBe('function');
+      const sqlSnippet = setArg.payoutAmount();
+
+      expect(sqlSnippet).toBe('"payoutAmount" + :amount');
+      expect(sqlSnippet).not.toContain('1 OR 1=1');
+      expect(qb.setParameter).toHaveBeenCalledWith('amount', adversarialAmount);
+    });
+
+    it('handles numeric boundary amount values safely with bound parameters', async () => {
+      configRepo.findOne.mockResolvedValue(
+        makeConfig({ maxSinglePayoutAmount: null, maxPayoutAmountPerPeriod: 1000 }),
+      );
+      mockManager.findOne.mockResolvedValue(
+        makeUsage({ resourceType: QuotaResourceType.PAYOUT, payoutAmount: 100 }),
+      );
+
+      const boundaryAmount = 0.00000001;
+      await service.enforcePayoutQuota('TENANT_A', boundaryAmount);
+
+      const qb = mockManager.createQueryBuilder.mock.results.find(
+        (r) => r.value.update.mock?.calls?.length > 0,
+      )?.value;
+
+      expect(qb).toBeDefined();
+      expect(qb.setParameter).toHaveBeenCalledWith('amount', boundaryAmount);
     });
   });
 });

--- a/BackEnd/src/modules/quota/quota.service.ts
+++ b/BackEnd/src/modules/quota/quota.service.ts
@@ -170,8 +170,9 @@ export class QuotaService {
       await manager
         .createQueryBuilder()
         .update(QuotaUsage)
-        .set({ payoutAmount: () => `"payoutAmount" + ${amount}` })
+        .set({ payoutAmount: () => '"payoutAmount" + :amount' })
         .where('id = :id', { id: usage.id })
+        .setParameter('amount', amount)
         .execute();
     });
   }


### PR DESCRIPTION
Closes #1903

## Description
Replaces raw SQL string interpolation in `enforcePayoutQuota` with parameterized query binding.

Previously, `enforcePayoutQuota` built the update query using string template interpolation (`.set({ payoutAmount: () => \`"payoutAmount" + \${amount}\` })`), which posed a potential SQL injection vulnerability if the type contract was ever loosened.

## Changes Made
- Updated `QuotaService.enforcePayoutQuota` in `src/modules/quota/quota.service.ts` to use `:amount` parameter placeholder with `.setParameter('amount', amount)`.
- Added unit and regression tests in `src/modules/quota/quota.service.spec.ts` to ensure bound parameters are used and boundary/adversarial input values are handled safely without SQL string interpolation.

## Verification
- Ran unit tests for `QuotaService` (`src/modules/quota/quota.service.spec.ts`) — 23 tests passed successfully.
