### PR TITLE
fix(auth): resolve real identity from JWT payload in AuthService.validate

### DIFF
--- a/BackEnd/src/modules/auth/CHANGELOG.md
+++ b/BackEnd/src/modules/auth/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AuthService.validate()` no longer returns a hardcoded stub identity for every request; it now resolves the real user (and their current role) from the verified JWT payload via `validateUser`, and `JwtStrategy` passes the full decoded payload instead of just the Stellar address. Closes #1888.
+
 ### Added
 
 - `POST /auth/challenge` endpoint that issues a time-boxed (5 min), single-use Stellar authentication challenge for a given address using `generateChallengeMessage` from `utils/signature`.

--- a/BackEnd/src/modules/auth/auth.service.spec.ts
+++ b/BackEnd/src/modules/auth/auth.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UnauthorizedException, NotFoundException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { RefreshToken } from './entities/refresh-token.entity';
@@ -40,11 +42,11 @@ describe('AuthService', () => {
       providers: [
         AuthService,
         {
-          provide: 'JwtService',
+          provide: JwtService,
           useValue: jwtService,
         },
         {
-          provide: 'ConfigService',
+          provide: ConfigService,
           useValue: configService,
         },
         {
@@ -65,8 +67,8 @@ describe('AuthService', () => {
       ],
     })
       .useMocker((token) => {
-        if (token === 'JwtService') return jwtService;
-        if (token === 'ConfigService') return configService;
+        if (token === JwtService) return jwtService;
+        if (token === ConfigService) return configService;
         return undefined;
       })
       .compile();
@@ -344,6 +346,82 @@ describe('AuthService', () => {
         stellarAddress,
         role: Role.USER,
       });
+    });
+  });
+
+  describe('validate (JWT payload → identity)', () => {
+    it('should resolve the real identity/role for the user encoded in the payload, not a stub', async () => {
+      const user = createMockUser({
+        id: 'user-a-id',
+        role: Role.ADMIN,
+      });
+      jest.spyOn(usersService, 'findById').mockResolvedValue(user);
+
+      const result = await service.validate({
+        sub: user.id,
+        stellarAddress: user.stellarAddress,
+        role: 'USER', // stale/forged claim in the token — must be ignored
+      });
+
+      expect(result).toEqual({
+        id: user.id,
+        stellarAddress: user.stellarAddress,
+        role: user.role,
+      });
+      expect(result.role).toBe(Role.ADMIN);
+    });
+
+    it('should never resolve two different users to the same identity', async () => {
+      const userA = createMockUser({ id: 'user-a-id', role: Role.USER });
+      const userB = createMockUser({
+        id: 'user-b-id',
+        role: Role.ADMIN,
+        stellarAddress: generateRandomStellarAddress(),
+      });
+
+      jest
+        .spyOn(usersService, 'findById')
+        .mockImplementation(async (id: string) =>
+          id === userA.id ? userA : id === userB.id ? userB : null,
+        );
+
+      const resultA = await service.validate({
+        sub: userA.id,
+        stellarAddress: userA.stellarAddress,
+        role: userA.role,
+      });
+      const resultB = await service.validate({
+        sub: userB.id,
+        stellarAddress: userB.stellarAddress,
+        role: userB.role,
+      });
+
+      expect(resultA.id).toBe(userA.id);
+      expect(resultA.role).toBe(Role.USER);
+      expect(resultB.id).toBe(userB.id);
+      expect(resultB.role).toBe(Role.ADMIN);
+      expect(resultA.id).not.toBe(resultB.id);
+      expect(resultA.role).not.toBe(resultB.role);
+    });
+
+    it('should fall back to the stellarAddress claim when sub is absent', async () => {
+      const user = createMockUser();
+      jest.spyOn(usersService, 'findByAddress').mockResolvedValue(user);
+
+      const result = await service.validate({
+        stellarAddress: user.stellarAddress,
+      } as any);
+
+      expect(usersService.findByAddress).toHaveBeenCalledWith(
+        user.stellarAddress,
+      );
+      expect(result.id).toBe(user.id);
+    });
+
+    it('should throw UnauthorizedException when the payload has no identifiable subject', async () => {
+      await expect(service.validate({} as any)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 

--- a/BackEnd/src/modules/auth/auth.service.ts
+++ b/BackEnd/src/modules/auth/auth.service.ts
@@ -19,6 +19,7 @@ import {
   isChallengeExpired,
   extractTimestampFromChallenge,
 } from './utils/signature';
+import type { JwtPayload } from './strategies/jwt.strategy';
 
 export interface AuthUser {
   id: string;
@@ -47,12 +48,19 @@ export class AuthService {
     private readonly refreshTokenRepository: Repository<RefreshToken>,
   ) {}
 
-  validate(payload: any): AuthUser {
-    return {
-      id: 'dummy-id',
-      stellarAddress: payload?.stellarAddress || 'G...ABC',
-      role: 'USER',
-    };
+  /**
+   * Resolve the identity encoded in a verified JWT payload. Called by
+   * `JwtStrategy` once the token's signature has already been checked, so
+   * `payload` is trustworthy — but role/identity are still re-resolved from
+   * the database here rather than trusted as-is, so a stale or forged claim
+   * embedded in an older token can never grant access it shouldn't have.
+   */
+  async validate(payload: JwtPayload): Promise<AuthUser> {
+    const identifier = payload?.sub || payload?.stellarAddress;
+    if (!identifier) {
+      throw new UnauthorizedException('Invalid token payload');
+    }
+    return this.validateUser(identifier);
   }
 
   async validateUser(idOrAddress: string): Promise<AuthUser> {

--- a/BackEnd/src/modules/auth/strategies/jwt.strategy.ts
+++ b/BackEnd/src/modules/auth/strategies/jwt.strategy.ts
@@ -72,7 +72,7 @@ export class JwtStrategy extends Strategy {
         },
       },
       async (payload: JwtPayload) => {
-        return this.authService.validate(payload.stellarAddress);
+        return this.authService.validate(payload);
       },
     );
   }


### PR DESCRIPTION
## Summary

`AuthService.validate()` always returned a hardcoded `{id:'dummy-id', stellarAddress:'G...ABC', role:'USER'}` regardless of the verified JWT payload, and `JwtStrategy` passed only `payload.stellarAddress` instead of the full payload. Every authenticated request therefore resolved to the same fake identity, making `RolesGuard`/`@Roles()` checks meaningless — a critical authorization bypass.

## Changes

- `AuthService.validate()` now looks up the real user via `payload.sub` (falling back to `payload.stellarAddress`), delegating to the existing `validateUser()` lookup. Role is re-derived from the database rather than trusted from a potentially stale/forged token claim.
- `JwtStrategy` now passes the full decoded payload to `validate()` instead of just the address string.
- Added regression tests in `auth.service.spec.ts` asserting a token issued for user A never resolves to user B's identity or role, plus coverage for the `sub`-absent fallback and the invalid-payload rejection path.
- Fixed `auth.service.spec.ts`'s test module wiring, which registered `JwtService`/`ConfigService` under string tokens (`'JwtService'`/`'ConfigService'`) instead of the actual class tokens — this caused every test in the file (all 23 pre-existing tests, not just the new ones) to fail dependency resolution and never actually run. Fixing it was necessary to get any real coverage of this fix.

## Acceptance criteria (from #1888)

- [x] `AuthService.validate()` returns the identity/role matching the verified token, not a stub
- [x] `JwtStrategy` passes the correct payload shape
- [x] Regression test covers cross-user identity confusion
- [x] Audited the only two callers of `AuthService.validate()` (`JwtStrategy` and a controller unit test mock) — no other `RolesGuard`/`@Roles()`-protected route calls it differently

Closes #1888

## Test plan

- `npm run build` — clean
- `npx jest src/modules/auth/auth.service.spec.ts` — 27/27 passing (23 pre-existing + 4 new)
- Diff scoped to exactly the auth module (`auth.service.ts`, `jwt.strategy.ts`, `auth.service.spec.ts`)