### PR TITLE
feat(#1984): Add dead-letter queue inspection and replay endpoints

### DIFF
--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -15,6 +15,9 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 - `DEFAULT_JOB_OPTIONS` is now derived from `DEFAULT_RETRY_POLICY` (5 attempts, exponential backoff starting at 5 s) to keep defaults consistent.
 - `job-scheduler.service.ts`: `startSchedule()` and `triggerScheduleNow()` embed `__jobType` and apply the per-type policy when enqueuing.
 - Stellar SDK transaction execution in `PayoutProcessor` (`payout.processor.ts`): replaces the `// TODO` simulation with a real `StellarService.sendPayment()` call. The processor now builds, signs, and submits a live Stellar payment; `transactionHash` in the job result reflects the on-chain hash.
+- `DeadLetterQueueService` for DLQ inspection, metrics, replay, and purge operations.
+- REST endpoints under `/jobs/dlq/*` for dead-letter queue management.
+- `__sourceQueue` tag on forwarded DLQ jobs for origin tracking.
 
 ### Changed
 

--- a/BackEnd/src/modules/jobs/jobs.controller.ts
+++ b/BackEnd/src/modules/jobs/jobs.controller.ts
@@ -1,19 +1,31 @@
 import {
   Controller,
   Get,
+  Post,
   Param,
+  Query,
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { JobsService } from './jobs.service';
+import { DeadLetterQueueService } from './services/dead-letter-queue.service';
 
 @ApiTags('Jobs')
 @Controller('jobs')
 export class JobsController {
   private readonly logger = new Logger(JobsController.name);
 
-  constructor(private readonly jobsService: JobsService) {}
+  constructor(
+    private readonly jobsService: JobsService,
+    private readonly dlqService: DeadLetterQueueService,
+  ) {}
 
   @Get('health')
   @ApiOperation({ summary: 'Job system health check' })
@@ -57,5 +69,54 @@ export class JobsController {
     const metrics = await this.jobsService.getQueueMetricsByName(queue);
     if (!metrics) throw new NotFoundException(`Queue "${queue}" not found`);
     return metrics;
+  }
+
+  @Get('dlq')
+  @ApiOperation({ summary: 'List jobs in the dead-letter queue' })
+  @ApiQuery({ name: 'start', required: false, type: Number })
+  @ApiQuery({ name: 'end', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'DLQ jobs listed' })
+  async listDlqJobs(
+    @Query('start') start?: number,
+    @Query('end') end?: number,
+  ) {
+    return this.dlqService.listDeadJobs(start ?? 0, end ?? 50);
+  }
+
+  @Get('dlq/metrics')
+  @ApiOperation({ summary: 'Get dead-letter queue metrics' })
+  @ApiResponse({ status: 200, description: 'DLQ metrics' })
+  async getDlqMetrics() {
+    return this.dlqService.getMetrics();
+  }
+
+  @Post('dlq/replay/:jobId')
+  @ApiOperation({ summary: 'Replay a single DLQ job to its original queue' })
+  @ApiParam({ name: 'jobId', description: 'DLQ job ID' })
+  @ApiResponse({ status: 200, description: 'Job replayed' })
+  @ApiResponse({ status: 404, description: 'Job not found' })
+  async replayDlqJob(@Param('jobId') jobId: string) {
+    const result = await this.dlqService.replayJob(jobId);
+    if (!result.success && result.message.includes('not found')) {
+      throw new NotFoundException(result.message);
+    }
+    return result;
+  }
+
+  @Post('dlq/replay-all')
+  @ApiOperation({
+    summary: 'Replay all DLQ jobs (optionally filtered by source queue)',
+  })
+  @ApiQuery({ name: 'sourceQueue', required: false, type: String })
+  @ApiResponse({ status: 200, description: 'Bulk replay result' })
+  async replayAllDlqJobs(@Query('sourceQueue') sourceQueue?: string) {
+    return this.dlqService.replayAll(sourceQueue);
+  }
+
+  @Post('dlq/purge')
+  @ApiOperation({ summary: 'Purge all jobs from the dead-letter queue' })
+  @ApiResponse({ status: 200, description: 'DLQ purged' })
+  async purgeDlq() {
+    return this.dlqService.purge();
   }
 }

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -7,6 +7,7 @@ import { JobsController } from './jobs.controller';
 import { JobLogService } from './services/job-log.service';
 import { JobSchedulerService } from './services/job-scheduler.service';
 import { JobIdempotencyService } from './services/job-idempotency.service';
+import { DeadLetterQueueService } from './services/dead-letter-queue.service';
 import { PayoutProcessor } from './processors/payout.processor';
 import { PayoutReconciliationProcessor } from './processors/payout-reconciliation.processor';
 import { EmailProcessor } from './processors/email.processor';
@@ -69,6 +70,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     // circular dependency on PayoutsModule.
     IdempotencyService,
     JobIdempotencyService,
+    DeadLetterQueueService,
     PayoutProcessor,
     PayoutReconciliationProcessor,
     EmailProcessor,
@@ -88,6 +90,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     JobLogService,
     JobSchedulerService,
     JobIdempotencyService,
+    DeadLetterQueueService,
     PayoutProcessor,
     PayoutReconciliationProcessor,
     EmailProcessor,

--- a/BackEnd/src/modules/jobs/jobs.service.ts
+++ b/BackEnd/src/modules/jobs/jobs.service.ts
@@ -358,7 +358,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
             failedJob: {
               id: job.id,
               name: job.name,
-              data: job.data,
+              data: { ...job.data, __sourceQueue: name },
               failedReason: err?.message ?? String(err),
               reason,
             },

--- a/BackEnd/src/modules/jobs/services/dead-letter-queue.service.spec.ts
+++ b/BackEnd/src/modules/jobs/services/dead-letter-queue.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeadLetterQueueService } from './dead-letter-queue.service';
+import { Queue } from 'bullmq';
+
+jest.mock('bullmq', () => {
+  return {
+    Queue: jest.fn().mockImplementation(() => ({
+      getJobs: jest.fn().mockResolvedValue([]),
+      getWaitingCount: jest.fn().mockResolvedValue(0),
+      getFailedCount: jest.fn().mockResolvedValue(0),
+      getCompletedCount: jest.fn().mockResolvedValue(0),
+      close: jest.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+describe('DeadLetterQueueService', () => {
+  let service: DeadLetterQueueService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DeadLetterQueueService],
+    }).compile();
+
+    service = module.get<DeadLetterQueueService>(DeadLetterQueueService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getMetrics', () => {
+    it('should return zero metrics when DLQ queue is unavailable', async () => {
+      // Force getDlqQueue to return null by making Queue throw
+      (Queue as unknown as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Connection refused');
+      });
+
+      const metrics = await service.getMetrics();
+
+      expect(metrics.total).toBe(0);
+      expect(metrics.bySourceQueue).toEqual({});
+      expect(metrics.oldestJobAge).toBeNull();
+    });
+  });
+
+  describe('listDeadJobs', () => {
+    it('should return empty list when DLQ queue is unavailable', async () => {
+      (Queue as unknown as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Connection refused');
+      });
+
+      const result = await service.listDeadJobs();
+
+      expect(result.jobs).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('replayJob', () => {
+    it('should fail gracefully when DLQ queue is unavailable', async () => {
+      (Queue as unknown as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Connection refused');
+      });
+
+      const result = await service.replayJob('nonexistent-id');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('unavailable');
+    });
+  });
+
+  describe('replayAll', () => {
+    it('should return zero counts when DLQ queue is unavailable', async () => {
+      (Queue as unknown as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Connection refused');
+      });
+
+      const result = await service.replayAll();
+
+      expect(result.replayed).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(result.skipped).toBe(0);
+    });
+  });
+
+  describe('purge', () => {
+    it('should return zero purged when DLQ queue is unavailable', async () => {
+      (Queue as unknown as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Connection refused');
+      });
+
+      const result = await service.purge();
+
+      expect(result.purged).toBe(0);
+    });
+  });
+});

--- a/BackEnd/src/modules/jobs/services/dead-letter-queue.service.ts
+++ b/BackEnd/src/modules/jobs/services/dead-letter-queue.service.ts
@@ -1,0 +1,274 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Queue, Job } from 'bullmq';
+import { QUEUES } from '../jobs.constants';
+
+export interface DeadLetterJob {
+  id: string | undefined;
+  name: string | undefined;
+  data: any;
+  failedReason: string;
+  reason: string;
+  timestamp: number;
+  sourceQueue: string;
+}
+
+export interface DeadLetterMetrics {
+  total: number;
+  bySourceQueue: Record<string, number>;
+  oldestJobAge: number | null;
+}
+
+/**
+ * Dead-Letter Queue Service
+ *
+ * Provides inspection, metrics, and replay capabilities for jobs that
+ * exhausted retries or hit non-retryable errors.  Integrates with the
+ * existing bounded retry infrastructure in `jobs.service.ts`.
+ */
+@Injectable()
+export class DeadLetterQueueService {
+  private readonly logger = new Logger(DeadLetterQueueService.name);
+  private dlqQueue: Queue | null = null;
+
+  private readonly maxReplayAttempts = parseInt(
+    process.env.DLQ_MAX_REPLAY_ATTEMPTS || '3',
+    10,
+  );
+
+  constructor() {}
+
+  /** Lazily resolve the DLQ queue from BullMQ. */
+  private getDlqQueue(): Queue | null {
+    if (this.dlqQueue) return this.dlqQueue;
+    try {
+      const url = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+      this.dlqQueue = new Queue(QUEUES.DEAD_LETTER, {
+        connection: { url },
+      });
+      return this.dlqQueue;
+    } catch (err) {
+      this.logger.error(
+        'Failed to connect to DLQ queue',
+        (err as Error).message,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * List all jobs currently in the dead-letter queue.
+   *
+   * @param start - offset for pagination (default 0)
+   * @param end   - exclusive end index (default 50)
+   */
+  async listDeadJobs(
+    start = 0,
+    end = 50,
+  ): Promise<{ jobs: DeadLetterJob[]; total: number }> {
+    const queue = this.getDlqQueue();
+    if (!queue) return { jobs: [], total: 0 };
+
+    const [waitingJobs, count] = await Promise.all([
+      queue.getJobs(['waiting', 'active', 'completed', 'failed'], start, end),
+      queue.getWaitingCount(),
+    ]);
+
+    const jobs: DeadLetterJob[] = waitingJobs.map((job) =>
+      this.mapToDeadLetterJob(job),
+    );
+
+    return { jobs, total: count };
+  }
+
+  /**
+   * Get metrics about the dead-letter queue.
+   */
+  async getMetrics(): Promise<DeadLetterMetrics> {
+    const queue = this.getDlqQueue();
+    if (!queue) return { total: 0, bySourceQueue: {}, oldestJobAge: null };
+
+    const [waitingCount, failedCount] = await Promise.all([
+      queue.getWaitingCount(),
+      queue.getFailedCount(),
+    ]);
+
+    const total = waitingCount + failedCount;
+
+    // Sample recent jobs to determine source queue distribution
+    const sampleJobs = await queue.getJobs(['waiting', 'failed'], 0, 99);
+    const bySourceQueue: Record<string, number> = {};
+    let oldestTimestamp = Infinity;
+
+    for (const job of sampleJobs) {
+      const sourceQueue = job.data?.failedJob?.data?.__sourceQueue ?? 'unknown';
+      bySourceQueue[sourceQueue] = (bySourceQueue[sourceQueue] || 0) + 1;
+
+      if (job.timestamp && job.timestamp < oldestTimestamp) {
+        oldestTimestamp = job.timestamp;
+      }
+    }
+
+    return {
+      total,
+      bySourceQueue,
+      oldestJobAge:
+        oldestTimestamp < Infinity ? Date.now() - oldestTimestamp : null,
+    };
+  }
+
+  /**
+   * Replay a single DLQ job back to its original source queue.
+   *
+   * The job is re-enqueued with a fresh retry budget.  A replay counter
+   * is attached to prevent infinite replay loops.
+   */
+  async replayJob(dlqJobId: string): Promise<{
+    success: boolean;
+    message: string;
+    targetQueue?: string;
+  }> {
+    const queue = this.getDlqQueue();
+    if (!queue) {
+      return { success: false, message: 'DLQ queue unavailable' };
+    }
+
+    const job = await queue.getJob(dlqJobId);
+    if (!job) {
+      return { success: false, message: `DLQ job ${dlqJobId} not found` };
+    }
+
+    const failedJob = job.data?.failedJob;
+    if (!failedJob?.data) {
+      return {
+        success: false,
+        message: 'DLQ job is missing original job data',
+      };
+    }
+
+    // Check replay loop protection
+    const replayCount: number =
+      (failedJob.data.__dlqReplayCount as number) ?? 0;
+    if (replayCount >= this.maxReplayAttempts) {
+      return {
+        success: false,
+        message: `Replay limit (${this.maxReplayAttempts}) reached for this job`,
+      };
+    }
+
+    const originalData = { ...failedJob.data };
+    delete originalData.__trace;
+    const sourceQueue: string =
+      originalData.__sourceQueue ?? QUEUES.NOTIFICATIONS;
+    delete originalData.__sourceQueue;
+
+    // Increment replay counter
+    originalData.__dlqReplayCount = replayCount + 1;
+    originalData.__dlqReplayedAt = new Date().toISOString();
+
+    try {
+      const replayQueue = new Queue(sourceQueue, {
+        connection: {
+          url: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+        },
+      });
+
+      await replayQueue.add(`${sourceQueue}-replay-job`, originalData, {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5_000 },
+      });
+
+      // Remove from DLQ
+      await job.remove();
+      await replayQueue.close();
+
+      this.logger.log(
+        `Replayed DLQ job ${dlqJobId} (source: ${sourceQueue}, attempt ${replayCount + 1}/${this.maxReplayAttempts})`,
+      );
+
+      return {
+        success: true,
+        message: `Job replayed to ${sourceQueue}`,
+        targetQueue: sourceQueue,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to replay DLQ job ${dlqJobId}: ${(err as Error).message}`,
+      );
+      return {
+        success: false,
+        message: `Replay failed: ${(err as Error).message}`,
+      };
+    }
+  }
+
+  /**
+   * Replay all DLQ jobs matching an optional source queue filter.
+   */
+  async replayAll(
+    sourceQueueFilter?: string,
+  ): Promise<{ replayed: number; failed: number; skipped: number }> {
+    const queue = this.getDlqQueue();
+    if (!queue) return { replayed: 0, failed: 0, skipped: 0 };
+
+    const jobs = await queue.getJobs(['waiting', 'failed'], 0, 1000);
+    let replayed = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const job of jobs) {
+      const sourceQueue = job.data?.failedJob?.data?.__sourceQueue ?? 'unknown';
+
+      if (sourceQueueFilter && sourceQueue !== sourceQueueFilter) {
+        skipped++;
+        continue;
+      }
+
+      const result = await this.replayJob(job.id!);
+      if (result.success) {
+        replayed++;
+      } else {
+        failed++;
+      }
+    }
+
+    this.logger.log(
+      `Bulk replay complete: ${replayed} replayed, ${failed} failed, ${skipped} skipped`,
+    );
+
+    return { replayed, failed, skipped };
+  }
+
+  /**
+   * Purge (delete) all jobs from the DLQ.
+   */
+  async purge(): Promise<{ purged: number }> {
+    const queue = this.getDlqQueue();
+    if (!queue) return { purged: 0 };
+
+    const jobs = await queue.getJobs(
+      ['waiting', 'active', 'completed', 'failed'],
+      0,
+      10000,
+    );
+
+    for (const job of jobs) {
+      await job.remove();
+    }
+
+    this.logger.log(`Purged ${jobs.length} jobs from DLQ`);
+    return { purged: jobs.length };
+  }
+
+  private mapToDeadLetterJob(job: Job): DeadLetterJob {
+    const failedJob = job.data?.failedJob ?? {};
+    return {
+      id: job.id,
+      name: failedJob.name ?? job.name,
+      data: failedJob.data,
+      failedReason: failedJob.failedReason ?? 'unknown',
+      reason: failedJob.reason ?? 'unknown',
+      timestamp: job.timestamp,
+      sourceQueue: failedJob.data?.__sourceQueue ?? 'unknown',
+    };
+  }
+}


### PR DESCRIPTION
Closes #1984

## Summary
- Adds `DeadLetterQueueService` with inspection, metrics, replay, and purge capabilities for the BullMQ dead-letter queue
- Tags forwarded DLQ jobs with `__sourceQueue` metadata for origin tracking
- Exposes 5 REST endpoints under `/jobs/dlq/*`

## Changes
- **New** `dead-letter-queue.service.ts` — DLQService with `listDeadJobs`, `getMetrics`, `replayJob`, `replayAll`, `purge`
- **New** `dead-letter-queue.service.spec.ts` — 6 unit tests
- **Modified** `jobs.service.ts` — Add `__sourceQueue` tag when forwarding to DLQ
- **Modified** `jobs.controller.ts` — Register DLQ endpoints with Swagger decorators
- **Modified** `jobs.module.ts` — Register and export DeadLetterQueueService

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | /jobs/dlq | List dead-letter jobs |
| GET | /jobs/dlq/metrics | DLQ metrics |
| POST | /jobs/dlq/replay/:jobId | Replay a single job |
| POST | /jobs/dlq/replay-all | Bulk replay |
| POST | /jobs/dlq/purge | Purge all DLQ jobs |