### PR TITLE
Add test coverage for ModerationController and ModerationService

### DIFF
--- a/BackEnd/test/moderation/moderation.controller.spec.ts
+++ b/BackEnd/test/moderation/moderation.controller.spec.ts
@@ -1,0 +1,231 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '#src/modules/auth/guards/jwt-auth.guard';
+import { RolesGuard } from '#src/modules/auth/guards/roles.guard';
+import { ROLES_KEY } from '#src/modules/auth/decorators/roles.decorator';
+import { Role } from '#src/common/enums/role.enum';
+import { ModerationController } from '#src/modules/moderation/moderation.controller';
+import { ModerationService } from '#src/modules/moderation/moderation.service';
+import { ModerationAction } from '#src/modules/moderation/entities/moderation-item.entity';
+import { AppealStatus } from '#src/modules/moderation/entities/moderation-appeal.entity';
+
+describe('ModerationController', () => {
+  let controller: ModerationController;
+  let service: jest.Mocked<
+    Pick<
+      ModerationService,
+      | 'scanText'
+      | 'listPending'
+      | 'getDashboardStats'
+      | 'applyAction'
+      | 'createAppeal'
+      | 'listAppealsPending'
+      | 'resolveAppeal'
+    >
+  >;
+
+  beforeEach(async () => {
+    service = {
+      scanText: jest.fn(),
+      listPending: jest.fn(),
+      getDashboardStats: jest.fn(),
+      applyAction: jest.fn(),
+      createAppeal: jest.fn(),
+      listAppealsPending: jest.fn(),
+      resolveAppeal: jest.fn(),
+    } as unknown as typeof service;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ModerationController],
+      providers: [{ provide: ModerationService, useValue: service }],
+    }).compile();
+
+    controller = module.get<ModerationController>(ModerationController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('scan', () => {
+    it('delegates to scanText and wraps the result', async () => {
+      const scanResult = {
+        score: 0.9,
+        keywordHits: [],
+        labels: {},
+        imageFlags: [],
+        shouldBlock: true,
+        shouldManualReview: false,
+      };
+      service.scanText.mockResolvedValue(scanResult);
+
+      const res = await controller.scan({ text: 'hello' });
+
+      expect(service.scanText).toHaveBeenCalledWith('hello');
+      expect(res).toEqual({ success: true, data: scanResult });
+    });
+  });
+
+  describe('dashboardPending', () => {
+    it('applies default pagination when query is empty', async () => {
+      service.listPending.mockResolvedValue({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+      });
+
+      const res = await controller.dashboardPending({});
+
+      expect(service.listPending).toHaveBeenCalledWith(1, 20);
+      expect(res.success).toBe(true);
+    });
+
+    it('passes through explicit pagination', async () => {
+      service.listPending.mockResolvedValue({
+        items: [],
+        total: 0,
+        page: 3,
+        limit: 50,
+      });
+
+      await controller.dashboardPending({ page: 3, limit: 50 });
+      expect(service.listPending).toHaveBeenCalledWith(3, 50);
+    });
+  });
+
+  describe('dashboardStats', () => {
+    it('returns the service stats', async () => {
+      service.getDashboardStats.mockResolvedValue({
+        pendingManualReview: 2,
+        pendingAppeals: 1,
+      });
+
+      const res = await controller.dashboardStats();
+      expect(res).toEqual({
+        success: true,
+        data: { pendingManualReview: 2, pendingAppeals: 1 },
+      });
+    });
+  });
+
+  describe('applyAction', () => {
+    it('passes the reviewer id from the request user', async () => {
+      const item = { id: 'i1' };
+      service.applyAction.mockResolvedValue(item as never);
+
+      const res = await controller.applyAction(
+        'i1',
+        { action: ModerationAction.APPROVE, notes: 'ok' },
+        { user: { id: 'admin-9' } },
+      );
+
+      expect(service.applyAction).toHaveBeenCalledWith(
+        'i1',
+        ModerationAction.APPROVE,
+        'admin-9',
+        'ok',
+      );
+      expect(res).toEqual({ success: true, data: { item } });
+    });
+  });
+
+  describe('createAppeal', () => {
+    it('passes the appellant id from the request user', async () => {
+      const appeal = { id: 'a1' };
+      service.createAppeal.mockResolvedValue(appeal as never);
+
+      const res = await controller.createAppeal(
+        { moderationItemId: 'i1', message: 'please review' },
+        { user: { id: 'user-1' } },
+      );
+
+      expect(service.createAppeal).toHaveBeenCalledWith(
+        'user-1',
+        'i1',
+        'please review',
+      );
+      expect(res).toEqual({ success: true, data: { appeal } });
+    });
+  });
+
+  describe('appealsPending', () => {
+    it('applies default pagination', async () => {
+      service.listAppealsPending.mockResolvedValue({
+        appeals: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+      });
+
+      await controller.appealsPending({});
+      expect(service.listAppealsPending).toHaveBeenCalledWith(1, 20);
+    });
+  });
+
+  describe('resolveAppeal', () => {
+    it('passes the resolver id from the request user', async () => {
+      const appeal = { id: 'a1' };
+      service.resolveAppeal.mockResolvedValue(appeal as never);
+
+      const res = await controller.resolveAppeal(
+        'a1',
+        { resolution: AppealStatus.APPROVED, resolutionNote: 'valid' },
+        { user: { id: 'admin-2' } },
+      );
+
+      expect(service.resolveAppeal).toHaveBeenCalledWith(
+        'a1',
+        AppealStatus.APPROVED,
+        'admin-2',
+        'valid',
+      );
+      expect(res).toEqual({ success: true, data: { appeal } });
+    });
+  });
+
+  /**
+   * Guard/role coverage. Rather than spinning up the HTTP layer, we assert the
+   * guard and @Roles metadata attached to each handler — this is what actually
+   * gates access in production and is cheap to verify by reflection.
+   */
+  describe('guard & role metadata', () => {
+    const guardsOf = (handler: (...args: unknown[]) => unknown) =>
+      (Reflect.getMetadata('__guards__', handler) ?? []) as Array<
+        new (...args: unknown[]) => unknown
+      >;
+    const rolesOf = (handler: (...args: unknown[]) => unknown) =>
+      Reflect.getMetadata(ROLES_KEY, handler) as Role[] | undefined;
+
+    const proto = ModerationController.prototype;
+
+    it('scan requires JWT auth only (any authenticated user)', () => {
+      const guards = guardsOf(proto.scan).map((g) => g.name);
+      expect(guards).toContain(JwtAuthGuard.name);
+      expect(guards).not.toContain(RolesGuard.name);
+      expect(rolesOf(proto.scan)).toBeUndefined();
+    });
+
+    it('createAppeal requires JWT auth only (owner appeals their own case)', () => {
+      const guards = guardsOf(proto.createAppeal).map((g) => g.name);
+      expect(guards).toContain(JwtAuthGuard.name);
+      expect(guards).not.toContain(RolesGuard.name);
+      expect(rolesOf(proto.createAppeal)).toBeUndefined();
+    });
+
+    it.each([
+      ['dashboardPending', proto.dashboardPending],
+      ['dashboardStats', proto.dashboardStats],
+      ['applyAction', proto.applyAction],
+      ['appealsPending', proto.appealsPending],
+      ['resolveAppeal', proto.resolveAppeal],
+    ])(
+      '%s is gated by JWT + Roles guards and restricted to ADMIN/MODERATOR',
+      (_name, handler) => {
+        const guards = guardsOf(handler as never).map((g) => g.name);
+        expect(guards).toContain(JwtAuthGuard.name);
+        expect(guards).toContain(RolesGuard.name);
+        expect(rolesOf(handler as never)).toEqual([Role.ADMIN, Role.MODERATOR]);
+      },
+    );
+  });
+});

--- a/BackEnd/test/moderation/moderation.spec.ts
+++ b/BackEnd/test/moderation/moderation.spec.ts
@@ -1,13 +1,18 @@
-﻿import { Test } from '@nestjs/testing';
-import { ConfigModule } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
 import { ModerationService } from '#src/modules/moderation/moderation.service';
 import {
   ModerationItem,
+  ModerationItemStatus,
   ModerationAction,
 } from '#src/modules/moderation/entities/moderation-item.entity';
-import { ModerationAppeal } from '#src/modules/moderation/entities/moderation-appeal.entity';
+import {
+  ModerationAppeal,
+  AppealStatus,
+} from '#src/modules/moderation/entities/moderation-appeal.entity';
 import { KeywordFilterService } from '#src/modules/moderation/filters/keyword-filter.service';
 import { ContentClassifierService } from '#src/modules/moderation/filters/content-classifier.service';
 import { ImageModerationService } from '#src/modules/moderation/filters/image-moderation.service';
@@ -50,41 +55,42 @@ describe('Moderation filters', () => {
   });
 });
 
+/**
+ * Service unit tests. Collaborators (keyword filter, classifier, image + external
+ * APIs) are mocked so scoring inputs are deterministic and threshold boundaries
+ * can be asserted precisely. Thresholds are fixed via a mocked ConfigService:
+ * high = 0.85, medium = 0.5, blockOnHighSeverity = true.
+ */
 describe('ModerationService', () => {
+  const HIGH = 0.85;
+  const MED = 0.5;
+
   let service: ModerationService;
   let itemRepo: Record<string, jest.Mock>;
   let appealRepo: Record<string, jest.Mock>;
+  let keywordFilter: { scan: jest.Mock };
+  let classifier: { classify: jest.Mock };
+  let imageModeration: {
+    extractUrlsFromProof: jest.Mock;
+    moderateUrls: jest.Mock;
+  };
+  let externalApi: { scoreText: jest.Mock };
+  let configValues: Record<string, unknown>;
 
-  beforeEach(async () => {
-    itemRepo = {
-      create: jest.fn((x: ModerationItem) => x),
-      save: jest.fn(async (x: ModerationItem) => x),
-      findOne: jest.fn(),
-      findAndCount: jest.fn(async () => [[], 0] as [ModerationItem[], number]),
-      count: jest.fn(async () => 0),
-    };
-    appealRepo = {
-      create: jest.fn((x: ModerationAppeal) => x),
-      save: jest.fn(async (x: ModerationAppeal) => x),
-      findOne: jest.fn(),
-      findAndCount: jest.fn(
-        async () => [[], 0] as [ModerationAppeal[], number],
-      ),
-      count: jest.fn(async () => 0),
-    };
-
+  const buildService = async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [
-        ConfigModule.forRoot({
-          load: [moderationConfig],
-        }),
-      ],
       providers: [
         ModerationService,
-        KeywordFilterService,
-        ContentClassifierService,
-        ImageModerationService,
-        ExternalModerationApiService,
+        { provide: KeywordFilterService, useValue: keywordFilter },
+        { provide: ContentClassifierService, useValue: classifier },
+        { provide: ImageModerationService, useValue: imageModeration },
+        { provide: ExternalModerationApiService, useValue: externalApi },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => configValues[key]),
+          },
+        },
         {
           provide: getRepositoryToken(ModerationItem),
           useValue: itemRepo as unknown as Repository<ModerationItem>,
@@ -96,32 +102,456 @@ describe('ModerationService', () => {
       ],
     }).compile();
 
-    service = moduleRef.get(ModerationService);
+    return moduleRef.get(ModerationService);
+  };
+
+  beforeEach(async () => {
+    itemRepo = {
+      create: jest.fn((x: Partial<ModerationItem>) => x),
+      save: jest.fn(async (x: ModerationItem) => x),
+      findOne: jest.fn(),
+      findAndCount: jest.fn(async () => [[], 0] as [ModerationItem[], number]),
+      count: jest.fn(async () => 0),
+    };
+    appealRepo = {
+      create: jest.fn((x: Partial<ModerationAppeal>) => x),
+      save: jest.fn(async (x: ModerationAppeal) => x),
+      findOne: jest.fn(),
+      findAndCount: jest.fn(
+        async () => [[], 0] as [ModerationAppeal[], number],
+      ),
+      count: jest.fn(async () => 0),
+    };
+
+    // Neutral collaborators by default; individual tests override return values.
+    keywordFilter = { scan: jest.fn(() => ({ hits: [], blocked: false })) };
+    classifier = {
+      classify: jest.fn(() => ({ labels: {}, primary: 'SAFE', score: 0 })),
+    };
+    imageModeration = {
+      extractUrlsFromProof: jest.fn(() => []),
+      moderateUrls: jest.fn(async () => []),
+    };
+    externalApi = { scoreText: jest.fn(async () => null) };
+
+    configValues = {
+      'moderation.highThreshold': HIGH,
+      'moderation.mediumThreshold': MED,
+      'moderation.blockOnHighSeverity': true,
+    };
+
+    service = await buildService();
   });
 
-  it('scanText returns structured result', async () => {
-    const r = await service.scanText('hello world');
-    expect(r).toHaveProperty('score');
-    expect(r).toHaveProperty('keywordHits');
-    expect(r).toHaveProperty('shouldBlock');
+  describe('scanText scoring & thresholds', () => {
+    it('returns a structured result', async () => {
+      const r = await service.scanText('hello world');
+      expect(r).toEqual(
+        expect.objectContaining({
+          score: expect.any(Number),
+          keywordHits: expect.any(Array),
+          labels: expect.any(Object),
+          imageFlags: expect.any(Array),
+          shouldBlock: expect.any(Boolean),
+          shouldManualReview: expect.any(Boolean),
+        }),
+      );
+    });
+
+    it('takes the max score across keyword / classifier / external signals', async () => {
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SPAM',
+        score: 0.3,
+      });
+      externalApi.scoreText.mockResolvedValue({ score: 0.7, categories: {} });
+
+      const r = await service.scanText('some text');
+      expect(r.score).toBe(0.7);
+    });
+
+    it('scores a blocked keyword hit at the maximum (1)', async () => {
+      keywordFilter.scan.mockReturnValue({
+        hits: ['terrorist'],
+        blocked: true,
+      });
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SAFE',
+        score: 0.1,
+      });
+
+      const r = await service.scanText('bad text');
+      expect(r.score).toBe(1);
+      expect(r.keywordHits).toEqual(['terrorist']);
+    });
+
+    it('applies a 0.95 floor when keyword hits are present but not blocking', async () => {
+      // hits without `blocked` (e.g. soft-match) still push the score to 0.95
+      keywordFilter.scan.mockReturnValue({ hits: ['spammy'], blocked: false });
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SAFE',
+        score: 0.1,
+      });
+
+      const r = await service.scanText('borderline text');
+      expect(r.score).toBe(0.95);
+    });
+
+    it('merges classifier and external labels', async () => {
+      classifier.classify.mockReturnValue({
+        labels: { SPAM: 0.2 },
+        primary: 'SPAM',
+        score: 0.2,
+      });
+      externalApi.scoreText.mockResolvedValue({
+        score: 0.1,
+        categories: { hate: 0.4 },
+      });
+
+      const r = await service.scanText('text');
+      expect(r.labels).toEqual({ SPAM: 0.2, hate: 0.4 });
+    });
+
+    it('does not manual-review or block just below the medium threshold', async () => {
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SAFE',
+        score: MED - 0.01,
+      });
+      const r = await service.scanText('text');
+      expect(r.shouldManualReview).toBe(false);
+      expect(r.shouldBlock).toBe(false);
+    });
+
+    it('flags for manual review exactly at the medium threshold (boundary)', async () => {
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SPAM',
+        score: MED,
+      });
+      const r = await service.scanText('text');
+      expect(r.shouldManualReview).toBe(true);
+      expect(r.shouldBlock).toBe(false);
+    });
+
+    it('still manual-reviews just below the high threshold', async () => {
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SPAM',
+        score: HIGH - 0.01,
+      });
+      const r = await service.scanText('text');
+      expect(r.shouldManualReview).toBe(true);
+      expect(r.shouldBlock).toBe(false);
+    });
+
+    it('blocks (and stops manual review) exactly at the high threshold (boundary)', async () => {
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SPAM',
+        score: HIGH,
+      });
+      const r = await service.scanText('text');
+      expect(r.shouldBlock).toBe(true);
+      expect(r.shouldManualReview).toBe(false);
+    });
+
+    it('does not block high-severity content when blockOnHighSeverity is false', async () => {
+      configValues['moderation.blockOnHighSeverity'] = false;
+      service = await buildService();
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SPAM',
+        score: 0.99,
+      });
+
+      const r = await service.scanText('text');
+      expect(r.shouldBlock).toBe(false);
+    });
+
+    it('falls back to default thresholds when config is unset', async () => {
+      configValues = {}; // get() returns undefined for everything
+      service = await buildService();
+      // default high = 0.85 → 0.9 should block
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SPAM',
+        score: 0.9,
+      });
+
+      const r = await service.scanText('text');
+      expect(r.shouldBlock).toBe(true);
+    });
+
+    it('handles empty text without throwing', async () => {
+      const r = await service.scanText('');
+      expect(r.score).toBe(0);
+      expect(r.shouldBlock).toBe(false);
+      expect(r.shouldManualReview).toBe(false);
+    });
   });
 
-  it('applyAction updates item when found', async () => {
-    itemRepo.findOne.mockResolvedValue({
-      id: '1',
-      status: 'MANUAL_REVIEW',
-    } as ModerationItem);
-    await service.applyAction('1', ModerationAction.APPROVE, 'admin-1', 'ok');
-    expect(itemRepo.save).toHaveBeenCalled();
+  describe('scanSubmissionContent', () => {
+    it('throws MODERATION_BLOCKED when scan says block', async () => {
+      classifier.classify.mockReturnValue({
+        labels: {},
+        primary: 'SPAM',
+        score: 0.99,
+      });
+
+      await expect(
+        service.scanSubmissionContent('sub-1', 'u1', { note: 'x' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(itemRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws when an image is on a blocked host even if text is clean', async () => {
+      imageModeration.extractUrlsFromProof.mockReturnValue([
+        'http://bad/x.png',
+      ]);
+      imageModeration.moderateUrls.mockResolvedValue([
+        { url: 'http://bad/x.png', reason: 'blocked_host' },
+      ]);
+
+      await expect(
+        service.scanSubmissionContent('sub-1', 'u1', {}),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('queues for manual review when an image is flagged (non-blocking reason)', async () => {
+      imageModeration.extractUrlsFromProof.mockReturnValue(['http://x/x.exe']);
+      imageModeration.moderateUrls.mockResolvedValue([
+        { url: 'http://x/x.exe', reason: 'suspicious_extension' },
+      ]);
+
+      const item = await service.scanSubmissionContent('sub-1', 'u1', {});
+      expect(item.status).toBe(ModerationItemStatus.MANUAL_REVIEW);
+      expect(item.priority).toBe(8);
+      expect(itemRepo.save).toHaveBeenCalled();
+    });
+
+    it('auto-approves clean submissions', async () => {
+      const item = await service.scanSubmissionContent('sub-1', 'u1', {
+        note: 'all good',
+      });
+      expect(item.status).toBe(ModerationItemStatus.AUTO_APPROVED);
+      expect(item.priority).toBe(0);
+    });
   });
 
-  it('createAppeal rejects wrong user', async () => {
-    itemRepo.findOne.mockResolvedValue({
-      id: '1',
-      userId: 'u1',
-    } as ModerationItem);
-    await expect(
-      service.createAppeal('u2', '1', 'please review'),
-    ).rejects.toThrow();
+  describe('applyAction — state transitions', () => {
+    it('throws NotFound when the item is missing', async () => {
+      itemRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.applyAction('missing', ModerationAction.APPROVE, 'admin-1'),
+      ).rejects.toThrow('Moderation item not found');
+    });
+
+    it('APPROVE moves item to APPROVED and records reviewer', async () => {
+      itemRepo.findOne.mockResolvedValue({
+        id: '1',
+        status: ModerationItemStatus.MANUAL_REVIEW,
+      } as ModerationItem);
+
+      const result = await service.applyAction(
+        '1',
+        ModerationAction.APPROVE,
+        'admin-1',
+        'looks fine',
+      );
+
+      expect(result.status).toBe(ModerationItemStatus.APPROVED);
+      expect(result.reviewedBy).toBe('admin-1');
+      expect(result.reviewedAt).toBeInstanceOf(Date);
+      expect(result.lastAction).toBe(ModerationAction.APPROVE);
+      expect(result.notes).toBe('looks fine');
+    });
+
+    it('REJECT moves item to REJECTED', async () => {
+      itemRepo.findOne.mockResolvedValue({
+        id: '1',
+        status: ModerationItemStatus.MANUAL_REVIEW,
+      } as ModerationItem);
+
+      const result = await service.applyAction(
+        '1',
+        ModerationAction.REJECT,
+        'admin-1',
+      );
+      expect(result.status).toBe(ModerationItemStatus.REJECTED);
+    });
+
+    it('ESCALATE bumps priority (capped at 100) without setting a terminal status', async () => {
+      itemRepo.findOne.mockResolvedValue({
+        id: '1',
+        status: ModerationItemStatus.MANUAL_REVIEW,
+        priority: 90,
+      } as ModerationItem);
+
+      const result = await service.applyAction(
+        '1',
+        ModerationAction.ESCALATE,
+        'admin-1',
+      );
+      expect(result.priority).toBe(100);
+      expect(result.status).toBe(ModerationItemStatus.MANUAL_REVIEW);
+      expect(result.lastAction).toBe(ModerationAction.ESCALATE);
+      // ESCALATE should not stamp a review decision
+      expect(result.reviewedBy).toBeUndefined();
+    });
+  });
+
+  describe('createAppeal', () => {
+    it('throws NotFound when the item is missing', async () => {
+      itemRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.createAppeal('u1', 'missing', 'please review'),
+      ).rejects.toThrow('Moderation item not found');
+    });
+
+    it('rejects appealing another user’s case', async () => {
+      itemRepo.findOne.mockResolvedValue({
+        id: '1',
+        userId: 'u1',
+      } as ModerationItem);
+      await expect(
+        service.createAppeal('u2', '1', 'please review'),
+      ).rejects.toThrow('You can only appeal your own moderation cases');
+    });
+
+    it('creates a PENDING appeal for the owner', async () => {
+      itemRepo.findOne.mockResolvedValue({
+        id: '1',
+        userId: 'u1',
+      } as ModerationItem);
+
+      const appeal = await service.createAppeal('u1', '1', 'please review');
+      expect(appealRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          moderationItemId: '1',
+          userId: 'u1',
+          message: 'please review',
+          status: AppealStatus.PENDING,
+        }),
+      );
+      expect(appeal.status).toBe(AppealStatus.PENDING);
+    });
+  });
+
+  describe('resolveAppeal — state transitions & edge cases', () => {
+    it('throws NotFound when the appeal is missing', async () => {
+      appealRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.resolveAppeal('missing', AppealStatus.APPROVED, 'admin-1'),
+      ).rejects.toThrow('Appeal not found');
+    });
+
+    it('rejects resolving an already-resolved appeal', async () => {
+      appealRepo.findOne.mockResolvedValue({
+        id: 'a1',
+        status: AppealStatus.REJECTED,
+      } as ModerationAppeal);
+
+      await expect(
+        service.resolveAppeal('a1', AppealStatus.APPROVED, 'admin-1'),
+      ).rejects.toThrow('Appeal already resolved');
+      expect(appealRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('APPROVED resolution also approves the linked moderation item', async () => {
+      const moderationItem = {
+        id: 'item-1',
+        status: ModerationItemStatus.REJECTED,
+      } as ModerationItem;
+      appealRepo.findOne.mockResolvedValue({
+        id: 'a1',
+        status: AppealStatus.PENDING,
+        moderationItem,
+      } as ModerationAppeal);
+
+      const result = await service.resolveAppeal(
+        'a1',
+        AppealStatus.APPROVED,
+        'admin-1',
+        'valid appeal',
+      );
+
+      expect(result.status).toBe(AppealStatus.APPROVED);
+      expect(result.resolvedBy).toBe('admin-1');
+      expect(result.resolvedAt).toBeInstanceOf(Date);
+      expect(result.resolutionNote).toBe('valid appeal');
+      // linked item flipped to APPROVED and persisted
+      expect(moderationItem.status).toBe(ModerationItemStatus.APPROVED);
+      expect(moderationItem.lastAction).toBe(ModerationAction.APPROVE);
+      expect(itemRepo.save).toHaveBeenCalledWith(moderationItem);
+    });
+
+    it('REJECTED resolution leaves the moderation item untouched', async () => {
+      const moderationItem = {
+        id: 'item-1',
+        status: ModerationItemStatus.REJECTED,
+      } as ModerationItem;
+      appealRepo.findOne.mockResolvedValue({
+        id: 'a1',
+        status: AppealStatus.PENDING,
+        moderationItem,
+      } as ModerationAppeal);
+
+      const result = await service.resolveAppeal(
+        'a1',
+        AppealStatus.REJECTED,
+        'admin-1',
+      );
+
+      expect(result.status).toBe(AppealStatus.REJECTED);
+      expect(result.resolutionNote).toBeNull();
+      expect(moderationItem.status).toBe(ModerationItemStatus.REJECTED);
+      expect(itemRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listing & stats', () => {
+    it('listPending queries MANUAL_REVIEW items with pagination', async () => {
+      itemRepo.findAndCount.mockResolvedValue([
+        [{ id: '1' } as ModerationItem],
+        1,
+      ]);
+      const result = await service.listPending(2, 10);
+      expect(result).toEqual({
+        items: [{ id: '1' }],
+        total: 1,
+        page: 2,
+        limit: 10,
+      });
+      expect(itemRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: ModerationItemStatus.MANUAL_REVIEW },
+          skip: 10,
+          take: 10,
+        }),
+      );
+    });
+
+    it('listAppealsPending queries PENDING appeals with the item relation', async () => {
+      appealRepo.findAndCount.mockResolvedValue([[], 0]);
+      await service.listAppealsPending(1, 20);
+      expect(appealRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: AppealStatus.PENDING },
+          relations: ['moderationItem'],
+          skip: 0,
+          take: 20,
+        }),
+      );
+    });
+
+    it('getDashboardStats returns pending review and appeal counts', async () => {
+      itemRepo.count.mockResolvedValue(3);
+      appealRepo.count.mockResolvedValue(5);
+      const stats = await service.getDashboardStats();
+      expect(stats).toEqual({ pendingManualReview: 3, pendingAppeals: 5 });
+    });
   });
 });


### PR DESCRIPTION
## Linked Issue

Closes #1905 

> **Required:** Every PR must be linked to an open issue. PRs without a linked issue will not be reviewed.

---

## Description

[test/moderation/moderation.spec.ts](vscode-webview://0g5451v6fase3m22jndpag4r166422hnehkrq0mlfep27itrgl20/BackEnd/test/moderation/moderation.spec.ts) — expanded the thin existing service spec. Collaborators (keyword filter, classifier, image + external APIs) and ConfigService are now mocked so scoring inputs are deterministic and thresholds are pinned (high=0.85, medium=0.5). Coverage:

Scoring — max across keyword/classifier/external signals; blocked keyword → score 1; non-blocking keyword hit → 0.95 floor; label merging.
Threshold boundaries — just below medium (no action), at medium (manual review), just below high (manual review), at high (block, no manual review), blockOnHighSeverity: false, config-unset fallback to defaults, empty text.
scanSubmissionContent — MODERATION_BLOCKED on high score, blocked-host image throw, non-blocking image flag → manual review, clean → auto-approve.
State transitions — applyAction APPROVE/REJECT/ESCALATE (priority cap at 100, no terminal status on escalate) + NotFound; createAppeal NotFound / wrong-user Forbidden / owner PENDING; resolveAppeal NotFound, already-resolved rejection, APPROVED cascades to the linked item, REJECTED leaves it untouched.
Listing/stats — pagination and query shape for listPending, listAppealsPending, getDashboardStats.
**What changed?**

**Why was it changed?**

**How was it implemented?**

---

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Security fix
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Tests only
- [ ] Configuration / DevOps change

---

## Contract Changelog Discipline

> **Required for changes under `contracts/earn-quest/src/**` or any contract storage, event, or interface change.**

- [ ] No contract implementation changes - not applicable
- [ ] Updated `contracts/earn-quest/CHANGELOG.md` under `## [Unreleased]`
- [ ] If breaking, added a `### Breaking Changes` entry with impact, affected files, and migration steps
- [ ] If breaking, used Conventional Commit breaking metadata (`type(scope)!:`) in the PR title or commit history
- [ ] If breaking, included a `BREAKING CHANGE:` explanation below

**BREAKING CHANGE details (required for breaking contract changes):**

```text
BREAKING CHANGE:
```

---

## Test Evidence

> **Required:** All PRs must include test evidence. PRs missing this section will be blocked from merging.

### Unit Tests

- [ ] New unit tests added for changed logic
- [ ] All existing unit tests pass (`npm run test`)
- [ ] Coverage does not regress (`npm run test:cov`)

**Test output / screenshot:**

```
<!-- Paste relevant test output here -->
```

### E2E / Integration Tests

- [ ] E2E tests added or updated (`npm run test:e2e`)
- [ ] Tested manually against a local environment

**Endpoints tested:**

| Method | Endpoint | Expected | Result |
|--------|----------|----------|--------|
| `GET`  | `/api/...` | 200 OK | [x] |

---

## Swagger / API Documentation

> **Required for any endpoint changes.**

- [ ] No API changes - Swagger update not applicable
- [ ] New endpoints documented with `@ApiOperation`, `@ApiResponse`, and `@ApiBearerAuth` decorators
- [ ] Updated DTOs annotated with `@ApiProperty` / `@ApiPropertyOptional`
- [ ] Swagger UI verified locally at `/api/docs` and responses are accurate
- [ ] Breaking changes to existing contracts are documented in the description above

---

## Error Handling Checklist

> All items below must be verified before requesting review.

### HTTP Exceptions

- [ ] Appropriate NestJS HTTP exceptions used (`NotFoundException`, `BadRequestException`, `ForbiddenException`, `UnauthorizedException`, `ConflictException`, etc.)
- [ ] No raw `Error` thrown where an HTTP exception is expected
- [ ] Global exception filter handles all unhandled errors gracefully
- [ ] Error responses follow the project's standard error shape

### Input Validation (DTOs)

- [ ] All incoming request bodies and query params have a corresponding DTO
- [ ] DTOs use `class-validator` decorators (`@IsString`, `@IsUUID`, `@IsNotEmpty`, `@IsOptional`, etc.)
- [ ] `class-transformer` decorators applied where necessary (`@Transform`, `@Type`, `@Expose`)
- [ ] `ValidationPipe` is applied globally or at the controller level - raw unvalidated input is never used

### Guards & Authorization

- [ ] Endpoints requiring authentication are protected with `@UseGuards(JwtAuthGuard)` or equivalent
- [ ] Admin-only endpoints use the appropriate admin guard / role check
- [ ] Public endpoints are explicitly marked with `@Public()` decorator where applicable
- [ ] Throttler guard behaviour verified - rate limits are not unintentionally bypassed

### Logging

- [ ] Significant operations and state transitions are logged using the project's Winston logger (`LoggerService`)
- [ ] Errors are logged at `error` level with stack traces
- [ ] No sensitive data (passwords, secrets, private keys, tokens) is included in log output
- [ ] Incoming request / response logging is handled by the global `LoggerMiddleware` - no duplicate logs added

### Stellar / Soroban Contract Interactions

- [ ] Contract calls wrapped in try/catch with descriptive error messages
- [ ] Horizon / Soroban RPC failures do not crash the service - fallback or retry logic applied where appropriate
- [ ] Transaction signing uses environment-provided keys only - no hardcoded secrets

---

## Database / Migration

- [ ] No database changes - not applicable
- [ ] TypeORM migration created and tested (`npm run typeorm:generate-migration`)
- [ ] Migration is reversible (down migration implemented)
- [ ] Seed data updated if required (`seed.ts`)

---

---

## Breaking Type / Model Changes (Frontend — FE-068)

> Required if your PR modifies any file under `FrontEnd/my-app/lib/types/**`,
> `FrontEnd/my-app/lib/api/**`, `FrontEnd/my-app/lib/schemas/**`,
> `FrontEnd/my-app/lib/validation/**`, or `FrontEnd/my-app/context/walletTypes.ts`.
>
> Full policy: [`FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md`](../FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md)

- [ ] My PR touches **none** of the watched type/model paths — not applicable.
- [ ] I classified my change as: ☐ `breaking-types` ☐ `breaking-runtime` ☐ `added` ☐ `changed` ☐ `deprecated` ☐ `removed` ☐ `fixed` ☐ `security`
- [ ] I added a bullet to `## [Unreleased]` in [`FrontEnd/my-app/CHANGELOG.md`](../FrontEnd/my-app/CHANGELOG.md) **OR** a new file in [`FrontEnd/my-app/.changeset/`](../FrontEnd/my-app/.changeset/README.md).
- [ ] If breaking, my entry includes a before/after `Migration:` code block.
- [ ] `cd FrontEnd/my-app && npm run changelog:check` passes locally.
- [ ] If I am asserting this change is non-breaking despite touching a watched file, I added the `changelog-skip` label or `[changelog-skip]` to the PR title.


## Final Pre-Merge Checklist

- [ ] Branch is up to date with `main` / `master`
- [ ] Linting passes (`npm run lint`)
- [ ] Formatting passes (`npm run format`)
- [ ] No `console.log` / debug statements left in production code
- [ ] No hardcoded secrets, API keys, or environment-specific values in source code
- [ ] `.env.example` updated if new environment variables were introduced
- [ ] `ReadMe Backend.md` or `ReadMe Frontend.md` updated if setup steps changed
- [ ] Self-review completed - I have read through every line of the diff

---

## Screenshots / Recordings (if applicable)

<!-- Attach screenshots or screen recordings for UI changes or Swagger updates -->

---

## Additional Notes for Reviewer

<!-- Anything the reviewer should pay special attention to, known limitations, follow-up issues, etc. -->
