### PR TITLE
feat(auth): wire up refresh token rotation via POST /auth/refresh

### DIFF
--- a/BackEnd/src/modules/auth/CHANGELOG.md
+++ b/BackEnd/src/modules/auth/CHANGELOG.md
@@ -10,6 +10,11 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 - `POST /auth/challenge` endpoint that issues a time-boxed (5 min), single-use Stellar authentication challenge for a given address using `generateChallengeMessage` from `utils/signature`.
 - Complete `AuthService` implementation: `generateChallenge`, `login` (Stellar signature verification via `verifyStellarSignature`), `generateTokens` (JWT + SHA-256-hashed refresh token), `refreshTokens` (rotation with old token revocation), `revokeToken` (single session or all-sessions), `validateUser` (UUID or Stellar address lookup), and `loginOAuthUser` (Google / GitHub OAuth upsert flow).
+- `POST /auth/refresh` endpoint wiring up the previously-implemented `AuthService.refreshTokens` rotation flow: accepts a `RefreshTokenDto`, returns a rotated `TokenResponseDto` (new access token, new refresh token, `expiresIn`, user), and revokes the presented refresh token in the same operation.
+
+### Changed
+
+- `AuthService.refreshTokens` now also returns `expiresIn` for the newly issued access token, matching the `TokenResponseDto` contract.
 
 ### Changed
 

--- a/BackEnd/src/modules/auth/auth.controller.spec.ts
+++ b/BackEnd/src/modules/auth/auth.controller.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { HttpStatus } from '@nestjs/common';
+import { HttpStatus, UnauthorizedException } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { LoginDto } from './dto/auth.dto';
+import { LoginDto, RefreshTokenDto } from './dto/auth.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RolesGuard } from './guards/roles.guard';
 import { generateRandomStellarAddress } from 'test/utils/test-helpers';
@@ -13,6 +13,7 @@ import { generateRandomStellarAddress } from 'test/utils/test-helpers';
  * Covers:
  *  - POST /auth/login – success path
  *  - POST /auth/login – missing / invalid body fields
+ *  - POST /auth/refresh – rotation success and downstream failure
  *  - Guard-protected routes rejecting unauthenticated requests
  */
 describe('AuthController', () => {
@@ -32,9 +33,25 @@ describe('AuthController', () => {
         accessToken: 'mock.access.token',
         expiresIn: 3600,
       }),
+      verifyAndLogin: jest.fn().mockResolvedValue({
+        accessToken: 'mock.access.token',
+        expiresIn: 3600,
+      }),
+      refreshTokens: jest.fn().mockResolvedValue({
+        accessToken: 'new.access.token',
+        refreshToken: 'new-refresh-token',
+        expiresIn: 900,
+        user: {
+          id: 'user-1',
+          stellarAddress:
+            'GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQA5XPJMWRFT5GEVQA3I5UU4K',
+          role: 'USER',
+        },
+      }),
       validate: jest.fn().mockReturnValue({
         id: 'dummy-id',
-        stellarAddress: 'GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQA5XPJMWRFT5GEVQA3I5UU4K',
+        stellarAddress:
+          'GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQA5XPJMWRFT5GEVQA3I5UU4K',
         role: 'USER',
       }),
     };
@@ -66,7 +83,7 @@ describe('AuthController', () => {
   // ─── POST /auth/login ─────────────────────────────────────────────────────
 
   describe('POST /auth/login', () => {
-    it('should call AuthService.login with the stellarAddress from the DTO', async () => {
+    it('should call AuthService.verifyAndLogin with the login DTO', async () => {
       const stellarAddress = generateRandomStellarAddress();
       const loginDto: LoginDto = {
         stellarAddress,
@@ -77,14 +94,14 @@ describe('AuthController', () => {
 
       await controller.login(loginDto, res);
 
-      expect(authService.login).toHaveBeenCalledTimes(1);
-      expect(authService.login).toHaveBeenCalledWith(loginDto.stellarAddress);
+      expect(authService.verifyAndLogin).toHaveBeenCalledTimes(1);
+      expect(authService.verifyAndLogin).toHaveBeenCalledWith(loginDto);
     });
 
-    it('should respond with the token object returned by AuthService.login', async () => {
+    it('should respond with the token object returned by AuthService.verifyAndLogin', async () => {
       const stellarAddress = generateRandomStellarAddress();
       const tokenResponse = { accessToken: 'jwt.token.value', expiresIn: 3600 };
-      authService.login.mockReturnValue(tokenResponse);
+      authService.verifyAndLogin.mockResolvedValue(tokenResponse);
 
       const loginDto: LoginDto = {
         stellarAddress,
@@ -116,11 +133,11 @@ describe('AuthController', () => {
       expect(typeof responseBody.expiresIn).toBe('number');
     });
 
-    it('should propagate errors thrown by AuthService.login', async () => {
+    it('should propagate errors thrown by AuthService.verifyAndLogin', async () => {
       const stellarAddress = generateRandomStellarAddress();
-      authService.login.mockImplementation(() => {
-        throw new Error('Service failure');
-      });
+      authService.verifyAndLogin.mockRejectedValue(
+        new Error('Service failure'),
+      );
 
       const loginDto: LoginDto = {
         stellarAddress,
@@ -131,6 +148,41 @@ describe('AuthController', () => {
 
       await expect(controller.login(loginDto, res)).rejects.toThrow(
         'Service failure',
+      );
+    });
+  });
+
+  // ─── POST /auth/refresh ───────────────────────────────────────────────────
+
+  describe('POST /auth/refresh', () => {
+    it('should call AuthService.refreshTokens with the refreshToken from the DTO', async () => {
+      const dto: RefreshTokenDto = { refreshToken: 'raw-refresh-token' };
+
+      await controller.refresh(dto);
+
+      expect(authService.refreshTokens).toHaveBeenCalledTimes(1);
+      expect(authService.refreshTokens).toHaveBeenCalledWith(dto.refreshToken);
+    });
+
+    it('should return the rotated token pair and user from the service', async () => {
+      const dto: RefreshTokenDto = { refreshToken: 'raw-refresh-token' };
+
+      const result = await controller.refresh(dto);
+
+      expect(result).toHaveProperty('accessToken');
+      expect(result).toHaveProperty('refreshToken');
+      expect(result).toHaveProperty('expiresIn');
+      expect(result).toHaveProperty('user');
+    });
+
+    it('should propagate UnauthorizedException for an invalid, revoked, or expired refresh token', async () => {
+      authService.refreshTokens.mockRejectedValue(
+        new UnauthorizedException('Invalid refresh token'),
+      );
+      const dto: RefreshTokenDto = { refreshToken: 'bad-token' };
+
+      await expect(controller.refresh(dto)).rejects.toThrow(
+        UnauthorizedException,
       );
     });
   });
@@ -177,6 +229,10 @@ describe('AuthController', () => {
             provide: AuthService,
             useValue: {
               login: jest.fn().mockReturnValue({
+                accessToken: 'valid.token',
+                expiresIn: 3600,
+              }),
+              verifyAndLogin: jest.fn().mockResolvedValue({
                 accessToken: 'valid.token',
                 expiresIn: 3600,
               }),

--- a/BackEnd/src/modules/auth/auth.controller.ts
+++ b/BackEnd/src/modules/auth/auth.controller.ts
@@ -13,6 +13,8 @@ import {
   ChallengeRequestDto,
   ChallengeResponseDto,
   LoginDto,
+  RefreshTokenDto,
+  TokenResponseDto,
 } from './dto/auth.dto';
 
 @ApiTags('auth')
@@ -22,7 +24,9 @@ export class AuthController {
 
   @Post('challenge')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Request a sign-in challenge for a Stellar address' })
+  @ApiOperation({
+    summary: 'Request a sign-in challenge for a Stellar address',
+  })
   @ApiResponse({ status: 200, type: ChallengeResponseDto })
   async challenge(
     @Body() dto: ChallengeRequestDto,
@@ -37,5 +41,23 @@ export class AuthController {
     const result = await this.authService.verifyAndLogin(loginDto);
 
     return res.json(result);
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Rotate a refresh token for a new access/refresh token pair',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Tokens refreshed successfully',
+    type: TokenResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Refresh token is invalid, revoked, or expired',
+  })
+  async refresh(@Body() dto: RefreshTokenDto): Promise<TokenResponseDto> {
+    return this.authService.refreshTokens(dto.refreshToken);
   }
 }

--- a/BackEnd/src/modules/auth/auth.service.spec.ts
+++ b/BackEnd/src/modules/auth/auth.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UnauthorizedException, NotFoundException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { RefreshToken } from './entities/refresh-token.entity';
@@ -40,11 +42,11 @@ describe('AuthService', () => {
       providers: [
         AuthService,
         {
-          provide: 'JwtService',
+          provide: JwtService,
           useValue: jwtService,
         },
         {
-          provide: 'ConfigService',
+          provide: ConfigService,
           useValue: configService,
         },
         {
@@ -63,13 +65,7 @@ describe('AuthService', () => {
           useValue: mockRefreshTokenRepository,
         },
       ],
-    })
-      .useMocker((token) => {
-        if (token === 'JwtService') return jwtService;
-        if (token === 'ConfigService') return configService;
-        return undefined;
-      })
-      .compile();
+    }).compile();
 
     service = module.get<AuthService>(AuthService);
     usersService = module.get<UsersService>(UsersService);
@@ -189,7 +185,9 @@ describe('AuthService', () => {
 
       expect(result).toHaveProperty('accessToken');
       expect(result).toHaveProperty('refreshToken');
+      expect(result).toHaveProperty('expiresIn');
       expect(result).toHaveProperty('user');
+      expect(typeof result.expiresIn).toBe('number');
     });
 
     it('should throw UnauthorizedException for invalid refresh token', async () => {

--- a/BackEnd/src/modules/auth/auth.service.ts
+++ b/BackEnd/src/modules/auth/auth.service.ts
@@ -66,7 +66,7 @@ export class AuthService {
           return {
             id: user.id,
             stellarAddress: user.stellarAddress ?? '',
-            role: user.role as string,
+            role: user.role,
           };
         }
       } catch {
@@ -80,7 +80,7 @@ export class AuthService {
       return {
         id: user.id,
         stellarAddress: user.stellarAddress ?? '',
-        role: user.role as string,
+        role: user.role,
       };
     }
     return { id: idOrAddress, stellarAddress: '', role: Role.USER };
@@ -167,6 +167,7 @@ export class AuthService {
   async refreshTokens(token: string): Promise<{
     accessToken: string;
     refreshToken: string;
+    expiresIn: number;
     user: AuthUser;
   }> {
     const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
@@ -225,23 +226,28 @@ export class AuthService {
       role: user.role,
     };
     const accessToken = this.jwtService.sign(jwtPayload);
+    const accessExpiresMs = this.parseExpirationToMs(
+      this.configService.get<string>('JWT_ACCESS_TOKEN_EXPIRATION', '15m'),
+    );
 
     const authUser: AuthUser = {
       id: user.id,
       stellarAddress: user.stellarAddress ?? '',
-      role: user.role as string,
+      role: user.role,
     };
 
-    return { accessToken, refreshToken: rawRefreshToken, user: authUser };
+    return {
+      accessToken,
+      refreshToken: rawRefreshToken,
+      expiresIn: Math.floor(accessExpiresMs / 1000),
+      user: authUser,
+    };
   }
 
   async revokeToken(userId: string, tokenId?: string): Promise<void> {
     if (tokenId) {
       const token = await this.refreshTokenRepository.findOne({
-        where: [
-          { id: tokenId, userId },
-          { id: tokenId },
-        ],
+        where: [{ id: tokenId, userId }, { id: tokenId }],
       });
       if (!token) {
         throw new NotFoundException('Token not found');
@@ -285,7 +291,7 @@ export class AuthService {
         googleId: profile.googleId,
         githubId: profile.githubId,
         avatarUrl: profile.avatarUrl,
-        role: Role.USER as any,
+        role: Role.USER,
       });
     }
 


### PR DESCRIPTION
## What
Resolves #1895 by wiring up the already-implemented refresh-token rotation flow to an actual HTTP route: `POST /auth/refresh`.

## Why / which path was chosen
The issue asked to either finish implementing refresh-token rotation, or remove it as dead code. Investigation showed this was **not** a half-finished feature:

- `AuthService.refreshTokens()` (rotation + revocation of the previous token via a shared `familyId`), `generateTokens()`, and `revokeToken()` were all fully implemented.
- `RefreshTokenDto` and `TokenResponseDto` already existed in `dto/auth.dto.ts`, fully annotated with `class-validator`/Swagger decorators.
- All of the above already had thorough unit test coverage in `auth.service.spec.ts` (23 tests across `generateTokens`, `refreshTokens`, `revokeToken`, `loginOAuthUser`).

The only thing missing was a controller route — `AuthController` only exposed `challenge` and `login`, so none of this code was reachable from any HTTP request. Given the logic was already correct and well-tested, wiring it up was clearly the right call over deleting working code.

## Changes
- **`auth.controller.ts`**: added `POST /auth/refresh`, accepting `RefreshTokenDto` and returning `TokenResponseDto`.
- **`auth.service.ts`**: `refreshTokens()` now also returns `expiresIn` (computed the same way `generateTokens()` does, via `JWT_ACCESS_TOKEN_EXPIRATION`), so its response fully satisfies the pre-existing `TokenResponseDto` contract instead of being a 3-of-4-fields subset of it.
- **`auth.controller.spec.ts`**: added tests for the new route (calls the service with the right token, returns its result, propagates `UnauthorizedException` for invalid/revoked/expired tokens).
- **`auth.service.spec.ts`**: extended the existing `refreshTokens` success assertion to also check `expiresIn`.

## Incidental fixes (both blocked verifying my own changes)
- `auth.service.spec.ts`'s test module provided `JwtService`/`ConfigService` under **string** tokens (`'JwtService'`, `'ConfigService'`) that never matched the **class-based** tokens `AuthService` actually injects (`private readonly jwtService: JwtService`, etc. — no `@Inject()` override). Every single test in the file failed at `compile()` regardless of what it tested — confirmed this is pre-existing by running the identical test unmodified against `main`. Fixed by providing the actual `JwtService`/`ConfigService` classes as tokens.
- `auth.controller.spec.ts`'s login tests asserted against `authService.login` (the unused, synchronous method), but the controller actually calls `authService.verifyAndLogin`. Since the shared mock never stubbed `verifyAndLogin`, 5 of 8 tests threw `TypeError: this.authService.verifyAndLogin is not a function` — also confirmed pre-existing on `main`. Fixed the mock and assertions to match what the controller actually calls.

## Testing
- `npx jest src/modules/auth` — 60/60 passing (was 37/60 passing before the incidental fixes above, due to the two pre-existing bugs)
- `npm run build` — passes
- `npm run lint` — 0 errors (only pre-existing warnings unrelated to this change)
- `npx prettier --check` on all touched files — clean

## Acceptance Criteria
- [x] Refresh token flow is either fully implemented and tested, or entirely removed (implemented + tested)
- [x] No unused/injected-but-uncalled repository remains (`refreshTokenRepository` is now reachable via `POST /auth/refresh`)

Closes #1895