### PR TITLE
perf(startup): defer heavy @sentry/node load until Sentry is configured

### DIFF
--- a/BackEnd/docs/STARTUP_LAZY_LOADING.md
+++ b/BackEnd/docs/STARTUP_LAZY_LOADING.md
@@ -1,0 +1,88 @@
+# Startup lazy-loading for heavy optional modules
+
+Tracks issue #2028. Goal: cut cold-start time and memory by not loading heavy,
+optional code at boot when it is not configured.
+
+## Investigation: NestJS feature modules
+
+The original `AppModule` eagerly imports ~25 feature modules. Most of them are
+NOT safe to convert to `LazyModuleLoader` because Nest wires HTTP routes and
+providers at boot:
+
+- Modules that register controllers must be present at boot, otherwise their
+  routes are never mounted. This rules out Admin, Analytics, Auth, Email,
+  FeatureFlags, Health, Jobs, Moderation, Notifications, Payouts, Postmortems,
+  QueryMonitoring, Quests, Submissions, Trace, Users, Webhooks and
+  ProcessResource (all have `@Controller`s).
+- The three modules with no controller (Quota, Stellar, Websocket) are still not
+  leaf candidates: Quota and Stellar export services that are injected into
+  eagerly loaded modules (Payouts/Quests and Jobs/Submissions), and Websocket
+  registers a gateway that must bind at boot to accept socket connections.
+
+So there is no feature module that can be moved behind `LazyModuleLoader` without
+breaking routing, DI, or the WebSocket gateway. Converting one anyway would be a
+functional regression, which the issue forbids.
+
+## Change made: defer the heavy optional Sentry SDK
+
+The measurable win is at the boot integration layer. `@sentry/node` (v9) pulls in
+`@sentry/core`, `@sentry/opentelemetry` and a large set of `@opentelemetry/*`
+packages. It was imported at the top level of two files that `main.ts` loads
+during boot:
+
+- `src/config/sentry.config.ts`
+- `src/common/filters/sentry-exception.filter.ts`
+
+Because of those top-level imports the whole SDK graph was `require()`d on every
+boot even when Sentry was disabled (`SENTRY_DSN` unset), which is the default in
+dev, in tests, and in many deployments.
+
+The SDK is now loaded lazily, only when Sentry is actually configured:
+
+- `initSentry()` (called once at boot) returns early when `SENTRY_DSN` is unset
+  and only then `require()`s `@sentry/node` and calls `Sentry.init(...)`.
+- A new `getSentry()` accessor returns the initialized client, or `null` when
+  Sentry is disabled.
+- `SentryExceptionFilter` uses `getSentry()` instead of a static import. When
+  Sentry is disabled it skips capture entirely (previously it called
+  `captureException` as a silent no-op against an SDK that was loaded for
+  nothing).
+
+Behavior is unchanged from the outside: with `SENTRY_DSN` set, the SDK loads and
+5xx / unexpected errors are captured exactly as before; with it unset, nothing is
+reported either way.
+
+## Benchmark
+
+Reproducible script: `scripts/bench-sentry-lazy-load.js`. It measures the
+`require('@sentry/node')` cost in isolated child processes, which is exactly the
+boot work removed in the common disabled case (the lazy path does zero work).
+
+```
+node scripts/bench-sentry-lazy-load.js
+```
+
+Results on this machine (7 runs, Node 22):
+
+| Metric                     | BEFORE (eager at boot) | AFTER (disabled, lazy) | Removed from boot |
+| -------------------------- | ---------------------- | ---------------------- | ----------------- |
+| require time (median)      | ~1.4 - 2.2 s           | ~0.0 ms                | ~1.4 - 2.2 s      |
+| require time (min)         | ~0.8 - 1.3 s           | ~0.0 ms                | ~0.8 - 1.3 s      |
+| heapUsed delta             | ~27 MB                 | ~0 MB                  | ~27 MB            |
+| rss delta                  | ~69 MB                 | ~0 MB                  | ~69 MB            |
+
+Load time varies with disk / OS file cache; the memory figures are stable across
+runs. When Sentry is disabled the boot no longer allocates ~27 MB of heap /
+~69 MB RSS and no longer pays the SDK require cost. When Sentry is enabled the
+same cost is paid once, lazily, at `initSentry()` instead of unconditionally.
+
+## Tests
+
+- `src/config/__tests__/sentry.config.spec.ts` - Sentry is not loaded when
+  `SENTRY_DSN` is unset (`getSentry()` is null and `Sentry.init` is never
+  called), and is lazily loaded + initialized with the DSN when it is set.
+- `src/common/filters/__tests__/sentry-exception.filter.spec.ts` - the filter
+  re-throws without touching Sentry when disabled, captures 5xx / unexpected
+  errors when enabled, and does not capture expected 4xx errors.
+
+Run: `npx jest src/config/__tests__/sentry.config.spec.ts src/common/filters/__tests__/sentry-exception.filter.spec.ts`

--- a/BackEnd/scripts/bench-sentry-lazy-load.js
+++ b/BackEnd/scripts/bench-sentry-lazy-load.js
@@ -1,0 +1,122 @@
+/*
+ * Benchmark: cost of eagerly loading @sentry/node at startup.
+ *
+ * Before this change both src/config/sentry.config.ts and
+ * src/common/filters/sentry-exception.filter.ts imported '@sentry/node' at the
+ * top level, so the whole SDK module graph was require()d during boot even when
+ * Sentry was disabled (SENTRY_DSN unset). After the change the SDK is loaded
+ * lazily inside initSentry() only when SENTRY_DSN is set.
+ *
+ * This script measures the require() cost of @sentry/node in isolated child
+ * processes. That cost is exactly what boot no longer pays in the common
+ * disabled case (the "after" path does zero work).
+ *
+ * Usage: node scripts/bench-sentry-lazy-load.js [runs]
+ */
+'use strict';
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const RUNS = Number(process.argv[2]) || 7;
+const cwd = path.resolve(__dirname, '..');
+
+// Child that require()s @sentry/node and reports load time + memory delta.
+const EAGER_CHILD = `
+  const start = process.hrtime.bigint();
+  const m0 = process.memoryUsage();
+  require('@sentry/node');
+  const end = process.hrtime.bigint();
+  const m1 = process.memoryUsage();
+  process.stdout.write(JSON.stringify({
+    loadMs: Number(end - start) / 1e6,
+    heapMB: (m1.heapUsed - m0.heapUsed) / 1048576,
+    rssMB: (m1.rss - m0.rss) / 1048576,
+  }));
+`;
+
+// Child that does NOT require @sentry/node (the disabled/after boot path).
+const LAZY_CHILD = `
+  const start = process.hrtime.bigint();
+  const m0 = process.memoryUsage();
+  const end = process.hrtime.bigint();
+  const m1 = process.memoryUsage();
+  process.stdout.write(JSON.stringify({
+    loadMs: Number(end - start) / 1e6,
+    heapMB: (m1.heapUsed - m0.heapUsed) / 1048576,
+    rssMB: (m1.rss - m0.rss) / 1048576,
+  }));
+`;
+
+function sample(code) {
+  const out = execFileSync(process.execPath, ['-e', code], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+
+function stats(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const median = sorted[Math.floor(sorted.length / 2)];
+  return { mean, median, min: sorted[0], max: sorted[sorted.length - 1] };
+}
+
+function bench(label, code) {
+  const loadMs = [];
+  const heapMB = [];
+  const rssMB = [];
+  for (let i = 0; i < RUNS; i++) {
+    const r = sample(code);
+    loadMs.push(r.loadMs);
+    heapMB.push(r.heapMB);
+    rssMB.push(r.rssMB);
+  }
+  return {
+    label,
+    loadMs: stats(loadMs),
+    heapMB: stats(heapMB),
+    rssMB: stats(rssMB),
+  };
+}
+
+function fmt(n) {
+  return n.toFixed(2).padStart(8);
+}
+
+function print(res) {
+  console.log(`\n${res.label}`);
+  console.log(
+    `  require time (ms):  mean ${fmt(res.loadMs.mean)}  median ${fmt(
+      res.loadMs.median,
+    )}  min ${fmt(res.loadMs.min)}  max ${fmt(res.loadMs.max)}`,
+  );
+  console.log(
+    `  heapUsed  (MB):     mean ${fmt(res.heapMB.mean)}  median ${fmt(
+      res.heapMB.median,
+    )}`,
+  );
+  console.log(
+    `  rss       (MB):     mean ${fmt(res.rssMB.mean)}  median ${fmt(
+      res.rssMB.median,
+    )}`,
+  );
+}
+
+console.log(`Benchmarking @sentry/node eager load over ${RUNS} runs...`);
+
+const eager = bench('BEFORE (eager): require("@sentry/node") at boot', EAGER_CHILD);
+const lazy = bench('AFTER (lazy, Sentry disabled): no require at boot', LAZY_CHILD);
+
+print(eager);
+print(lazy);
+
+const savedMs = eager.loadMs.mean - lazy.loadMs.mean;
+const savedHeap = eager.heapMB.mean - lazy.heapMB.mean;
+const savedRss = eager.rssMB.mean - lazy.rssMB.mean;
+
+console.log('\nStartup work removed when Sentry is disabled (SENTRY_DSN unset):');
+console.log(`  time saved:     ${savedMs.toFixed(2)} ms`);
+console.log(`  heapUsed saved: ${savedHeap.toFixed(2)} MB`);
+console.log(`  rss saved:      ${savedRss.toFixed(2)} MB`);

--- a/BackEnd/src/common/filters/__tests__/sentry-exception.filter.spec.ts
+++ b/BackEnd/src/common/filters/__tests__/sentry-exception.filter.spec.ts
@@ -1,0 +1,70 @@
+import {
+  ArgumentsHost,
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { SentryExceptionFilter } from '../sentry-exception.filter';
+import { getSentry } from '../../../config/sentry.config';
+
+jest.mock('../../../config/sentry.config', () => ({
+  getSentry: jest.fn(),
+}));
+
+const mockedGetSentry = getSentry as jest.Mock;
+
+describe('SentryExceptionFilter - lazy Sentry', () => {
+  let filter: SentryExceptionFilter;
+  let mockArgumentsHost: ArgumentsHost;
+  let sentryStub: { addBreadcrumb: jest.Mock; captureException: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    filter = new SentryExceptionFilter();
+
+    const mockRequest: Partial<Request> = {
+      method: 'GET',
+      originalUrl: '/api/test',
+    };
+
+    mockArgumentsHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue(mockRequest),
+      }),
+    } as any;
+
+    sentryStub = {
+      addBreadcrumb: jest.fn(),
+      captureException: jest.fn(),
+    };
+  });
+
+  it('re-throws and does not touch Sentry when it is disabled', () => {
+    mockedGetSentry.mockReturnValue(null);
+    const error = new Error('boom');
+
+    expect(() => filter.catch(error, mockArgumentsHost)).toThrow(error);
+  });
+
+  it('captures unexpected (5xx) errors when Sentry is enabled', () => {
+    mockedGetSentry.mockReturnValue(sentryStub);
+    const error = new InternalServerErrorException('db down');
+
+    expect(() => filter.catch(error, mockArgumentsHost)).toThrow(error);
+    expect(sentryStub.addBreadcrumb).toHaveBeenCalledTimes(1);
+    expect(sentryStub.captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        extra: expect.objectContaining({ statusCode: 500 }),
+      }),
+    );
+  });
+
+  it('does not capture expected 4xx errors even when Sentry is enabled', () => {
+    mockedGetSentry.mockReturnValue(sentryStub);
+    const error = new BadRequestException('bad input');
+
+    expect(() => filter.catch(error, mockArgumentsHost)).toThrow(error);
+    expect(sentryStub.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/BackEnd/src/common/filters/sentry-exception.filter.ts
+++ b/BackEnd/src/common/filters/sentry-exception.filter.ts
@@ -7,7 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Request } from 'express';
-import * as Sentry from '@sentry/node';
+import { getSentry } from '../../config/sentry.config';
 
 @Catch()
 export class SentryExceptionFilter implements ExceptionFilter {
@@ -22,8 +22,11 @@ export class SentryExceptionFilter implements ExceptionFilter {
         ? exception.getStatus()
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
-    // Only capture 5xx errors and unexpected exceptions in Sentry
-    if (status >= 500 || !(exception instanceof HttpException)) {
+    // Only capture 5xx errors and unexpected exceptions in Sentry. getSentry()
+    // returns null when Sentry is disabled (SENTRY_DSN unset), in which case the
+    // SDK was never loaded and there is nothing to report to.
+    const Sentry = getSentry();
+    if (Sentry && (status >= 500 || !(exception instanceof HttpException))) {
       Sentry.addBreadcrumb({
         category: 'http',
         message: `${request.method} ${request.originalUrl}`,

--- a/BackEnd/src/config/__tests__/sentry.config.spec.ts
+++ b/BackEnd/src/config/__tests__/sentry.config.spec.ts
@@ -1,0 +1,43 @@
+import { initSentry, getSentry } from '../sentry.config';
+import * as Sentry from '@sentry/node';
+
+jest.mock('@sentry/node', () => ({
+  init: jest.fn(),
+  captureException: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  httpIntegration: jest.fn(() => ({ name: 'Http' })),
+}));
+
+describe('Sentry config - lazy loading', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('does not load Sentry when SENTRY_DSN is unset', () => {
+    delete process.env.SENTRY_DSN;
+
+    initSentry();
+
+    expect(getSentry()).toBeNull();
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it('lazy-loads and initializes Sentry when SENTRY_DSN is set', () => {
+    process.env.SENTRY_DSN = 'https://examplePublicKey@o0.ingest.sentry.io/0';
+
+    initSentry();
+
+    const sentry = getSentry();
+    expect(sentry).not.toBeNull();
+    expect(typeof sentry.captureException).toBe('function');
+    expect(Sentry.init).toHaveBeenCalledTimes(1);
+    expect(Sentry.init.mock.calls[0][0].dsn).toBe(process.env.SENTRY_DSN);
+  });
+});

--- a/BackEnd/src/config/sentry.config.ts
+++ b/BackEnd/src/config/sentry.config.ts
@@ -1,4 +1,6 @@
-import * as Sentry from '@sentry/node';
+type SentryModule = typeof import('@sentry/node');
+
+let sentry: SentryModule | null = null;
 
 export function initSentry(): void {
   const dsn = process.env.SENTRY_DSN;
@@ -6,6 +8,13 @@ export function initSentry(): void {
   if (!dsn) {
     return;
   }
+
+  // Lazy-load the heavy @sentry/node module graph only when Sentry is actually
+  // configured. When SENTRY_DSN is unset (dev, test and many deployments) this
+  // avoids requiring the SDK at boot, cutting cold-start time and memory.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Sentry = require('@sentry/node') as SentryModule;
+  sentry = Sentry;
 
   Sentry.init({
     dsn,
@@ -26,4 +35,10 @@ export function initSentry(): void {
   });
 }
 
-export { Sentry };
+/**
+ * Returns the initialized Sentry client, or null when Sentry is disabled
+ * (SENTRY_DSN unset) and therefore was never loaded.
+ */
+export function getSentry(): SentryModule | null {
+  return sentry;
+}


### PR DESCRIPTION
## What
Cuts cold-start cost by deferring the heaviest optional dependency loaded at boot: the `@sentry/node` SDK.

I audited all ~25 modules in `BackEnd/src/app.module.ts` for lazy-loading via `LazyModuleLoader`. Every module that registers HTTP controllers must be present at boot (lazy-loading them un-mounts routes), and the three controller-less modules (Quota, Stellar, Websocket) still export services injected into eager modules or bind a gateway at boot. So no feature module is safely lazy-loadable without a functional regression.

The real, safe win is the heavy optional SDK: `@sentry/node` (v9, which pulls in `@sentry/opentelemetry` and a large `@opentelemetry/*` graph) was imported at the top of two files `main.ts` loads at boot, so the whole SDK was `require()`d on every startup even when `SENTRY_DSN` is unset (the default in dev, tests, and many deploys).

**Change:** `@sentry/node` now loads lazily inside `initSentry()` only when `SENTRY_DSN` is set. A `getSentry()` accessor returns the client (or `null` when disabled), and `SentryExceptionFilter` uses it instead of a static import. No routes or DI touched; behavior is identical when Sentry is configured.

## Benchmark (before/after)
`node BackEnd/scripts/bench-sentry-lazy-load.js` measures the boot cost removed when Sentry is disabled:
- require time: ~1.4-2.2s median removed
- heapUsed: ~27 MB removed (stable)
- rss: ~69 MB removed (stable)

When Sentry is enabled, the same cost is paid once, lazily, instead of unconditionally at boot.

## Testing
- `npm run build` (nest build): passes.
- 5 new regression tests (2 suites) pass: Sentry disabled -> `getSentry()` null and no load; enabled -> loads and captures; the exception filter guards capture when disabled.
- Full `jest` suite: 950 pass / 118 fail. Baselined by stashing this change and re-running the same 27 suites on clean main - all fail identically there (pre-existing, environment-dependent: Redis/DB/network unavailable). None are Sentry-related, none import the changed files; this change adds zero new failures.

Docs: `BackEnd/docs/STARTUP_LAZY_LOADING.md` (investigation + numbers).

Closes #2028
