### PR TITLE
feat(webhooks): add class-validator DTOs for webhook event routes

### DIFF
--- a/BackEnd/src/modules/webhooks/CHANGELOG.md
+++ b/BackEnd/src/modules/webhooks/CHANGELOG.md
@@ -27,3 +27,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Improved error logging formatting in WebhooksService
+
+# Changelog - Webhooks Module
+
+## [Unreleased]
+
+### Changed
+- Updated `WebhooksController` and unit tests to enforce `WebhookPayloadDto` validation.

--- a/BackEnd/src/modules/webhooks/dto/webhook-event.dto.ts
+++ b/BackEnd/src/modules/webhooks/dto/webhook-event.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsEnum,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum WebhookEventType {
+  PAYMENT_RECEIVED = 'PAYMENT_RECEIVED',
+  QUEST_COMPLETED = 'QUEST_COMPLETED',
+  TRANSACTION_FAILED = 'TRANSACTION_FAILED',
+}
+
+export class WebhookDataDto {
+  @IsString()
+  @IsNotEmpty()
+  transactionHash!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  sourceAccount!: string;
+
+  @IsOptional()
+  @IsString()
+  amount?: string;
+}
+
+export class WebhookPayloadDto {
+  @IsString()
+  @IsNotEmpty()
+  eventId!: string;
+
+  @IsEnum(WebhookEventType)
+  eventType!: WebhookEventType;
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => WebhookDataDto)
+  data!: WebhookDataDto;
+}

--- a/BackEnd/src/modules/webhooks/webhooks.controller.spec.ts
+++ b/BackEnd/src/modules/webhooks/webhooks.controller.spec.ts
@@ -8,6 +8,7 @@ import { WebhooksController } from './webhooks.controller';
 import { WebhooksService, WebhookResponse } from './webhooks.service';
 import { TraceService } from '../trace/trace.service';
 import { FailedWebhookStatus } from './entities/failed-webhook-event.entity';
+import { WebhookEventType, WebhookPayloadDto } from './dto/webhook-event.dto';
 
 /**
  * Unit tests for WebhooksController.
@@ -23,6 +24,16 @@ describe('WebhooksController', () => {
   let controller: WebhooksController;
   let webhooksService: jest.Mocked<WebhooksService>;
   let traceService: jest.Mocked<TraceService>;
+
+  const mockPayload: WebhookPayloadDto = {
+    eventId: 'evt_123',
+    eventType: WebhookEventType.PAYMENT_RECEIVED,
+    data: {
+      transactionHash: '0xabc1234567890',
+      sourceAccount: 'GABCD1234567890',
+      amount: '100.00',
+    },
+  };
 
   const successResponse = (
     overrides: Partial<WebhookResponse> = {},
@@ -73,15 +84,7 @@ describe('WebhooksController', () => {
     it('should reject a request missing the X-GitHub-Event header', async () => {
       await expect(
         controller.handleGithubWebhook(
-          {},
-          undefined as unknown as string,
-          'delivery-1',
-          undefined as unknown as string,
-        ),
-      ).rejects.toThrow(BadRequestException);
-      await expect(
-        controller.handleGithubWebhook(
-          {},
+          mockPayload,
           undefined as unknown as string,
           'delivery-1',
           undefined as unknown as string,
@@ -94,7 +97,7 @@ describe('WebhooksController', () => {
     it('should reject a request missing the X-GitHub-Delivery header', async () => {
       await expect(
         controller.handleGithubWebhook(
-          {},
+          mockPayload,
           'push',
           undefined as unknown as string,
           undefined as unknown as string,
@@ -110,7 +113,7 @@ describe('WebhooksController', () => {
       );
 
       const result = await controller.handleGithubWebhook(
-        { questId: 'q-1', submitterAddress: 'GABC' },
+        mockPayload,
         'push',
         'delivery-1',
         'sha256=deadbeef',
@@ -120,7 +123,8 @@ describe('WebhooksController', () => {
       expect(traceService.createTrace).toHaveBeenCalledWith(
         expect.objectContaining({
           webhookEventId: 'delivery-1',
-          questId: 'q-1',
+          questId: '0xabc1234567890',
+          submitterAddress: 'GABCD1234567890',
         }),
       );
       expect(traceService.linkOnchain).toHaveBeenCalledWith(
@@ -132,7 +136,7 @@ describe('WebhooksController', () => {
     it('should append a CONFIRMED event when no on-chain tx hash is returned', async () => {
       webhooksService.processWebhook.mockResolvedValue(successResponse());
 
-      await controller.handleGithubWebhook({}, 'push', 'delivery-1', 'sig');
+      await controller.handleGithubWebhook(mockPayload, 'push', 'delivery-1', 'sig');
 
       expect(traceService.linkOnchain).not.toHaveBeenCalled();
       expect(traceService.appendEvent).toHaveBeenCalledWith(
@@ -151,7 +155,7 @@ describe('WebhooksController', () => {
       );
 
       await expect(
-        controller.handleGithubWebhook({}, 'push', 'delivery-1', 'bad-sig'),
+        controller.handleGithubWebhook(mockPayload, 'push', 'delivery-1', 'bad-sig'),
       ).rejects.toThrow(UnauthorizedException);
 
       expect(traceService.appendEvent).toHaveBeenCalledWith(
@@ -168,7 +172,7 @@ describe('WebhooksController', () => {
     it('should reject a request missing the X-Event-Type header', async () => {
       await expect(
         controller.handleApiVerificationWebhook(
-          {},
+          mockPayload,
           undefined as unknown as string,
           'webhook-1',
           undefined as unknown as string,
@@ -181,7 +185,7 @@ describe('WebhooksController', () => {
     it('should reject a request missing the X-Webhook-ID header', async () => {
       await expect(
         controller.handleApiVerificationWebhook(
-          {},
+          mockPayload,
           'submission_verify',
           undefined as unknown as string,
           undefined as unknown as string,
@@ -195,7 +199,7 @@ describe('WebhooksController', () => {
       webhooksService.processWebhook.mockResolvedValue(successResponse());
 
       await controller.handleApiVerificationWebhook(
-        { submissionId: 's-1' },
+        mockPayload,
         'submission_verify',
         'webhook-1',
         'Bearer some-token-value',
@@ -213,7 +217,7 @@ describe('WebhooksController', () => {
       webhooksService.processWebhook.mockResolvedValue(successResponse());
 
       await controller.handleApiVerificationWebhook(
-        {},
+        mockPayload,
         'submission_verify',
         'webhook-1',
         'Basic abc123',
@@ -234,7 +238,7 @@ describe('WebhooksController', () => {
 
       await expect(
         controller.handleApiVerificationWebhook(
-          {},
+          mockPayload,
           'submission_verify',
           'webhook-1',
           undefined as unknown as string,
@@ -248,7 +252,7 @@ describe('WebhooksController', () => {
   describe('POST /webhooks/generic/:service — allowlist enforcement', () => {
     it('should reject an unknown service name with BadRequestException', async () => {
       await expect(
-        controller.handleGenericWebhook({}, {}, 'sig', 'push', 'unknown'),
+        controller.handleGenericWebhook(mockPayload, {}, 'sig', 'push', 'unknown'),
       ).rejects.toThrow(BadRequestException);
       expect(webhooksService.processWebhook).not.toHaveBeenCalled();
     });
@@ -257,7 +261,7 @@ describe('WebhooksController', () => {
       process.env.AWS_SECRET_ACCESS_KEY = 'should-not-be-reachable';
       await expect(
         controller.handleGenericWebhook(
-          {},
+          mockPayload,
           {},
           'sig',
           'push',
@@ -269,7 +273,7 @@ describe('WebhooksController', () => {
 
     it('should reject a known service whose secret env var is not set', async () => {
       await expect(
-        controller.handleGenericWebhook({}, {}, 'sig', 'push', 'github'),
+        controller.handleGenericWebhook(mockPayload, {}, 'sig', 'push', 'github'),
       ).rejects.toThrow(BadRequestException);
       expect(webhooksService.processWebhook).not.toHaveBeenCalled();
     });
@@ -277,7 +281,7 @@ describe('WebhooksController', () => {
     it('should reject a known service whose secret env var is empty', async () => {
       process.env.GITHUB_WEBHOOK_SECRET = '';
       await expect(
-        controller.handleGenericWebhook({}, {}, 'sig', 'push', 'github'),
+        controller.handleGenericWebhook(mockPayload, {}, 'sig', 'push', 'github'),
       ).rejects.toThrow(BadRequestException);
       expect(webhooksService.processWebhook).not.toHaveBeenCalled();
     });
@@ -293,7 +297,7 @@ describe('WebhooksController', () => {
 
       await expect(
         controller.handleGenericWebhook(
-          {},
+          mockPayload,
           {},
           'sha256=invalidsig',
           'push',
@@ -315,7 +319,7 @@ describe('WebhooksController', () => {
       );
 
       const result = await controller.handleGenericWebhook(
-        {},
+        mockPayload,
         {},
         'sig',
         'push',
@@ -336,7 +340,7 @@ describe('WebhooksController', () => {
       webhooksService.processWebhook.mockResolvedValue(successResponse());
 
       const result = await controller.handleGenericWebhook(
-        {},
+        mockPayload,
         {},
         'sig',
         'push',
@@ -354,7 +358,7 @@ describe('WebhooksController', () => {
       webhooksService.processWebhook.mockResolvedValue(successResponse());
 
       await controller.handleGenericWebhook(
-        {},
+        mockPayload,
         {},
         'sig',
         undefined as unknown as string,

--- a/BackEnd/src/modules/webhooks/webhooks.controller.ts
+++ b/BackEnd/src/modules/webhooks/webhooks.controller.ts
@@ -13,6 +13,8 @@ import {
   Param,
   Query,
   UseGuards,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -36,6 +38,7 @@ import {
   FailedWebhookEventResponseDto,
   RetryWebhookResponseDto,
 } from './dto/webhook-response.dto';
+import { WebhookPayloadDto } from './dto/webhook-event.dto';
 import { FailedWebhookStatus } from './entities/failed-webhook-event.entity';
 import { TraceService } from '../trace/trace.service';
 import { TraceIdUtil } from '../trace/trace-id.util';
@@ -72,9 +75,16 @@ export class WebhooksController {
    */
   @Post('github')
   @HttpCode(HttpStatus.OK)
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  )
   @ApiOperation({ summary: 'Receive GitHub webhook events' })
   @ApiConsumes('application/json')
-  @ApiBody({ schema: { type: 'object' } })
+  @ApiBody({ type: WebhookPayloadDto })
   @ApiResponse({
     status: 200,
     description: 'Webhook processed successfully',
@@ -86,7 +96,7 @@ export class WebhooksController {
     description: 'Unauthorized or invalid signature',
   })
   async handleGithubWebhook(
-    @Body() payload: any,
+    @Body() payload: WebhookPayloadDto,
     @Headers('x-github-event') eventType: string,
     @Headers('x-github-delivery') deliveryId: string,
     @Headers('x-hub-signature-256') signature: string,
@@ -107,8 +117,8 @@ export class WebhooksController {
       await this.traceService.createTrace({
         traceId,
         webhookEventId: deliveryId,
-        questId: payload?.questId ?? 'unknown',
-        submitterAddress: payload?.submitterAddress ?? 'unknown',
+        questId: payload?.data?.transactionHash ?? 'unknown',
+        submitterAddress: payload?.data?.sourceAccount ?? 'unknown',
       });
 
       try {
@@ -136,7 +146,6 @@ export class WebhooksController {
           throw new UnauthorizedException(response.message);
         }
 
-        // Link on-chain tx hash if the service returns one
         if (response.txHash) {
           await this.traceService.linkOnchain({
             traceId,
@@ -154,7 +163,7 @@ export class WebhooksController {
         }
 
         return response;
-      } catch (error) {
+      } catch (error: any) {
         if (!(error instanceof UnauthorizedException)) {
           await this.traceService.appendEvent(
             traceId,
@@ -178,9 +187,16 @@ export class WebhooksController {
    */
   @Post('api-verify')
   @HttpCode(HttpStatus.OK)
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  )
   @ApiOperation({ summary: 'API verification webhook endpoint' })
   @ApiConsumes('application/json')
-  @ApiBody({ schema: { type: 'object' } })
+  @ApiBody({ type: WebhookPayloadDto })
   @ApiResponse({
     status: 200,
     description: 'Verification processed',
@@ -192,7 +208,7 @@ export class WebhooksController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async handleApiVerificationWebhook(
-    @Body() payload: any,
+    @Body() payload: WebhookPayloadDto,
     @Headers('x-event-type') eventType: string,
     @Headers('x-webhook-id') webhookId: string,
     @Headers('authorization') authHeader: string,
@@ -213,8 +229,8 @@ export class WebhooksController {
       await this.traceService.createTrace({
         traceId,
         webhookEventId: webhookId,
-        questId: payload?.questId ?? 'unknown',
-        submitterAddress: payload?.submitterAddress ?? 'unknown',
+        questId: payload?.data?.transactionHash ?? 'unknown',
+        submitterAddress: payload?.data?.sourceAccount ?? 'unknown',
       });
 
       try {
@@ -264,7 +280,7 @@ export class WebhooksController {
         }
 
         return response;
-      } catch (error) {
+      } catch (error: any) {
         if (!(error instanceof UnauthorizedException)) {
           await this.traceService.appendEvent(
             traceId,
@@ -284,13 +300,19 @@ export class WebhooksController {
 
   /**
    * Generic webhook endpoint for other external services
-   * Note: This should be placed after specific routes to avoid conflicts
    */
   @Post('generic/:service')
   @HttpCode(HttpStatus.OK)
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  )
   @ApiOperation({ summary: 'Generic webhook receiver for external services' })
   @ApiConsumes('application/json')
-  @ApiBody({ schema: { type: 'object' } })
+  @ApiBody({ type: WebhookPayloadDto })
   @ApiResponse({
     status: 200,
     description: 'Webhook processed',
@@ -298,7 +320,7 @@ export class WebhooksController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async handleGenericWebhook(
-    @Body() payload: any,
+    @Body() payload: WebhookPayloadDto,
     @Headers() headers: any,
     @Headers('x-signature') signature: string,
     @Headers('x-event-type') eventType: string,
@@ -328,8 +350,8 @@ export class WebhooksController {
       await this.traceService.createTrace({
         traceId,
         webhookEventId: eventId,
-        questId: payload?.questId ?? 'unknown',
-        submitterAddress: payload?.submitterAddress ?? 'unknown',
+        questId: payload?.data?.transactionHash ?? 'unknown',
+        submitterAddress: payload?.data?.sourceAccount ?? 'unknown',
       });
 
       try {
@@ -371,7 +393,7 @@ export class WebhooksController {
         }
 
         return response;
-      } catch (error) {
+      } catch (error: any) {
         if (!(error instanceof UnauthorizedException)) {
           await this.traceService.appendEvent(
             traceId,
@@ -485,6 +507,6 @@ export class WebhooksController {
    * Generate unique event ID
    */
   private generateEventId(): string {
-    return `evt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `evt_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
   }
 }


### PR DESCRIPTION
# 🎯 Summary
Closes #2064

Replaces untrusted `@Body() payload: any` parameters across webhook endpoints with validated `WebhookPayloadDto` schemas enforcing structural checks via `class-validator` and `class-transformer`. Rejects malformed or unknown fields before hitting service business logic.

---

## 🛠️ Key Architectural Changes
* Introduced `WebhookPayloadDto` & `WebhookDataDto` with strict nested validation rules.
* Configured `ValidationPipe` with `whitelist: true` and `forbidNonWhitelisted: true` on webhook routes.

---

## 🧪 Testing & Verification
```bash
npm run test -- src/modules/webhooks/webhooks.controller.spec.ts