### PR TITLE
Lazy-load wallet kit, cancel superseded requests, clamp moderation pagination

### DIFF
--- a/BackEnd/src/modules/moderation/CHANGELOG.md
+++ b/BackEnd/src/modules/moderation/CHANGELOG.md
@@ -8,3 +8,6 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - `ExternalModerationApiService` now uses `PooledHttpClientService` (keep-alive connection pool, 8 s `medium` timeout budget) instead of a raw `axios` call. `HttpClientModule` added to `ModerationModule` imports.
+
+### Fixed
+- `listPending`/`listAppealsPending` now clamp `page`/`limit` server-side (limit capped at 100) as defense in depth, independent of the existing DTO-level `@Max(100)` validation at the controller boundary.

--- a/BackEnd/src/modules/moderation/moderation.service.spec.ts
+++ b/BackEnd/src/modules/moderation/moderation.service.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ModerationService } from './moderation.service';
+import { ModerationItem } from './entities/moderation-item.entity';
+import { ModerationAppeal } from './entities/moderation-appeal.entity';
+import { KeywordFilterService } from './filters/keyword-filter.service';
+import { ContentClassifierService } from './filters/content-classifier.service';
+import { ImageModerationService } from './filters/image-moderation.service';
+import { ExternalModerationApiService } from './filters/external-moderation-api.service';
+
+describe('ModerationService', () => {
+  let service: ModerationService;
+
+  const mockItemRepo = {
+    findAndCount: jest.fn(),
+  };
+  const mockAppealRepo = {
+    findAndCount: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockItemRepo.findAndCount.mockResolvedValue([[], 0]);
+    mockAppealRepo.findAndCount.mockResolvedValue([[], 0]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ModerationService,
+        { provide: getRepositoryToken(ModerationItem), useValue: mockItemRepo },
+        {
+          provide: getRepositoryToken(ModerationAppeal),
+          useValue: mockAppealRepo,
+        },
+        { provide: KeywordFilterService, useValue: { scan: jest.fn() } },
+        {
+          provide: ContentClassifierService,
+          useValue: { classify: jest.fn() },
+        },
+        { provide: ImageModerationService, useValue: {} },
+        {
+          provide: ExternalModerationApiService,
+          useValue: { scoreText: jest.fn() },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<ModerationService>(ModerationService);
+  });
+
+  describe('listPending', () => {
+    it('clamps an oversized limit to the maximum allowed page size', async () => {
+      await service.listPending(1, 10_000);
+
+      expect(mockItemRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100, skip: 0 }),
+      );
+    });
+
+    it('passes through a limit within the allowed range unchanged', async () => {
+      await service.listPending(2, 50);
+
+      expect(mockItemRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 50, skip: 50 }),
+      );
+    });
+
+    it('falls back to page 1 for a non-positive page value', async () => {
+      const result = await service.listPending(-5, 20);
+
+      expect(result.page).toBe(1);
+      expect(mockItemRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0 }),
+      );
+    });
+
+    it('falls back to the default limit for a non-positive limit value', async () => {
+      const result = await service.listPending(1, 0);
+
+      expect(result.limit).toBe(20);
+    });
+  });
+
+  describe('listAppealsPending', () => {
+    it('clamps an oversized limit to the maximum allowed page size', async () => {
+      await service.listAppealsPending(1, 5000);
+
+      expect(mockAppealRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100, skip: 0 }),
+      );
+    });
+
+    it('reflects the clamped values in the returned metadata', async () => {
+      const result = await service.listAppealsPending(1, 500);
+
+      expect(result.limit).toBe(100);
+    });
+  });
+});

--- a/BackEnd/src/modules/moderation/moderation.service.ts
+++ b/BackEnd/src/modules/moderation/moderation.service.ts
@@ -32,6 +32,13 @@ export interface ScanResult {
   shouldManualReview: boolean;
 }
 
+// Defense-in-depth cap on page size, independent of DTO validation at the
+// controller boundary. Keeps listPending/listAppealsPending safe even if
+// called with unvalidated input (e.g. directly, or from a future caller
+// that bypasses the controller's ValidationPipe).
+const MAX_PAGE_LIMIT = 100;
+const DEFAULT_PAGE_LIMIT = 20;
+
 @Injectable()
 export class ModerationService {
   private readonly logger = new Logger(ModerationService.name);
@@ -182,7 +189,24 @@ export class ModerationService {
     return this.itemRepo.save(item);
   }
 
+  /**
+   * Clamps page/limit to sane bounds so callers can't request unbounded
+   * page sizes, regardless of whether DTO validation ran upstream.
+   */
+  private clampPagination(
+    page: number,
+    limit: number,
+  ): { page: number; limit: number } {
+    const safePage = Number.isFinite(page) && page >= 1 ? Math.floor(page) : 1;
+    const safeLimit =
+      Number.isFinite(limit) && limit >= 1
+        ? Math.min(Math.floor(limit), MAX_PAGE_LIMIT)
+        : DEFAULT_PAGE_LIMIT;
+    return { page: safePage, limit: safeLimit };
+  }
+
   async listPending(page = 1, limit = 20) {
+    ({ page, limit } = this.clampPagination(page, limit));
     const [items, total] = await this.itemRepo.findAndCount({
       where: { status: ModerationItemStatus.MANUAL_REVIEW },
       order: { priority: 'DESC', createdAt: 'ASC' },
@@ -255,6 +279,7 @@ export class ModerationService {
   }
 
   async listAppealsPending(page = 1, limit = 20) {
+    ({ page, limit } = this.clampPagination(page, limit));
     const [appeals, total] = await this.appealRepo.findAndCount({
       where: { status: AppealStatus.PENDING },
       order: { createdAt: 'ASC' },

--- a/FrontEnd/my-app/context/WalletContext.test.tsx
+++ b/FrontEnd/my-app/context/WalletContext.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import { WalletProvider } from './WalletContext';
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
@@ -16,11 +16,13 @@ const {
   mockStoreActions,
   mockStoreState,
   mockUseStore,
+  mockStellarWalletsKitCtor,
 } = vi.hoisted(() => {
   const mockGetAddress = vi.fn();
   const mockSetWallet = vi.fn();
   const mockDisconnectKit = vi.fn();
   const mockLogout = vi.fn().mockResolvedValue({ message: 'ok' });
+  const mockStellarWalletsKitCtor = vi.fn();
 
   const mockStoreState: Record<string, any> = {};
 
@@ -59,6 +61,7 @@ const {
     mockStoreActions,
     mockStoreState,
     mockUseStore,
+    mockStellarWalletsKitCtor,
   };
 });
 
@@ -77,7 +80,7 @@ vi.mock('../lib/api/auth', () => ({
 }));
 
 vi.mock('@creit.tech/stellar-wallets-kit', () => ({
-  StellarWalletsKit: vi.fn().mockImplementation(() => ({
+  StellarWalletsKit: mockStellarWalletsKitCtor.mockImplementation(() => ({
     setWallet: mockSetWallet,
     getAddress: mockGetAddress,
     disconnect: mockDisconnectKit,
@@ -252,5 +255,87 @@ describe('WalletProvider — reconnection verification', () => {
 
     // isVerifyingWallet must be cleared even though logout threw
     expect(mockStoreActions.setIsVerifyingWallet).toHaveBeenCalledWith(false);
+  });
+});
+
+// ── Lazy loading + caching of the wallet kit ────────────────────────────────
+// Each test here re-imports the module fresh (vi.resetModules) so the
+// module-level kit cache always starts empty, letting these tests assert
+// exact construction counts instead of relative deltas.
+
+describe('WalletProvider — lazy kit loading and caching', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    Object.assign(mockStoreState, {
+      address: null,
+      isConnected: false,
+      isConnecting: false,
+      isVerifyingWallet: false,
+      selectedWalletId: null,
+      isModalOpen: false,
+      walletError: null,
+    });
+    Object.assign(mockStoreState, mockStoreActions);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not construct the wallet kit on mount when there is no persisted session', async () => {
+    const { WalletProvider: FreshProvider } = await import('./WalletContext');
+
+    render(
+      <FreshProvider>
+        <div data-testid="child" />
+      </FreshProvider>
+    );
+
+    await waitFor(() => {
+      expect(mockGetAddress).not.toHaveBeenCalled();
+    });
+    expect(mockStellarWalletsKitCtor).not.toHaveBeenCalled();
+  });
+
+  it('constructs the wallet kit exactly once, on the first connect() call', async () => {
+    const { WalletProvider: FreshProvider, useWallet: freshUseWallet } =
+      await import('./WalletContext');
+
+    function Harness() {
+      const { connect } = freshUseWallet();
+      return (
+        <button data-testid="connect-btn" onClick={() => connect('freighter')}>
+          connect
+        </button>
+      );
+    }
+
+    mockGetAddress.mockResolvedValue({ address: 'GNEWADDRESS' });
+
+    const { getByTestId } = render(
+      <FreshProvider>
+        <Harness />
+      </FreshProvider>
+    );
+
+    // Kit is not built until connect() is actually called.
+    expect(mockStellarWalletsKitCtor).not.toHaveBeenCalled();
+
+    fireEvent.click(getByTestId('connect-btn'));
+
+    await waitFor(() => {
+      expect(mockSetWallet).toHaveBeenCalledTimes(1);
+    });
+    expect(mockStellarWalletsKitCtor).toHaveBeenCalledTimes(1);
+
+    // A second connect reuses the same cached kit instance — no re-import,
+    // no re-construction.
+    fireEvent.click(getByTestId('connect-btn'));
+
+    await waitFor(() => {
+      expect(mockSetWallet).toHaveBeenCalledTimes(2);
+    });
+    expect(mockStellarWalletsKitCtor).toHaveBeenCalledTimes(1);
   });
 });

--- a/FrontEnd/my-app/context/WalletContext.tsx
+++ b/FrontEnd/my-app/context/WalletContext.tsx
@@ -27,6 +27,34 @@ interface WalletContextType {
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
+// ── Lazy, cached wallet kit loader ──────────────────────────────────────────
+// The @creit.tech/stellar-wallets-kit SDK is heavy, so it must not load until
+// it's actually needed (session verification or an explicit connect). A
+// module-level singleton promise ensures the dynamic import + kit
+// instantiation only ever happens once per page session — every caller
+// (verification effect, connect()) awaits and reuses the same instance
+// instead of re-importing/re-constructing it.
+let kitPromise: Promise<any> | null = null;
+
+function loadWalletKit(): Promise<any> {
+  if (!kitPromise) {
+    kitPromise = import('@creit.tech/stellar-wallets-kit')
+      .then((walletKitModule) => {
+        return new walletKitModule.StellarWalletsKit({
+          network: walletKitModule.WalletNetwork.TESTNET,
+          selectedWalletId: walletKitModule.FREIGHTER_ID,
+          modules: walletKitModule.allowAllModules(),
+        });
+      })
+      .catch((err) => {
+        // Don't cache a failed load — let the next caller retry.
+        kitPromise = null;
+        throw err;
+      });
+  }
+  return kitPromise;
+}
+
 export const useWallet = () => {
   const context = useContext(WalletContext);
   if (!context)
@@ -57,101 +85,103 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 
   const hydrated = useHydrated();
 
+  // Guards against duplicate verification runs if this effect fires more
+  // than once for the same mount (e.g. React 18 StrictMode's dev-only
+  // double-invoke of effects) — without it, the address/network query
+  // below could fire twice for a single page load.
+  const verificationStartedRef = React.useRef(false);
+
   useEffect(() => {
-    const initKit = async () => {
+    // Wait until Zustand's persist middleware has rehydrated from
+    // localStorage so we know whether there is a session to verify.
+    // Without this gate the effect races against async rehydration
+    // and could skip verification on a cold load (address would still
+    // be the default null).
+    if (!hydrated) return;
+
+    const persistedAddress = useStore.getState().address;
+    const persistedWalletId = useStore.getState().selectedWalletId;
+
+    if (!persistedAddress || !persistedWalletId) {
+      // No previously-connected session — nothing to verify, and no
+      // reason to pay the cost of loading the wallet kit SDK until the
+      // user actually initiates a connection.
+      return;
+    }
+
+    if (verificationStartedRef.current) return;
+    verificationStartedRef.current = true;
+
+    const verify = async () => {
+      // Mark verifying so UI renders neither connected nor disconnected
+      // until we know whether the session is still valid.
+      setIsVerifyingWallet(true);
+
       try {
-        const walletKitModule = await import('@creit.tech/stellar-wallets-kit');
-        const kitInstance = new walletKitModule.StellarWalletsKit({
-          network: walletKitModule.WalletNetwork.TESTNET,
-          selectedWalletId: walletKitModule.FREIGHTER_ID,
-          modules: walletKitModule.allowAllModules(),
-        });
+        // Loading the kit itself is part of "can we verify this session" —
+        // a failed/slow load fails closed the same way an extension query
+        // failure does, below.
+        const kitInstance = await loadWalletKit();
         setKit(kitInstance);
+        kitInstance.setWallet(persistedWalletId);
 
-        // ── Wallet reconnection verification ────────────────────────────
-        // Wait until Zustand's persist middleware has rehydrated from
-        // localStorage so we know whether there is a session to verify.
-        // Without this gate the effect races against async rehydration
-        // and could skip verification on a cold load (address would still
-        // be the default null).
-        if (!hydrated) return;
+        // Query the wallet extension for the current address *without*
+        // triggering a popup (skipRequestAccess).  If the extension was
+        // uninstalled, frozen, or the user revoked permissions, this
+        // will throw or return a different address.
+        const verifyPromise = kitInstance.getAddress({
+          skipRequestAccess: true,
+        });
+        const timeoutPromise = new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('Wallet verification timed out')),
+            5000
+          )
+        );
 
-        const persistedAddress = useStore.getState().address;
-        const persistedWalletId = useStore.getState().selectedWalletId;
+        const { address: liveAddress } = await Promise.race([
+          verifyPromise,
+          timeoutPromise,
+        ]);
 
-        if (!persistedAddress || !persistedWalletId) {
-          // No previously-connected session — nothing to verify.
-          return;
-        }
-
-        // Mark verifying so UI renders neither connected nor disconnected
-        // until we know whether the session is still valid.
-        setIsVerifyingWallet(true);
-
-        try {
-          kitInstance.setWallet(persistedWalletId);
-
-          // Query the wallet extension for the current address *without*
-          // triggering a popup (skipRequestAccess).  If the extension was
-          // uninstalled, frozen, or the user revoked permissions, this
-          // will throw or return a different address.
-          const verifyPromise = kitInstance.getAddress({
-            skipRequestAccess: true,
-          });
-          const timeoutPromise = new Promise<never>((_, reject) =>
-            setTimeout(
-              () => reject(new Error('Wallet verification timed out')),
-              5000
-            )
+        if (liveAddress !== persistedAddress) {
+          // Identity-boundary violation: the wallet extension now controls
+          // a *different* account than the one the backend session was
+          // issued for.  Full logout is the only safe response — the
+          // backend does not re-verify wallet ownership on API calls, so
+          // leaving the session alive would let the UI show account B
+          // while the backend authenticates every write as account A.
+          console.warn(
+            'Wallet verification: address mismatch —',
+            `persisted ${persistedAddress}, got ${liveAddress}.`,
+            'Clearing session.'
           );
-
-          const { address: liveAddress } = await Promise.race([
-            verifyPromise,
-            timeoutPromise,
-          ]);
-
-          if (liveAddress !== persistedAddress) {
-            // Identity-boundary violation: the wallet extension now controls
-            // a *different* account than the one the backend session was
-            // issued for.  Full logout is the only safe response — the
-            // backend does not re-verify wallet ownership on API calls, so
-            // leaving the session alive would let the UI show account B
-            // while the backend authenticates every write as account A.
-            console.warn(
-              'Wallet verification: address mismatch —',
-              `persisted ${persistedAddress}, got ${liveAddress}.`,
-              'Clearing session.'
-            );
-            await authApi.logout();
-            disconnectWallet();
-          }
-          // Address matches — session is still valid, no action needed.
-        } catch (err) {
-          // Fail-closed: if we cannot reach the wallet extension at all
-          // (uninstalled, frozen, permissions revoked) OR if verification
-          // times out, we clear both the wallet state and the backend
-          // session.  This is conservative — "can't verify" and "verified
-          // as wrong" are distinguishable in code but not obviously
-          // distinguishable in security posture.  The backend never
-          // re-verifies wallet ownership after login, so there is no
-          // independent safety net if we leave the session alive.
-          console.error('Wallet verification failed:', err);
-          try {
-            await authApi.logout();
-          } catch {
-            // Logout call itself failed — best-effort, still clear
-            // the local wallet state below so the UI is not stuck.
-          }
+          await authApi.logout();
           disconnectWallet();
-        } finally {
-          setIsVerifyingWallet(false);
         }
+        // Address matches — session is still valid, no action needed.
       } catch (err) {
-        console.error('Failed to initialize wallet kit:', err);
-        setWalletError('Failed to load wallet kit');
+        // Fail-closed: if the kit fails to load, we cannot reach the wallet
+        // extension at all (uninstalled, frozen, permissions revoked), OR
+        // verification times out, we clear both the wallet state and the
+        // backend session.  This is conservative — "can't verify" and
+        // "verified as wrong" are distinguishable in code but not obviously
+        // distinguishable in security posture.  The backend never
+        // re-verifies wallet ownership after login, so there is no
+        // independent safety net if we leave the session alive.
+        console.error('Wallet verification failed:', err);
+        try {
+          await authApi.logout();
+        } catch {
+          // Logout call itself failed — best-effort, still clear
+          // the local wallet state below so the UI is not stuck.
+        }
+        disconnectWallet();
+      } finally {
+        setIsVerifyingWallet(false);
       }
     };
-    initKit();
+    verify();
   }, [hydrated]);
 
   const supportedWallets = [
@@ -163,17 +193,18 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
   ];
 
   const connect = async (moduleId: string) => {
-    if (!kit) {
-      setWalletError('Wallet kit not loaded yet');
-      return;
-    }
-
     setIsConnecting(true);
     setWalletError(null);
 
     try {
-      kit.setWallet(moduleId);
-      const { address: walletAddress } = await kit.getAddress();
+      // Loads the kit on first use if the mount-time verification effect
+      // never ran (no persisted session) — otherwise reuses the same
+      // cached instance it already loaded.
+      const kitInstance = kit ?? (await loadWalletKit());
+      if (!kit) setKit(kitInstance);
+
+      kitInstance.setWallet(moduleId);
+      const { address: walletAddress } = await kitInstance.getAddress();
       setWalletAddress(walletAddress);
       setSelectedWalletId(moduleId);
       setWalletModalOpen(false);

--- a/FrontEnd/my-app/lib/hooks/useQuests.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuests.test.ts
@@ -1,0 +1,132 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useQuests } from './useQuests';
+import type { QuestQueryParams } from '@/lib/types/api.types';
+
+const { mockGetQuests, mockStoreActions, mockUseStore } = vi.hoisted(() => {
+  const mockGetQuests = vi.fn();
+
+  const mockStoreState: Record<string, unknown> = {
+    quests: [],
+    questsLoading: false,
+    questsError: null,
+    pagination: null,
+  };
+
+  const mockStoreActions = {
+    setQuests: vi.fn(),
+    setQuestsLoading: vi.fn(),
+    setQuestsError: vi.fn(),
+    setQuestPagination: vi.fn(),
+  };
+
+  const mockUseStore = (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ ...mockStoreState, ...mockStoreActions });
+
+  return { mockGetQuests, mockStoreActions, mockUseStore };
+});
+
+vi.mock('@/lib/store', () => ({
+  useStore: mockUseStore,
+}));
+
+vi.mock('@/lib/api/quests', () => ({
+  getQuests: (...args: any[]) => mockGetQuests(...args),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const emptyResponse = {
+  quests: [],
+  page: 1,
+  limit: 12,
+  total: 0,
+  totalPages: 0,
+};
+
+describe('useQuests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes a cancel token to getQuests and aborts it on unmount', async () => {
+    const pending = deferred<typeof emptyResponse>();
+    mockGetQuests.mockReturnValue(pending.promise);
+
+    const { unmount } = renderHook(() => useQuests());
+
+    await waitFor(() => {
+      expect(mockGetQuests).toHaveBeenCalledTimes(1);
+    });
+
+    const cancelToken = mockGetQuests.mock.calls[0][1];
+    expect(cancelToken).toBeDefined();
+    expect(cancelToken.signal.aborted).toBe(false);
+
+    unmount();
+
+    expect(cancelToken.signal.aborted).toBe(true);
+  });
+
+  it('cancels the previous in-flight request when filters change', async () => {
+    const first = deferred<typeof emptyResponse>();
+    mockGetQuests.mockReturnValueOnce(first.promise);
+
+    const { rerender } = renderHook(
+      ({ filters }: { filters: QuestQueryParams }) => useQuests(filters),
+      { initialProps: { filters: { status: 'Active' } as QuestQueryParams } }
+    );
+
+    await waitFor(() => {
+      expect(mockGetQuests).toHaveBeenCalledTimes(1);
+    });
+    const firstToken = mockGetQuests.mock.calls[0][1];
+    expect(firstToken.signal.aborted).toBe(false);
+
+    mockGetQuests.mockResolvedValueOnce(emptyResponse);
+    rerender({ filters: { status: 'Completed' } as QuestQueryParams });
+
+    await waitFor(() => {
+      expect(mockGetQuests).toHaveBeenCalledTimes(2);
+    });
+
+    expect(firstToken.signal.aborted).toBe(true);
+  });
+
+  it('does not report an error when the request was cancelled, not failed', async () => {
+    const pending = deferred<typeof emptyResponse>();
+    mockGetQuests.mockReturnValue(pending.promise);
+
+    const { unmount } = renderHook(() => useQuests());
+
+    await waitFor(() => {
+      expect(mockGetQuests).toHaveBeenCalledTimes(1);
+    });
+    const cancelToken = mockGetQuests.mock.calls[0][1];
+
+    unmount();
+    // Simulate the in-flight request rejecting after cancellation, as a
+    // real aborted axios request would.
+    const abortError = new Error('canceled');
+    abortError.name = 'CanceledError';
+    pending.reject(abortError);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(cancelToken.signal.aborted).toBe(true);
+    // setQuestsError(null) is called up front to clear stale error state —
+    // what must never happen is being called with an actual error message
+    // for a request we deliberately cancelled.
+    for (const call of mockStoreActions.setQuestsError.mock.calls) {
+      expect(call[0]).toBeNull();
+    }
+  });
+});

--- a/FrontEnd/my-app/lib/hooks/useQuests.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuests.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useStore } from '@/lib/store';
 import { getQuests } from '@/lib/api/quests';
+import { createCancelToken } from '@/lib/api/client';
 import type { QuestQueryParams, PaginationParams } from '@/lib/types/api.types';
 
 export function useQuests(
@@ -39,15 +40,29 @@ export function useQuests(
     [pagination?.page, pagination?.limit, pagination?.cursor]
   );
 
+  // Tracks the in-flight request's cancel token so a superseding fetch (new
+  // filters, a manual refetch, or the component unmounting) can abort it
+  // instead of letting it race a newer request or update state after unmount.
+  const cancelTokenRef = useRef<ReturnType<typeof createCancelToken> | null>(
+    null
+  );
+
   const fetchQuests = useCallback(async () => {
+    cancelTokenRef.current?.cancel();
+    const cancelToken = createCancelToken();
+    cancelTokenRef.current = cancelToken;
+
     try {
       setQuestsLoading(true);
       setQuestsError(null);
 
-      const response = await getQuests({
-        ...memoizedFilters,
-        ...memoizedPagination,
-      });
+      const response = await getQuests(
+        {
+          ...memoizedFilters,
+          ...memoizedPagination,
+        },
+        cancelToken
+      );
       setQuests(response.quests as any);
       setPagination({
         page: response.page ?? 1,
@@ -57,12 +72,21 @@ export function useQuests(
         hasMore: (response.page ?? 0) < (response.totalPages ?? 0),
       });
     } catch (err) {
+      // A cancelled request isn't a real error — either a newer fetch
+      // superseded it, or the component unmounted. Don't surface stale
+      // error state for it.
+      if (cancelToken.signal.aborted) return;
+
       setQuestsError(
         err instanceof Error ? err.message : 'Failed to fetch quests'
       );
       setQuests([]);
     } finally {
-      setQuestsLoading(false);
+      // Only the request that "won" should clear the loading flag — if
+      // this one was cancelled, whatever superseded it owns that state.
+      if (!cancelToken.signal.aborted) {
+        setQuestsLoading(false);
+      }
     }
   }, [
     memoizedFilters,
@@ -76,6 +100,9 @@ export function useQuests(
 
   useEffect(() => {
     fetchQuests();
+    return () => {
+      cancelTokenRef.current?.cancel();
+    };
   }, [fetchQuests]);
 
   return {

--- a/FrontEnd/my-app/lib/hooks/useSearch.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useSearch.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSearch } from './useSearch';
+
+const { mockSearchGlobal, mockGetRecentSearches, mockSaveRecentSearch } =
+  vi.hoisted(() => ({
+    mockSearchGlobal: vi.fn(),
+    mockGetRecentSearches: vi.fn().mockResolvedValue([]),
+    mockSaveRecentSearch: vi.fn(),
+  }));
+
+vi.mock('@/lib/api/search', () => ({
+  searchGlobal: (...args: any[]) => mockSearchGlobal(...args),
+  getRecentSearches: (...args: any[]) => mockGetRecentSearches(...args),
+  saveRecentSearch: (...args: any[]) => mockSaveRecentSearch(...args),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const emptyResults = { results: [], suggestions: [], total: 0 };
+
+describe('useSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRecentSearches.mockResolvedValue([]);
+  });
+
+  it('passes a cancel token through to searchGlobal', async () => {
+    mockSearchGlobal.mockResolvedValue(emptyResults);
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      result.current.search('stellar');
+      // debounce delay defaults to 300ms
+      await new Promise((r) => setTimeout(r, 350));
+    });
+
+    await waitFor(() => {
+      expect(mockSearchGlobal).toHaveBeenCalledTimes(1);
+    });
+    const [, , cancelToken] = mockSearchGlobal.mock.calls[0];
+    expect(cancelToken).toBeDefined();
+    expect(cancelToken.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('cancels the in-flight search when the component unmounts', async () => {
+    const pending = deferred<typeof emptyResults>();
+    mockSearchGlobal.mockReturnValue(pending.promise);
+
+    const { result, unmount } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.search('stellar');
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 350));
+    });
+
+    await waitFor(() => {
+      expect(mockSearchGlobal).toHaveBeenCalledTimes(1);
+    });
+    const [, , cancelToken] = mockSearchGlobal.mock.calls[0];
+    expect(cancelToken.signal.aborted).toBe(false);
+
+    unmount();
+
+    expect(cancelToken.signal.aborted).toBe(true);
+  });
+
+  it('aborts a previous search when a newer one starts', async () => {
+    const first = deferred<typeof emptyResults>();
+    mockSearchGlobal.mockReturnValueOnce(first.promise);
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      result.current.search('stel');
+      await new Promise((r) => setTimeout(r, 350));
+    });
+
+    await waitFor(() => {
+      expect(mockSearchGlobal).toHaveBeenCalledTimes(1);
+    });
+    const firstToken = mockSearchGlobal.mock.calls[0][2];
+    expect(firstToken.signal.aborted).toBe(false);
+
+    mockSearchGlobal.mockResolvedValueOnce(emptyResults);
+
+    await act(async () => {
+      result.current.search('stellar');
+      await new Promise((r) => setTimeout(r, 350));
+    });
+
+    await waitFor(() => {
+      expect(mockSearchGlobal).toHaveBeenCalledTimes(2);
+    });
+    expect(firstToken.signal.aborted).toBe(true);
+  });
+});

--- a/FrontEnd/my-app/lib/hooks/useSearch.ts
+++ b/FrontEnd/my-app/lib/hooks/useSearch.ts
@@ -6,6 +6,7 @@ import {
   type SearchResult,
   type SearchFilters,
 } from '@/lib/api/search';
+import { createCancelToken, type CancelToken } from '@/lib/api/client';
 import { debounce } from '@/lib/utils/debounce';
 
 interface UseSearchReturn {
@@ -31,28 +32,29 @@ export function useSearch(
   const [error, setError] = useState<Error | null>(null);
   const [total, setTotal] = useState(0);
 
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const cancelTokenRef = useRef<CancelToken | null>(null);
 
   const performSearch = useCallback(
     async (searchQuery: string) => {
       if (!searchQuery.trim()) {
+        cancelTokenRef.current?.cancel();
         setResults([]);
         setSuggestions([]);
         setTotal(0);
         return;
       }
 
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-
-      abortControllerRef.current = new AbortController();
+      // Cancel any still-in-flight search before starting a new one, so a
+      // slow earlier response can't overwrite results from a later query.
+      cancelTokenRef.current?.cancel();
+      const cancelToken = createCancelToken();
+      cancelTokenRef.current = cancelToken;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const response = await searchGlobal(searchQuery, filters);
+        const response = await searchGlobal(searchQuery, filters, cancelToken);
         setResults(response.results);
         setSuggestions(response.suggestions);
         setTotal(response.total);
@@ -60,14 +62,20 @@ export function useSearch(
         const recent = await getRecentSearches();
         setRecentSearches(recent);
       } catch (err) {
-        if (err instanceof Error && err.name !== 'AbortError') {
+        // A cancelled request (superseded by a newer search, or the
+        // component unmounted) isn't a real error.
+        if (cancelToken.signal.aborted) return;
+
+        if (err instanceof Error) {
           setError(err);
           setResults([]);
           setSuggestions([]);
           setTotal(0);
         }
       } finally {
-        setIsLoading(false);
+        if (!cancelToken.signal.aborted) {
+          setIsLoading(false);
+        }
       }
     },
     [filters]
@@ -103,6 +111,14 @@ export function useSearch(
     };
     loadInitial();
   }, [initialQuery, performSearch]);
+
+  // Cancel any in-flight search when the component unmounts, so a slow
+  // response can't resolve into state after there's nothing left to show it.
+  useEffect(() => {
+    return () => {
+      cancelTokenRef.current?.cancel();
+    };
+  }, []);
 
   return {
     results,

--- a/FrontEnd/my-app/lib/hooks/useSubmissions.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useSubmissions.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSubmissions } from './useSubmissions';
+
+const { mockFetchSubmissions, mockStoreActions, mockUseStore } = vi.hoisted(
+  () => {
+    const mockFetchSubmissions = vi.fn();
+
+    const mockStoreState: Record<string, unknown> = {
+      submissions: [],
+      submissionsLoading: false,
+      submissionsError: null,
+      submissionPagination: { page: 1, limit: 20, hasMore: false },
+    };
+
+    const mockStoreActions = {
+      setSubmissions: vi.fn(),
+      setSubmissionsLoading: vi.fn(),
+      setSubmissionsError: vi.fn(),
+      setSubmissionPagination: vi.fn(),
+      setSubmissionFilters: vi.fn(),
+      optimisticallyUpdateSubmission: vi.fn(),
+    };
+
+    const mockUseStore = (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({ ...mockStoreState, ...mockStoreActions });
+
+    return { mockFetchSubmissions, mockStoreActions, mockUseStore };
+  }
+);
+
+vi.mock('@/lib/store', () => ({
+  useStore: mockUseStore,
+}));
+
+vi.mock('@/lib/api/submissions', () => ({
+  fetchSubmissions: (...args: any[]) => mockFetchSubmissions(...args),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+type SubmissionsResponse = {
+  data: never[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasMore: boolean;
+  };
+};
+
+describe('useSubmissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes a cancel token to fetchSubmissions and aborts it on unmount', async () => {
+    const pending = deferred<SubmissionsResponse>();
+    mockFetchSubmissions.mockReturnValue(pending.promise);
+
+    const { unmount } = renderHook(() => useSubmissions());
+
+    await waitFor(() => {
+      expect(mockFetchSubmissions).toHaveBeenCalledTimes(1);
+    });
+
+    const cancelToken = mockFetchSubmissions.mock.calls[0][2];
+    expect(cancelToken).toBeDefined();
+    expect(cancelToken.signal.aborted).toBe(false);
+
+    unmount();
+
+    expect(cancelToken.signal.aborted).toBe(true);
+  });
+
+  it('does not report an error for a cancelled request', async () => {
+    const pending = deferred<SubmissionsResponse>();
+    mockFetchSubmissions.mockReturnValue(pending.promise);
+
+    const { unmount } = renderHook(() => useSubmissions());
+
+    await waitFor(() => {
+      expect(mockFetchSubmissions).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    const abortError = new Error('canceled');
+    abortError.name = 'CanceledError';
+    // Simulate the in-flight request rejecting after cancellation, as a
+    // real aborted axios request would.
+    pending.reject(abortError);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    for (const call of mockStoreActions.setSubmissionsError.mock.calls) {
+      expect(call[0]).toBeNull();
+    }
+  });
+});

--- a/FrontEnd/my-app/lib/hooks/useSubmissions.ts
+++ b/FrontEnd/my-app/lib/hooks/useSubmissions.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useStore } from '@/lib/store';
 import { fetchSubmissions } from '@/lib/api/submissions';
+import { createCancelToken } from '@/lib/api/client';
 import type {
   SubmissionFilters,
   PaginationParams,
@@ -34,16 +35,31 @@ export function useSubmissions(
     ]
   );
 
+  // Tracks the in-flight request's cancel token so a superseding fetch (new
+  // filters/page, a manual refetch, or unmount) can abort it instead of
+  // letting it race a newer request or update state after unmount.
+  const cancelTokenRef = useRef<ReturnType<typeof createCancelToken> | null>(
+    null
+  );
+
   const load = useCallback(async () => {
+    cancelTokenRef.current?.cancel();
+    const cancelToken = createCancelToken();
+    cancelTokenRef.current = cancelToken;
+
     setLoading(true);
     setError(null);
 
     try {
-      const response = await fetchSubmissions(memoizedFilters as any, {
-        page: pagination.page,
-        limit: pagination.limit,
-        ...memoizedInitialPagination,
-      });
+      const response = await fetchSubmissions(
+        memoizedFilters as any,
+        {
+          page: pagination.page,
+          limit: pagination.limit,
+          ...memoizedInitialPagination,
+        },
+        cancelToken
+      );
 
       setSubmissions(response.data as any);
       setPagination({
@@ -52,12 +68,18 @@ export function useSubmissions(
         hasMore: response.pagination.hasMore ?? false,
       });
     } catch (err) {
+      // A cancelled request isn't a real error — either a newer fetch
+      // superseded it, or the component unmounted.
+      if (cancelToken.signal.aborted) return;
+
       setError(
         err instanceof Error ? err.message : 'Failed to load submissions'
       );
       setSubmissions([]);
     } finally {
-      setLoading(false);
+      if (!cancelToken.signal.aborted) {
+        setLoading(false);
+      }
     }
   }, [
     memoizedFilters,
@@ -77,6 +99,9 @@ export function useSubmissions(
 
   useEffect(() => {
     load();
+    return () => {
+      cancelTokenRef.current?.cancel();
+    };
   }, [load]);
 
   const goToPage = useCallback(


### PR DESCRIPTION
## Summary

- **Wallet kit lazy-loading + caching** (`FrontEnd/my-app/context/WalletContext.tsx`): the `@creit.tech/stellar-wallets-kit` SDK previously loaded unconditionally on every `WalletProvider` mount, even for first-time visitors with no wallet session to verify. It now only loads when there's a persisted session to verify, or when the user calls `connect()`. A module-level cache (`loadWalletKit()`) ensures the dynamic import + kit construction happens at most once and is reused by every subsequent caller instead of re-importing/re-instantiating. A ref guard also stops the mount-time verification query from firing twice under React 18 StrictMode's dev-only double-invoke of effects.

- **AbortController-based request cancellation** (`useQuests`, `useSearch`, `useSubmissions`): the API client already supported per-request cancellation via `createCancelToken()`/`signal`, but none of these hooks used it — `useQuests` and `useSubmissions` never created a cancel token at all, and `useSearch` created an `AbortController` but never actually passed its `signal` to the fetch, so calling `.abort()` on it did nothing. All three hooks now cancel their previous in-flight request when superseded (new filters, new query, page change) and on unmount, and no longer surface stale error state for a request that was cancelled rather than actually failed.

- **Pagination clamp** (`BackEnd/src/modules/moderation/moderation.service.ts`): `listPending`/`listAppealsPending` now clamp `page`/`limit` server-side (limit capped at 100) as defense in depth, independent of the existing DTO-level `@Max(100)` validation at the controller boundary.

## Testing

- Backend: `npm run build`, `npm run lint`, `npx prettier --check`, and the new `moderation.service.spec.ts` suite all pass.
- Frontend: `npm run typecheck`, `npm run lint`, `npm run validate:path-aliases`, `npm run format:check`, the full `npm run test` suite (682 tests), and `npm run build` all pass. New/updated tests cover the wallet-kit lazy-load + single-construction behavior and the cancellation behavior of all three hooks.

Closes #2061
Closes #2060
Closes #2054
Closes #1906