### PR TITLE
Add test coverage for AdminController and AdminService

### DIFF
--- a/BackEnd/src/modules/admin/admin.controller.spec.ts
+++ b/BackEnd/src/modules/admin/admin.controller.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { AdminController, AdminService } from './admin.module';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { IpWhitelistGuard } from '../../common/guards/ip-whitelist.guard';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let service: AdminService;
+
+  const mockAdminService = {
+    getUsers: jest.fn(),
+    getUserById: jest.fn(),
+    getPlatformStats: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [{ provide: AdminService, useValue: mockAdminService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(IpWhitelistGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<AdminController>(AdminController);
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getUsers', () => {
+    it('should call adminService.getUsers', () => {
+      const page = 1;
+      const limit = 10;
+      controller.getUsers(page, limit);
+      expect(service.getUsers).toHaveBeenCalledWith(page, limit);
+    });
+
+    it('should coerce query-string page/limit to numbers', () => {
+      controller.getUsers('2' as unknown as number, '50' as unknown as number);
+      expect(service.getUsers).toHaveBeenCalledWith(2, 50);
+    });
+
+    it('should apply default pagination values', () => {
+      controller.getUsers();
+      expect(service.getUsers).toHaveBeenCalledWith(1, 20);
+    });
+  });
+
+  describe('getUserById', () => {
+    it('should call adminService.getUserById', () => {
+      const userId = '1';
+      controller.getUserById(userId);
+      expect(service.getUserById).toHaveBeenCalledWith(userId);
+    });
+
+    it('should propagate ForbiddenException when the user is missing', async () => {
+      mockAdminService.getUserById.mockRejectedValueOnce(
+        new ForbiddenException('User not found'),
+      );
+      await expect(controller.getUserById('missing')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('guards', () => {
+    it('should protect the controller with the admin guard stack', () => {
+      const guards = Reflect.getMetadata('__guards__', AdminController) ?? [];
+      expect(guards).toEqual(
+        expect.arrayContaining([JwtAuthGuard, RolesGuard, IpWhitelistGuard]),
+      );
+    });
+  });
+
+  describe('getPlatformStats', () => {
+    it('should call adminService.getPlatformStats', () => {
+      controller.getPlatformStats();
+      expect(service.getPlatformStats).toHaveBeenCalled();
+    });
+  });
+});

--- a/BackEnd/src/modules/admin/admin.service.spec.ts
+++ b/BackEnd/src/modules/admin/admin.service.spec.ts
@@ -1,0 +1,103 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AdminService } from './admin.module';
+import { User } from '../users/entities/user.entity';
+import { ForbiddenException } from '@nestjs/common';
+import { Role } from '../../common/enums/role.enum';
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  const mockUserRepo = {
+    findAndCount: jest.fn(),
+    findOne: jest.fn(),
+    count: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getUsers', () => {
+    it('should return paginated users', async () => {
+      const page = 1;
+      const limit = 10;
+      const users = [{ id: '1', username: 'test' }] as User[];
+      const total = 1;
+
+      mockUserRepo.findAndCount.mockResolvedValue([users, total]);
+
+      const result = await service.getUsers(page, limit);
+
+      expect(result).toEqual({ users, total, page, limit });
+      expect(mockUserRepo.findAndCount).toHaveBeenCalledWith({
+        skip: (page - 1) * limit,
+        take: limit,
+        order: { createdAt: 'DESC' },
+      });
+    });
+  });
+
+  describe('getUserById', () => {
+    it('should return a user if found', async () => {
+      const userId = '1';
+      const user = { id: userId, username: 'test' } as User;
+
+      mockUserRepo.findOne.mockResolvedValue(user);
+
+      const result = await service.getUserById(userId);
+
+      expect(result).toEqual(user);
+      expect(mockUserRepo.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+    });
+
+    it('should throw ForbiddenException if user not found', async () => {
+      const userId = '1';
+      mockUserRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getUserById(userId)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('getPlatformStats', () => {
+    it('should return platform stats', async () => {
+      const totalUsers = 10;
+      const adminCount = 2;
+
+      mockUserRepo.count.mockImplementation((options) => {
+        if (
+          options &&
+          'where' in options &&
+          options.where &&
+          'role' in options.where &&
+          options.where.role === Role.ADMIN
+        ) {
+          return Promise.resolve(adminCount);
+        }
+        return Promise.resolve(totalUsers);
+      });
+
+      const result = await service.getPlatformStats();
+
+      expect(result).toEqual({ totalUsers, adminCount });
+    });
+  });
+});

--- a/BackEnd/src/modules/auth/guards/roles.guard.spec.ts
+++ b/BackEnd/src/modules/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,81 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { Role } from '../../../common/enums/role.enum';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  const mockExecutionContext = (user?: { role?: Role }): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should allow access when no roles are required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+
+    expect(guard.canActivate(mockExecutionContext({ role: Role.USER }))).toBe(
+      true,
+    );
+  });
+
+  it('should allow an admin caller when ADMIN role is required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.ADMIN]);
+
+    expect(guard.canActivate(mockExecutionContext({ role: Role.ADMIN }))).toBe(
+      true,
+    );
+  });
+
+  it('should reject a non-admin caller when ADMIN role is required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.ADMIN]);
+
+    expect(guard.canActivate(mockExecutionContext({ role: Role.USER }))).toBe(
+      false,
+    );
+  });
+
+  it('should read required roles from both handler and class', () => {
+    const spy = jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([Role.ADMIN]);
+    const handler = () => ({});
+    const cls = class {};
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: Role.ADMIN } }),
+      }),
+      getHandler: () => handler,
+      getClass: () => cls,
+    } as unknown as ExecutionContext;
+
+    guard.canActivate(context);
+
+    expect(spy).toHaveBeenCalledWith(ROLES_KEY, [handler, cls]);
+  });
+
+  it('should accept any one of several required roles', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([Role.ADMIN, Role.MODERATOR]);
+
+    expect(
+      guard.canActivate(mockExecutionContext({ role: Role.MODERATOR })),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Summary
Added meaningful spec coverage for the admin module and its guard checks. Three spec files (19 tests, all passing, lint-clean):

[admin.service.spec.ts](vscode-webview://0g5451v6fase3m22jndpag4r166422hnehkrq0mlfep27itrgl20/BackEnd/src/modules/admin/admin.service.spec.ts) — user listing/pagination (verifies skip/take/order), getUserById success path, the getUserById error path (throws ForbiddenException when the user is missing), and platform stats.

[admin.controller.spec.ts](vscode-webview://0g5451v6fase3m22jndpag4r166422hnehkrq0mlfep27itrgl20/BackEnd/src/modules/admin/admin.controller.spec.ts) — delegation for all three endpoints, query-string Number() coercion, default pagination values, ForbiddenException propagation from the service, and a guard-wiring test confirming the controller declares the full JwtAuthGuard/RolesGuard/IpWhitelistGuard stack.

[roles.guard.spec.ts](vscode-webview://0g5451v6fase3m22jndpag4r166422hnehkrq0mlfep27itrgl20/BackEnd/src/modules/auth/guards/roles.guard.spec.ts) — new spec proving the guard rejects a non-admin caller when ADMIN is required, admits admins, admits any of several allowed roles, allows through when no roles are required, and reads roles from both handler and class.

Two things worth flagging that diverged from the plan:

No role-change operation exists. The admin module is read-only (@Get endpoints only) — there is no updateRole/changeRole method or route anywhere in the module. That plan item couldn't be tested because the feature isn't implemented. If role changes are expected, that's a feature gap, not a test gap.
The AdminController has no @Roles(Role.ADMIN) decorator. It applies RolesGuard, but RolesGuard returns true when no roles metadata is present — so as currently wired, non-admins are not actually rejected by that guard on admin routes (only the IP whitelist and JWT auth apply). The guard mechanism rejects non-admins (now proven by roles.guard.spec.ts), but it's never armed on this controller. Worth adding @Roles(Role.ADMIN) to the controller if admin-only access is the intent.

Closes #1908
