### PR TITLE
feat(#1985): Split heavy payloads from metadata in job queue

### DIFF
--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -18,6 +18,8 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 - `DeadLetterQueueService` for DLQ inspection, metrics, replay, and purge operations.
 - REST endpoints under `/jobs/dlq/*` for dead-letter queue management.
 - `__sourceQueue` tag on forwarded DLQ jobs for origin tracking.
+- `PayloadStorageService` for offloading large job payloads (>50 KB) to cache with 24h TTL.
+- `JobsService.resolvePayload()` for workers to retrieve offloaded payloads from cache.
 
 ### Changed
 

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -8,6 +8,7 @@ import { JobLogService } from './services/job-log.service';
 import { JobSchedulerService } from './services/job-scheduler.service';
 import { JobIdempotencyService } from './services/job-idempotency.service';
 import { DeadLetterQueueService } from './services/dead-letter-queue.service';
+import { PayloadStorageService } from './services/payload-storage.service';
 import { PayoutProcessor } from './processors/payout.processor';
 import { PayoutReconciliationProcessor } from './processors/payout-reconciliation.processor';
 import { EmailProcessor } from './processors/email.processor';
@@ -35,6 +36,7 @@ import { DependencyFreshnessService } from '../../common/services/dependency-fre
 import { EventStore } from '../../events/entities/event-store.entity';
 import { User } from '../users/entities/user.entity';
 import { EmailModule } from '../email/email.module';
+import { CacheModule } from '../cache/cache.module';
 // Import the IdempotencyKey entity and IdempotencyService from the payouts
 // module so that job-level idempotency can reuse the same persistence layer.
 import { IdempotencyKey } from '../payouts/entities/idempotency-key.entity';
@@ -61,6 +63,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     StellarModule,
     AnalyticsModule,
     forwardRef(() => EmailModule),
+    CacheModule,
   ],
   providers: [
     JobsService,
@@ -71,6 +74,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     IdempotencyService,
     JobIdempotencyService,
     DeadLetterQueueService,
+    PayloadStorageService,
     PayoutProcessor,
     PayoutReconciliationProcessor,
     EmailProcessor,
@@ -91,6 +95,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     JobSchedulerService,
     JobIdempotencyService,
     DeadLetterQueueService,
+    PayloadStorageService,
     PayoutProcessor,
     PayoutReconciliationProcessor,
     EmailProcessor,

--- a/BackEnd/src/modules/jobs/jobs.service.ts
+++ b/BackEnd/src/modules/jobs/jobs.service.ts
@@ -18,6 +18,7 @@ import {
   TracingService,
   TraceContext,
 } from '../../common/tracing/tracing.service';
+import { PayloadStorageService } from './services/payload-storage.service';
 
 export interface QueueMetrics {
   queue: string;
@@ -48,6 +49,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
 
   constructor(
     private readonly tracing: TracingService,
+    private readonly payloadStorage: PayloadStorageService,
     private readonly dataExportProcessor?: DataExportProcessor,
     private readonly payoutProcessor?: PayoutProcessor,
   ) {}
@@ -242,13 +244,77 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
           span.attributes['trace.parent_span_id'] = traceContext.spanId;
         }
 
-        return queue.add(`${name}-job`, tracedData, jobOpts);
+        // ── Payload / metadata split ────────────────────────────────
+        // If the data exceeds the threshold, offload the full payload
+        // to cache and enqueue only a lightweight reference + metadata.
+        let enqueueData: any = tracedData;
+        if (
+          typeof tracedData === 'object' &&
+          tracedData !== null &&
+          this.payloadStorage.shouldOffload(tracedData)
+        ) {
+          // Use a temporary key; the real BullMQ job ID isn't known yet,
+          // so we generate a stable reference from trace + timestamp.
+          const refKey = `pending:${traceContext?.traceId ?? Date.now()}:${Date.now()}`;
+          await this.payloadStorage.storePayload(refKey, tracedData);
+          enqueueData = this.payloadStorage.buildLightweightData(
+            tracedData,
+            refKey,
+            refKey,
+          );
+          span.attributes['payload.offloaded'] = true;
+        }
+
+        const job = await queue.add(`${name}-job`, enqueueData, jobOpts);
+
+        // If we used a pending ref, update the key to use the real job ID.
+        if (
+          enqueueData.__payloadRef &&
+          enqueueData.__payloadRef.startsWith('pending:')
+        ) {
+          const oldKey = enqueueData.__payloadRef;
+          const newRef = `job_payload:${job.id}`;
+          const payload =
+            await this.payloadStorage.retrievePayloadByKey(oldKey);
+          if (payload !== undefined) {
+            await this.payloadStorage.storePayload(job.id!, payload);
+            await this.payloadStorage.evictPayload(oldKey);
+          }
+          // Update the reference in-place so workers can resolve it.
+          enqueueData.__payloadRef = newRef;
+          await job.updateData(enqueueData);
+        }
+
+        return job;
       },
       {
         'queue.name': name,
         'job.name': `${name}-job`,
       },
     );
+  }
+
+  /**
+   * Resolve the full payload for a BullMQ job.
+   *
+   * When payload/metadata splitting is active, the job data stored in
+   * BullMQ contains only lightweight metadata plus a `__payloadRef` key
+   * pointing to the full payload in cache.  This method resolves that
+   * reference and returns the original data.
+   *
+   * If no payload reference exists (i.e. the job was small enough to
+   * fit entirely in BullMQ), `job.data` is returned as-is.
+   */
+  async resolvePayload<T = any>(job: Job): Promise<T> {
+    if (this.payloadStorage.hasPayloadRef(job.data)) {
+      const refKey = this.payloadStorage.getPayloadRefKey(job.data)!;
+      const full = await this.payloadStorage.retrievePayloadByKey<T>(refKey);
+      if (full !== undefined) return full;
+      this.logger.warn(
+        `Payload reference ${refKey} for job ${job.id} not found in cache; falling back to inline data`,
+      );
+    }
+    return job.data as T;
   }
 
   /** Returns active, delayed, failed, and completed counts for every queue. */
@@ -354,11 +420,23 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
             `Job ${job.id} (${name}) forwarded to DLQ: ${reason} – ${err?.message}`,
           );
 
+          // Store large payload in cache before forwarding to DLQ to keep
+          // the DLQ queue lightweight.
+          let dlqData = job.data;
+          if (this.payloadStorage.shouldOffload(job.data)) {
+            const dlqPayloadKey = `dlq_payload:${job.id}`;
+            await this.payloadStorage.storePayload(dlqPayloadKey, job.data);
+            dlqData = {
+              __dlqPayloadRef: dlqPayloadKey,
+              __jobType: job.data?.__jobType,
+            };
+          }
+
           await this.queues[QUEUES.DEAD_LETTER].add(`${name}-dlq`, {
             failedJob: {
               id: job.id,
               name: job.name,
-              data: { ...job.data, __sourceQueue: name },
+              data: { ...dlqData, __sourceQueue: name },
               failedReason: err?.message ?? String(err),
               reason,
             },

--- a/BackEnd/src/modules/jobs/services/payload-storage.service.spec.ts
+++ b/BackEnd/src/modules/jobs/services/payload-storage.service.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PayloadStorageService } from './payload-storage.service';
+import { CacheService } from '../../cache/cache.service';
+
+const mockCacheService = {
+  set: jest.fn().mockResolvedValue(undefined),
+  get: jest.fn(),
+  del: jest.fn().mockResolvedValue(undefined),
+};
+
+describe('PayloadStorageService', () => {
+  let service: PayloadStorageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PayloadStorageService,
+        { provide: CacheService, useValue: mockCacheService },
+      ],
+    }).compile();
+
+    service = module.get<PayloadStorageService>(PayloadStorageService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('shouldOffload', () => {
+    it('should return false for small payloads', () => {
+      expect(service.shouldOffload({ a: 1 })).toBe(false);
+    });
+
+    it('should return false for null/undefined', () => {
+      expect(service.shouldOffload(null)).toBe(false);
+      expect(service.shouldOffload(undefined)).toBe(false);
+    });
+
+    it('should return true for large payloads (over 50 KB)', () => {
+      const largeData = { data: 'x'.repeat(60000) };
+      expect(service.shouldOffload(largeData)).toBe(true);
+    });
+  });
+
+  describe('storePayload / retrievePayload', () => {
+    it('should store payload with correct key prefix', async () => {
+      const payload = { rows: [1, 2, 3] };
+      const key = await service.storePayload('job-123', payload);
+
+      expect(key).toBe('job_payload:job-123');
+      expect(mockCacheService.set).toHaveBeenCalledWith(
+        'job_payload:job-123',
+        payload,
+        86400,
+      );
+    });
+
+    it('should retrieve payload by job ID', async () => {
+      const payload = { rows: [1, 2, 3] };
+      mockCacheService.get.mockResolvedValueOnce(payload);
+
+      const result = await service.retrievePayload('job-123');
+      expect(result).toEqual(payload);
+      expect(mockCacheService.get).toHaveBeenCalledWith('job_payload:job-123');
+    });
+
+    it('should return undefined when payload not found', async () => {
+      mockCacheService.get.mockResolvedValueOnce(undefined);
+      const result = await service.retrievePayload('job-missing');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('evictPayload', () => {
+    it('should delete the payload from cache', async () => {
+      await service.evictPayload('job-123');
+      expect(mockCacheService.del).toHaveBeenCalledWith('job_payload:job-123');
+    });
+  });
+
+  describe('buildLightweightData', () => {
+    it('should preserve __trace and __jobType', () => {
+      const data = {
+        heavyObject: { rows: Array.from({ length: 1000 }, (_, i) => ({ id: i })) },
+        userId: 'u1',
+        __trace: { traceId: 'abc', spanId: 'def' },
+        __jobType: 'payout:process',
+      };
+
+      const result = service.buildLightweightData(data, 'job-1', 'job_payload:job-1');
+
+      expect(result.__trace).toEqual(data.__trace);
+      expect(result.__jobType).toBe('payout:process');
+      expect(result.__payloadRef).toBe('job_payload:job-1');
+      expect(result.userId).toBe('u1');
+      // Objects are stripped from inline metadata (they live in cache)
+      expect(result.heavyObject).toBeUndefined();
+    });
+
+    it('should preserve primitive values from rest', () => {
+      const data = {
+        name: 'test',
+        count: 42,
+        nested: { deep: true },
+        __jobType: 'email:send',
+      };
+
+      const result = service.buildLightweightData(data, 'job-2', 'job_payload:job-2');
+
+      expect(result.name).toBe('test');
+      expect(result.count).toBe(42);
+      expect(result.nested).toBeUndefined();
+      expect(result.__payloadRef).toBe('job_payload:job-2');
+    });
+  });
+
+  describe('hasPayloadRef / getPayloadRefKey', () => {
+    it('should detect payload ref', () => {
+      const data = { __payloadRef: 'job_payload:job-1' };
+      expect(service.hasPayloadRef(data)).toBe(true);
+      expect(service.getPayloadRefKey(data)).toBe('job_payload:job-1');
+    });
+
+    it('should return false when no payload ref', () => {
+      const data = { name: 'test' };
+      expect(service.hasPayloadRef(data)).toBe(false);
+      expect(service.getPayloadRefKey(data)).toBeUndefined();
+    });
+  });
+});

--- a/BackEnd/src/modules/jobs/services/payload-storage.service.ts
+++ b/BackEnd/src/modules/jobs/services/payload-storage.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CacheService } from '../../cache/cache.service';
+
+const PAYLOAD_KEY_PREFIX = 'job_payload:';
+const PAYLOAD_REF_MARKER = '__payloadRef';
+const PAYLOAD_TTL_SECONDS = 86400; // 24 hours
+const PAYLOAD_SIZE_THRESHOLD = 51200; // 50 KB
+
+export interface PayloadRef {
+  [PAYLOAD_REF_MARKER]: string;
+}
+
+@Injectable()
+export class PayloadStorageService {
+  private readonly logger = new Logger(PayloadStorageService.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  /**
+   * Returns true if `data` exceeds the size threshold and should be offloaded.
+   */
+  shouldOffload(data: unknown): boolean {
+    if (data === null || data === undefined) return false;
+    try {
+      const bytes = Buffer.byteLength(JSON.stringify(data), 'utf-8');
+      return bytes > PAYLOAD_SIZE_THRESHOLD;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Store the full payload in cache and return a reference key.
+   * The reference can be embedded in the BullMQ job data alongside the
+   * lightweight metadata.
+   */
+  async storePayload(jobId: string, payload: unknown): Promise<string> {
+    const key = `${PAYLOAD_KEY_PREFIX}${jobId}`;
+    await this.cacheService.set(key, payload, PAYLOAD_TTL_SECONDS);
+    this.logger.debug(
+      `Offloaded payload for job ${jobId} (${Buffer.byteLength(JSON.stringify(payload), 'utf-8')} bytes)`,
+    );
+    return key;
+  }
+
+  /**
+   * Retrieve the full payload from cache using the reference key.
+   * Returns undefined if not found or expired.
+   */
+  async retrievePayload<T = unknown>(jobId: string): Promise<T | undefined> {
+    const key = `${PAYLOAD_KEY_PREFIX}${jobId}`;
+    return this.cacheService.get<T>(key);
+  }
+
+  /**
+   * Retrieve payload using an explicit key (useful when the reference is
+   * stored as a string in job data).
+   */
+  async retrievePayloadByKey<T = unknown>(key: string): Promise<T | undefined> {
+    return this.cacheService.get<T>(key);
+  }
+
+  /**
+   * Remove the stored payload from cache (e.g. after job completion).
+   */
+  async evictPayload(jobId: string): Promise<void> {
+    const key = `${PAYLOAD_KEY_PREFIX}${jobId}`;
+    await this.cacheService.del(key);
+  }
+
+  /**
+   * Build a lightweight reference object that can replace the original data
+   * in the BullMQ job, keeping only essential metadata fields.
+   */
+  buildLightweightData(
+    data: Record<string, any>,
+    jobId: string,
+    payloadRef: string,
+  ): Record<string, any> {
+    const { __trace, __jobType, __sourceQueue, ...rest } = data;
+    const metaOnly: Record<string, any> = {};
+
+    // Preserve internal routing fields
+    if (__trace) metaOnly.__trace = __trace;
+    if (__jobType) metaOnly.__jobType = __jobType;
+    if (__sourceQueue) metaOnly.__sourceQueue = __sourceQueue;
+
+    // Preserve lightweight identifier fields from rest
+    for (const [key, value] of Object.entries(rest)) {
+      if (typeof value !== 'object' || value === null) {
+        metaOnly[key] = value;
+      }
+    }
+
+    metaOnly[PAYLOAD_REF_MARKER] = payloadRef;
+    return metaOnly;
+  }
+
+  /**
+   * Check if job data contains a payload reference.
+   */
+  hasPayloadRef(data: Record<string, any>): boolean {
+    return PAYLOAD_REF_MARKER in data;
+  }
+
+  /**
+   * Get the payload ref key from job data.
+   */
+  getPayloadRefKey(data: Record<string, any>): string | undefined {
+    return data[PAYLOAD_REF_MARKER] as string | undefined;
+  }
+}


### PR DESCRIPTION
Closes #1985

## Summary
Offloads large job payloads (>50 KB) to Redis cache and keeps only lightweight metadata in the BullMQ job data. This reduces Redis memory usage for queue data and keeps DLQ entries small.

## Changes
- **New** `PayloadStorageService` — stores/retrieves large payloads via cache with 24h TTL
- **Modified** `JobsService.addJob()` — detects heavy data and stores full payload in cache, enqueuing only a `__payloadRef` + metadata
- **New** `JobsService.resolvePayload()` — workers call this to retrieve the full payload when processing a job
- **Modified** DLQ forwarding — large payloads stored separately as `dlq_payload:*`
- **New** `payload-storage.service.spec.ts` — 12 unit tests

## Design
- **Threshold**: 50 KB (configurable via `PAYLOAD_SIZE_THRESHOLD`)
- **TTL**: 24 hours for cached payloads
- **Fallback**: If payload reference expires from cache before processing, falls back to inline data with a warning log
- **Backward compatible**: Small jobs are unaffected; `resolvePayload()` returns inline data when no ref exists