### PR TITLE
perf(frontend): virtualize lists, defer hydration, stream segments, server-fetch quests

### DIFF
--- a/FrontEnd/my-app/app/[locale]/admin/quests/loading.tsx
+++ b/FrontEnd/my-app/app/[locale]/admin/quests/loading.tsx
@@ -1,0 +1,20 @@
+export default function AdminQuestsLoading() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="h-9 w-52 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="h-9 w-32 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+
+      {/* Admin quest table skeleton */}
+      <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-14 animate-pulse border-b border-zinc-100 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/FrontEnd/my-app/app/[locale]/dashboard/loading.tsx
+++ b/FrontEnd/my-app/app/[locale]/dashboard/loading.tsx
@@ -1,0 +1,30 @@
+export default function DashboardLoading() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <div className="h-9 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="mt-2 h-4 w-64 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+
+      {/* Stat cards skeleton */}
+      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-28 animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+
+      {/* Two-column content skeleton */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-80 animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/FrontEnd/my-app/app/[locale]/submissions/loading.tsx
+++ b/FrontEnd/my-app/app/[locale]/submissions/loading.tsx
@@ -1,0 +1,30 @@
+export default function SubmissionsLoading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <div className="h-9 w-56 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="mt-2 h-4 w-80 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+
+      {/* Summary cards skeleton */}
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-24 animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+
+      {/* Submission rows skeleton */}
+      <div className="space-y-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-32 animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/FrontEnd/my-app/components/quest/QuestListServer.tsx
+++ b/FrontEnd/my-app/components/quest/QuestListServer.tsx
@@ -1,0 +1,55 @@
+import { getQuestsServer } from '@/lib/server/questsServer';
+import type { QuestQueryParams } from '@/lib/types/api.types';
+
+interface QuestListServerProps {
+  params?: QuestQueryParams;
+}
+
+/**
+ * Server Component that fetches quests on the server and renders them without
+ * shipping any fetching logic to the browser. Drop it inside a `<Suspense>`
+ * boundary (with a skeleton fallback) to stream the list into the page:
+ *
+ * ```tsx
+ * <Suspense fallback={<QuestsLoading />}>
+ *   <QuestListServer params={{ page: 1, limit: 12 }} />
+ * </Suspense>
+ * ```
+ */
+export async function QuestListServer({ params }: QuestListServerProps) {
+  const { quests } = await getQuestsServer(params);
+
+  if (quests.length === 0) {
+    return (
+      <p className="py-12 text-center text-sm text-zinc-500 dark:text-zinc-400">
+        No quests found.
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3"
+      aria-label={`${quests.length} quests`}
+    >
+      {quests.map((quest) => (
+        <li
+          key={quest.id}
+          className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+        >
+          <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+            {quest.title}
+          </h3>
+          <p className="mt-2 line-clamp-2 text-sm text-zinc-500 dark:text-zinc-400">
+            {quest.description}
+          </p>
+          <p className="mt-3 text-xs font-medium text-zinc-600 dark:text-zinc-300">
+            {quest.rewardAmount} {quest.rewardAsset}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default QuestListServer;

--- a/FrontEnd/my-app/components/submission/SubmissionsList.tsx
+++ b/FrontEnd/my-app/components/submission/SubmissionsList.tsx
@@ -4,6 +4,17 @@ import { memo } from 'react';
 import { SubmissionCard } from './SubmissionCard';
 import type { Submission } from '@/lib/types/submission';
 import { Skeleton } from '@/components/ui/Skeleton';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
+
+/**
+ * Lists longer than this switch to windowed rendering so only the rows in view
+ * are mounted. Shorter lists keep the plain flow layout unchanged.
+ */
+const VIRTUALIZE_THRESHOLD = 40;
+/** Approximate rendered height of a SubmissionCard row, including spacing. */
+const ROW_HEIGHT = 180;
+/** Height of the virtualized scroll viewport. */
+const VIEWPORT_HEIGHT = 800;
 
 interface SubmissionsListProps {
   submissions: Submission[];
@@ -87,6 +98,28 @@ export const SubmissionsList = memo(function SubmissionsList({
 
   if (submissions.length === 0) {
     return <EmptyState />;
+  }
+
+  if (submissions.length > VIRTUALIZE_THRESHOLD) {
+    return (
+      <div id="submissions-list">
+        <VirtualizedList
+          items={submissions}
+          itemHeight={ROW_HEIGHT}
+          height={VIEWPORT_HEIGHT}
+          ariaLabel={`${submissions.length} submissions`}
+          getKey={(submission) => submission.id}
+          renderItem={(submission) => (
+            <div className="pb-4">
+              <SubmissionCard
+                submission={submission}
+                onClick={onSubmissionClick}
+              />
+            </div>
+          )}
+        />
+      </div>
+    );
   }
 
   return (

--- a/FrontEnd/my-app/components/ui/DeferHydration.test.tsx
+++ b/FrontEnd/my-app/components/ui/DeferHydration.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { DeferHydration } from './DeferHydration';
+
+type IOEntry = { isIntersecting: boolean; target: Element };
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  private callback: (entries: IOEntry[]) => void;
+  private element: Element | null = null;
+
+  constructor(callback: (entries: IOEntry[]) => void) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(element: Element) {
+    this.element = element;
+  }
+
+  disconnect() {}
+
+  trigger(isIntersecting: boolean) {
+    if (this.element) {
+      this.callback([{ isIntersecting, target: this.element }]);
+    }
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  MockIntersectionObserver.instances = [];
+});
+
+describe('DeferHydration', () => {
+  it('shows the placeholder until the widget scrolls into view, then mounts it', () => {
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
+    render(
+      <DeferHydration placeholder={<div>loading widget</div>}>
+        <button>Interactive Widget</button>
+      </DeferHydration>
+    );
+
+    expect(screen.getByText('loading widget')).toBeInTheDocument();
+    expect(screen.queryByText('Interactive Widget')).not.toBeInTheDocument();
+
+    act(() => {
+      MockIntersectionObserver.instances[0].trigger(true);
+    });
+
+    expect(screen.getByText('Interactive Widget')).toBeInTheDocument();
+    expect(screen.queryByText('loading widget')).not.toBeInTheDocument();
+  });
+
+  it('falls back to rendering children when IntersectionObserver is unavailable', () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+
+    render(
+      <DeferHydration placeholder={<div>loading widget</div>}>
+        <button>Interactive Widget</button>
+      </DeferHydration>
+    );
+
+    expect(screen.getByText('Interactive Widget')).toBeInTheDocument();
+  });
+});

--- a/FrontEnd/my-app/components/ui/DeferHydration.tsx
+++ b/FrontEnd/my-app/components/ui/DeferHydration.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useEffect, useState, type ReactNode } from 'react';
+import { useIntersectionObserver } from '@/lib/hooks/useIntersectionObserver';
+
+interface DeferHydrationProps {
+  /** The interactive widget to mount once it is near the viewport. */
+  children: ReactNode;
+  /** Rendered before the widget mounts. Defaults to a shimmer block. */
+  placeholder?: ReactNode;
+  /** How early (before entering the viewport) to start mounting. */
+  rootMargin?: string;
+  /** Reserved height for the placeholder to limit layout shift. */
+  minHeight?: number | string;
+  className?: string;
+}
+
+/**
+ * Defers mounting (and therefore hydration) of a below-the-fold interactive
+ * widget until it scrolls near the viewport. The server and first client render
+ * both show the placeholder, avoiding a hydration mismatch; the real children
+ * mount on the client only once visible — reducing the up-front hydration and
+ * JavaScript execution cost of the initial page.
+ */
+export function DeferHydration({
+  children,
+  placeholder,
+  rootMargin = '200px',
+  minHeight = 120,
+  className,
+}: DeferHydrationProps) {
+  const [setRef, entry] = useIntersectionObserver({
+    rootMargin,
+    freezeOnceVisible: true,
+  });
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // When IntersectionObserver is unavailable (older browsers / no-JS crawlers
+  // that still execute effects), fall back to rendering the children so content
+  // is never permanently hidden.
+  const intersectionUnsupported =
+    typeof window !== 'undefined' &&
+    typeof window.IntersectionObserver === 'undefined';
+
+  const visible =
+    mounted && (intersectionUnsupported || Boolean(entry?.isIntersecting));
+
+  const fallback = placeholder ?? (
+    <div
+      className="animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-800"
+      style={{ minHeight }}
+      aria-hidden="true"
+    />
+  );
+
+  return (
+    <div ref={setRef} className={className}>
+      {visible ? children : fallback}
+    </div>
+  );
+}
+
+export default DeferHydration;

--- a/FrontEnd/my-app/components/ui/VirtualizedList.test.tsx
+++ b/FrontEnd/my-app/components/ui/VirtualizedList.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VirtualizedList } from './VirtualizedList';
+
+function renderList(itemCount: number) {
+  const items = Array.from({ length: itemCount }, (_, i) => `item-${i}`);
+  return render(
+    <VirtualizedList
+      items={items}
+      itemHeight={40}
+      height={200}
+      ariaLabel="test list"
+      renderItem={(item) => <span data-testid="row">{item}</span>}
+    />
+  );
+}
+
+describe('VirtualizedList', () => {
+  it('renders only the rows within the viewport window, not the full set', () => {
+    renderList(1000);
+    const rows = screen.getAllByTestId('row');
+    // viewport = ceil(200/40)=5 rows + overscan (4*2) => far fewer than 1000.
+    expect(rows.length).toBeLessThan(1000);
+    expect(rows.length).toBeLessThanOrEqual(20);
+    expect(screen.getByText('item-0')).toBeInTheDocument();
+  });
+
+  it('reserves the full scroll height for all items', () => {
+    renderList(100);
+    const container = screen.getByTestId('virtualized-list');
+    const spacer = container.firstElementChild as HTMLElement;
+    // 100 items * 40px = 4000px total scrollable height.
+    expect(spacer.style.height).toBe('4000px');
+  });
+
+  it('renders later items after scrolling', () => {
+    renderList(1000);
+    const container = screen.getByTestId('virtualized-list');
+    Object.defineProperty(container, 'scrollTop', {
+      value: 4000,
+      writable: true,
+    });
+    fireEvent.scroll(container);
+    // At scrollTop 4000 (row 100) item-0 is out of the window.
+    expect(screen.queryByText('item-0')).not.toBeInTheDocument();
+    expect(screen.getByText('item-100')).toBeInTheDocument();
+  });
+
+  it('handles an empty list without rendering rows', () => {
+    renderList(0);
+    expect(screen.queryAllByTestId('row')).toHaveLength(0);
+  });
+});

--- a/FrontEnd/my-app/components/ui/VirtualizedList.tsx
+++ b/FrontEnd/my-app/components/ui/VirtualizedList.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React, { useCallback, useState, type UIEvent } from 'react';
+
+export interface VirtualizedListProps<T> {
+  /** Full data set. Only the rows in (and near) the viewport are rendered. */
+  items: T[];
+  /** Fixed height, in pixels, of every row. */
+  itemHeight: number;
+  /** Height, in pixels, of the scrollable viewport. */
+  height: number;
+  /** Render a single item. */
+  renderItem: (item: T, index: number) => React.ReactNode;
+  /** Stable key for an item. Falls back to the index. */
+  getKey?: (item: T, index: number) => React.Key;
+  /** Extra rows to render above/below the viewport to smooth fast scrolling. */
+  overscan?: number;
+  className?: string;
+  role?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * A dependency-free windowing list. Long collections render only the rows in
+ * view (plus a small overscan) instead of mounting every row, which keeps
+ * paint time and scroll cost flat as the data set grows.
+ */
+export function VirtualizedList<T>({
+  items,
+  itemHeight,
+  height,
+  renderItem,
+  getKey,
+  overscan = 4,
+  className,
+  role = 'list',
+  ariaLabel,
+}: VirtualizedListProps<T>) {
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const total = items.length;
+  const totalHeight = total * itemHeight;
+  const viewportCount = Math.max(1, Math.ceil(height / itemHeight));
+  const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
+  const endIndex = Math.min(total, startIndex + viewportCount + overscan * 2);
+  const offsetY = startIndex * itemHeight;
+  const visible = items.slice(startIndex, endIndex);
+
+  const handleScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
+    setScrollTop(event.currentTarget.scrollTop);
+  }, []);
+
+  return (
+    <div
+      className={className}
+      style={{ height, overflowY: 'auto' }}
+      onScroll={handleScroll}
+      role={role}
+      aria-label={ariaLabel}
+      data-testid="virtualized-list"
+    >
+      <div style={{ height: totalHeight, position: 'relative' }}>
+        <div style={{ transform: `translateY(${offsetY}px)` }}>
+          {visible.map((item, offset) => {
+            const index = startIndex + offset;
+            return (
+              <div
+                key={getKey ? getKey(item, index) : index}
+                style={{ height: itemHeight }}
+                role="listitem"
+              >
+                {renderItem(item, index)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default VirtualizedList;

--- a/FrontEnd/my-app/docs/performance-optimizations.md
+++ b/FrontEnd/my-app/docs/performance-optimizations.md
@@ -1,0 +1,61 @@
+# Frontend performance optimizations
+
+This document describes four rendering/performance building blocks and where
+they apply.
+
+## 1. Virtualized long lists (#2035)
+
+`components/ui/VirtualizedList.tsx` is a dependency-free windowing list: it
+renders only the rows inside the scroll viewport (plus a small overscan)
+instead of mounting every row, so paint time and scroll cost stay flat as data
+grows.
+
+`components/submission/SubmissionsList.tsx` now switches to windowed rendering
+once a list exceeds `VIRTUALIZE_THRESHOLD` (40) rows. Shorter lists keep the
+original flow layout, so existing behaviour is unchanged.
+
+**Measuring:** render a submissions list of 500+ rows and compare mounted DOM
+nodes in the React Profiler / Elements panel — windowing keeps the mounted row
+count roughly constant (viewport + overscan) instead of scaling with the data.
+
+## 2. Deferred hydration of below-the-fold widgets (#2066)
+
+`components/ui/DeferHydration.tsx` mounts (and therefore hydrates) an
+interactive widget only once it scrolls near the viewport, using
+`IntersectionObserver`. The server and first client render both show a
+placeholder, so there is no hydration mismatch; if `IntersectionObserver` is
+unavailable it falls back to rendering the children.
+
+Wrap heavy below-the-fold interactive sections:
+
+```tsx
+<DeferHydration>
+  <HeavyInteractiveWidget />
+</DeferHydration>
+```
+
+**Measuring:** compare Total Blocking Time / hydration time in a Lighthouse or
+React Profiler trace with and without the wrapper on a page with several
+below-the-fold widgets.
+
+## 3. Suspense streaming + loading skeletons (#2037)
+
+Added `loading.tsx` skeletons for the `submissions`, `dashboard`, and
+`admin/quests` route segments (alongside the existing `quests` skeletons).
+Next.js renders these instantly as a Suspense fallback while the segment's data
+resolves, so the shell streams in immediately instead of blocking on data.
+
+**Measuring:** throttle the network and compare First Contentful Paint / the
+time until a non-blank screen appears for those routes.
+
+## 4. Server-side quest data fetching (#2036)
+
+`lib/server/questsServer.ts` fetches quests on the server (`getQuestsServer`,
+plus the pure, unit-tested `buildQuestsSearchParams`). `components/quest/
+QuestListServer.tsx` is a Server Component that awaits that data and renders it
+without shipping fetching logic to the browser; drop it inside a `<Suspense>`
+boundary to stream the list.
+
+**Measuring:** compare the client JS bundle (via `npm run analyze`) and the
+time-to-content for a server-rendered quests list versus the client-fetched
+path.

--- a/FrontEnd/my-app/lib/server/questsServer.test.ts
+++ b/FrontEnd/my-app/lib/server/questsServer.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildQuestsSearchParams } from './questsServer';
+
+describe('buildQuestsSearchParams', () => {
+  it('returns an empty string when no params are provided', () => {
+    expect(buildQuestsSearchParams()).toBe('');
+  });
+
+  it('serializes filter and pagination params', () => {
+    const query = buildQuestsSearchParams({
+      status: 'Active',
+      difficulty: 'beginner',
+      page: 2,
+      limit: 12,
+    });
+    const parsed = new URLSearchParams(query);
+    expect(parsed.get('status')).toBe('Active');
+    expect(parsed.get('difficulty')).toBe('beginner');
+    expect(parsed.get('page')).toBe('2');
+    expect(parsed.get('limit')).toBe('12');
+  });
+
+  it('omits undefined, null, and empty values', () => {
+    const query = buildQuestsSearchParams({
+      status: undefined,
+      category: '',
+      search: 'stellar',
+    });
+    const parsed = new URLSearchParams(query);
+    expect(parsed.has('status')).toBe(false);
+    expect(parsed.has('category')).toBe(false);
+    expect(parsed.get('search')).toBe('stellar');
+  });
+});

--- a/FrontEnd/my-app/lib/server/questsServer.ts
+++ b/FrontEnd/my-app/lib/server/questsServer.ts
@@ -1,0 +1,65 @@
+import type {
+  PaginatedQuestsResponse,
+  QuestQueryParams,
+} from '@/lib/types/api.types';
+
+/**
+ * Server-side quest data fetching for React Server Components.
+ *
+ * Moving quest listing/detail fetches to the server removes client-side
+ * fetch waterfalls and keeps fetching logic out of the browser bundle. Pair
+ * with a Suspense boundary (see `QuestListServer`) to stream content.
+ */
+
+const API_VERSION = 'v1';
+
+function apiBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:3000';
+}
+
+/**
+ * Build the query string for the quests endpoint from filter/pagination params.
+ * Pure and side-effect free so it can be unit tested without a network call.
+ */
+export function buildQuestsSearchParams(params: QuestQueryParams = {}): string {
+  const search = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    search.set(key, String(value));
+  }
+
+  return search.toString();
+}
+
+export interface GetQuestsServerOptions {
+  /** ISR revalidation window in seconds. */
+  revalidate?: number;
+}
+
+/**
+ * Fetch a page of quests on the server. Intended for use inside Server
+ * Components; the result can be streamed to the client via Suspense.
+ */
+export async function getQuestsServer(
+  params: QuestQueryParams = {},
+  options: GetQuestsServerOptions = {}
+): Promise<PaginatedQuestsResponse> {
+  const query = buildQuestsSearchParams(params);
+  const url = `${apiBaseUrl()}/api/${API_VERSION}/quests${
+    query ? `?${query}` : ''
+  }`;
+
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    next: { revalidate: options.revalidate ?? 60 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch quests: ${response.status}`);
+  }
+
+  return (await response.json()) as PaginatedQuestsResponse;
+}


### PR DESCRIPTION
Four frontend rendering/performance improvements on one branch. All changes are scoped to `FrontEnd/my-app` and verified locally against the full CI chain (lint, typecheck, `validate:path-aliases`, `format:check`, vitest, `next build`).

## Virtualize long lists (#2035)

Adds `components/ui/VirtualizedList.tsx` — a dependency-free windowing list that renders only the rows in the scroll viewport (plus a small overscan). `SubmissionsList` switches to it once a list exceeds 40 rows; shorter lists keep the original layout, so existing behaviour is unchanged. Unit tests cover the window size, total scroll height, scroll updates, and the empty case.

## Defer hydration of below-the-fold widgets (#2066)

Adds `components/ui/DeferHydration.tsx`, which mounts (and hydrates) an interactive widget only once it scrolls near the viewport via `IntersectionObserver`. Server and first client render both show a placeholder to avoid a hydration mismatch, with a fallback to render children when `IntersectionObserver` is unavailable. Unit tests cover both paths.

## Suspense streaming + loading skeletons (#2037)

Adds `loading.tsx` skeletons for the `submissions`, `dashboard`, and `admin/quests` route segments (matching the existing `quests` skeletons), so Next.js streams the shell immediately instead of blocking on data.

## Server-side quest data fetching (#2036)

Adds `lib/server/questsServer.ts` (`getQuestsServer` + the pure, unit-tested `buildQuestsSearchParams`) and `components/quest/QuestListServer.tsx`, a Server Component that fetches quests on the server and can be dropped inside a `<Suspense>` boundary — keeping fetch logic out of the browser bundle.

Documented in `FrontEnd/my-app/docs/performance-optimizations.md`, including how to measure each change.

closes #2035
closes #2036
closes #2037
closes #2066
