### PR TITLE
feat(#1986): Add job archival service and missing composite indexes

### DIFF
--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -18,6 +18,9 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 - `DeadLetterQueueService` for DLQ inspection, metrics, replay, and purge operations.
 - REST endpoints under `/jobs/dlq/*` for dead-letter queue management.
 - `__sourceQueue` tag on forwarded DLQ jobs for origin tracking.
+- `JobArchivalService` for batched archival of completed/failed jobs to `job_logs_archive` table.
+- 5 composite indexes on `job_logs` for common query patterns (archival, dashboard, user history, type analytics).
+- REST endpoints under `/jobs/archival/*` for archival metrics, archive, purge, and maintenance.
 
 ### Changed
 

--- a/BackEnd/src/modules/jobs/entities/job-log-archive.entity.ts
+++ b/BackEnd/src/modules/jobs/entities/job-log-archive.entity.ts
@@ -1,0 +1,117 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  Index,
+  CreateDateColumn,
+} from 'typeorm';
+import { JobStatus, JobType } from '../job.types';
+
+/**
+ * Job Log Archive Entity
+ *
+ * Mirrors the active `JobLog` schema but lives in a separate table
+ * (`job_logs_archive`).  Completed and failed jobs older than the
+ * retention window are moved here by the archival service, keeping the
+ * active table small and fast.
+ *
+ * Indexes are intentionally kept minimal — archived rows are rarely
+ * queried and typically scanned in bulk for compliance exports.
+ */
+@Entity('job_logs_archive')
+@Index('idx_archive_job_logs_created', ['createdAt'])
+@Index('idx_archive_job_logs_job_type', ['jobType'])
+export class JobLogArchive {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  jobType: JobType;
+
+  @Column({ type: 'varchar', nullable: true })
+  externalJobId: string;
+
+  @Column({ type: 'enum', enum: JobStatus })
+  status: JobStatus;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  queueName: string;
+
+  @Column({ type: 'int', default: 0 })
+  attempt: number;
+
+  @Column({ type: 'int', default: 0 })
+  maxAttempts: number;
+
+  @Column({ type: 'jsonb', nullable: true })
+  payload: Record<string, any>;
+
+  @Column({ type: 'jsonb', nullable: true })
+  result: Record<string, any>;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage: string;
+
+  @Column({ type: 'text', nullable: true })
+  errorStack: string;
+
+  @Column({ type: 'int', nullable: true })
+  durationMs: number;
+
+  @Column({ type: 'bigint', nullable: true })
+  processedAtTimestamp: number;
+
+  @Column({ type: 'varchar', length: 36, nullable: true })
+  correlationId: string;
+
+  @Column({ type: 'varchar', length: 36, nullable: true })
+  traceId: string;
+
+  @Column({ type: 'varchar', length: 36, nullable: true })
+  organizationId: string;
+
+  @Column({ type: 'varchar', length: 36, nullable: true })
+  userId: string;
+
+  @Column({ type: 'simple-array', nullable: true })
+  tags: string[];
+
+  @Column({ type: 'boolean', default: false })
+  isRetryable: boolean;
+
+  @Column({ type: 'varchar', length: 36, nullable: true })
+  parentJobId: string;
+
+  @Column({ type: 'simple-array', nullable: true })
+  dependentJobIds: string[];
+
+  @Column({ type: 'int', default: 0 })
+  progress: number;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  progressMessage: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  scheduledAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  startedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  completedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  nextRetryAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  updatedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expiresAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  archivedAt: Date;
+}

--- a/BackEnd/src/modules/jobs/entities/job-log.entity.ts
+++ b/BackEnd/src/modules/jobs/entities/job-log.entity.ts
@@ -27,7 +27,11 @@ import { JobStatus, JobType } from '../job.types';
 @Index('idx_job_logs_organization_status', ['organizationId', 'status'])
 // Composite indexes for archival queries and common filter combinations
 @Index('idx_job_logs_status_completed_created', ['status', 'createdAt'])
-@Index('idx_job_logs_org_status_created', ['organizationId', 'status', 'createdAt'])
+@Index('idx_job_logs_org_status_created', [
+  'organizationId',
+  'status',
+  'createdAt',
+])
 @Index('idx_job_logs_user_status_created', ['userId', 'status', 'createdAt'])
 @Index('idx_job_logs_type_status_created', ['jobType', 'status', 'createdAt'])
 @Index('idx_job_logs_correlation', ['correlationId'])

--- a/BackEnd/src/modules/jobs/entities/job-log.entity.ts
+++ b/BackEnd/src/modules/jobs/entities/job-log.entity.ts
@@ -25,6 +25,12 @@ import { JobStatus, JobType } from '../job.types';
 @Index('idx_job_logs_external_id', ['externalJobId'])
 @Index('idx_job_logs_status_created', ['status', 'createdAt'])
 @Index('idx_job_logs_organization_status', ['organizationId', 'status'])
+// Composite indexes for archival queries and common filter combinations
+@Index('idx_job_logs_status_completed_created', ['status', 'createdAt'])
+@Index('idx_job_logs_org_status_created', ['organizationId', 'status', 'createdAt'])
+@Index('idx_job_logs_user_status_created', ['userId', 'status', 'createdAt'])
+@Index('idx_job_logs_type_status_created', ['jobType', 'status', 'createdAt'])
+@Index('idx_job_logs_correlation', ['correlationId'])
 export class JobLog {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/BackEnd/src/modules/jobs/jobs.controller.ts
+++ b/BackEnd/src/modules/jobs/jobs.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/swagger';
 import { JobsService } from './jobs.service';
 import { DeadLetterQueueService } from './services/dead-letter-queue.service';
+import { JobArchivalService } from './services/job-archival.service';
 
 @ApiTags('Jobs')
 @Controller('jobs')
@@ -25,6 +26,7 @@ export class JobsController {
   constructor(
     private readonly jobsService: JobsService,
     private readonly dlqService: DeadLetterQueueService,
+    private readonly archivalService: JobArchivalService,
   ) {}
 
   @Get('health')
@@ -118,5 +120,53 @@ export class JobsController {
   @ApiResponse({ status: 200, description: 'DLQ purged' })
   async purgeDlq() {
     return this.dlqService.purge();
+  }
+
+  // ── Archival endpoints ──────────────────────────────────────────────
+
+  @Get('archival/metrics')
+  @ApiOperation({
+    summary: 'Get job archival metrics (active vs archived counts)',
+  })
+  @ApiResponse({ status: 200, description: 'Archival metrics' })
+  async getArchivalMetrics() {
+    return this.archivalService.getMetrics();
+  }
+
+  @Post('archival/archive')
+  @ApiOperation({
+    summary: 'Archive completed/failed jobs older than retention window',
+  })
+  @ApiQuery({ name: 'retentionDays', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Archival result' })
+  async archiveOldJobs(@Param('retentionDays') retentionDays?: string) {
+    const days = retentionDays ? parseInt(retentionDays, 10) : undefined;
+    return this.archivalService.archiveOldJobs(days);
+  }
+
+  @Post('archival/purge')
+  @ApiOperation({
+    summary: 'Permanently delete archived jobs older than archive retention',
+  })
+  @ApiQuery({ name: 'retentionDays', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Purge result' })
+  async purgeOldArchives(@Param('retentionDays') retentionDays?: string) {
+    const days = retentionDays ? parseInt(retentionDays, 10) : undefined;
+    return this.archivalService.purgeOldArchives(days);
+  }
+
+  @Post('archival/run')
+  @ApiOperation({ summary: 'Run full archival maintenance (archive + purge)' })
+  @ApiQuery({ name: 'activeRetentionDays', required: false, type: Number })
+  @ApiQuery({ name: 'archiveRetentionDays', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Maintenance result' })
+  async runMaintenance(
+    @Param('activeRetentionDays') activeDays?: string,
+    @Param('archiveRetentionDays') archiveDays?: string,
+  ) {
+    return this.archivalService.runMaintenance(
+      activeDays ? parseInt(activeDays, 10) : undefined,
+      archiveDays ? parseInt(archiveDays, 10) : undefined,
+    );
   }
 }

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -8,6 +8,7 @@ import { JobLogService } from './services/job-log.service';
 import { JobSchedulerService } from './services/job-scheduler.service';
 import { JobIdempotencyService } from './services/job-idempotency.service';
 import { DeadLetterQueueService } from './services/dead-letter-queue.service';
+import { JobArchivalService } from './services/job-archival.service';
 import { PayoutProcessor } from './processors/payout.processor';
 import { PayoutReconciliationProcessor } from './processors/payout-reconciliation.processor';
 import { EmailProcessor } from './processors/email.processor';
@@ -24,6 +25,7 @@ import {
   JobDependency,
   JobSchedule,
 } from './entities/job-log.entity';
+import { JobLogArchive } from './entities/job-log-archive.entity';
 import { DataExport } from '../users/entities/data-export.entity';
 import { DataExportListener } from './listeners/data-export.listener';
 import { Payout } from '../payouts/entities/payout.entity';
@@ -47,6 +49,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
       JobLogRetry,
       JobDependency,
       JobSchedule,
+      JobLogArchive,
       DataExport,
       Payout,
       Quest,
@@ -71,6 +74,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     IdempotencyService,
     JobIdempotencyService,
     DeadLetterQueueService,
+    JobArchivalService,
     PayoutProcessor,
     PayoutReconciliationProcessor,
     EmailProcessor,
@@ -91,6 +95,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     JobSchedulerService,
     JobIdempotencyService,
     DeadLetterQueueService,
+    JobArchivalService,
     PayoutProcessor,
     PayoutReconciliationProcessor,
     EmailProcessor,

--- a/BackEnd/src/modules/jobs/services/job-archival.service.spec.ts
+++ b/BackEnd/src/modules/jobs/services/job-archival.service.spec.ts
@@ -1,10 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JobArchivalService } from './job-archival.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { JobLog } from '../entities/job-log.entity';
 import { JobLogArchive } from '../entities/job-log-archive.entity';
-import { JobStatus, JobType } from '../job.types';
 
 const mockJobLogRepo = {
   find: jest.fn().mockResolvedValue([]),
@@ -35,7 +33,10 @@ describe('JobArchivalService', () => {
       providers: [
         JobArchivalService,
         { provide: getRepositoryToken(JobLog), useValue: mockJobLogRepo },
-        { provide: getRepositoryToken(JobLogArchive), useValue: mockArchiveRepo },
+        {
+          provide: getRepositoryToken(JobLogArchive),
+          useValue: mockArchiveRepo,
+        },
       ],
     }).compile();
 

--- a/BackEnd/src/modules/jobs/services/job-archival.service.spec.ts
+++ b/BackEnd/src/modules/jobs/services/job-archival.service.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobArchivalService } from './job-archival.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { JobLog } from '../entities/job-log.entity';
+import { JobLogArchive } from '../entities/job-log-archive.entity';
+import { JobStatus, JobType } from '../job.types';
+
+const mockJobLogRepo = {
+  find: jest.fn().mockResolvedValue([]),
+  count: jest.fn().mockResolvedValue(0),
+  delete: jest.fn().mockResolvedValue({ affected: 0 }),
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+const mockArchiveRepo = {
+  find: jest.fn().mockResolvedValue([]),
+  count: jest.fn().mockResolvedValue(0),
+  delete: jest.fn().mockResolvedValue({ affected: 0 }),
+  findOne: jest.fn().mockResolvedValue(null),
+  createQueryBuilder: jest.fn(() => ({
+    insert: jest.fn().mockReturnThis(),
+    into: jest.fn().mockReturnThis(),
+    values: jest.fn().mockReturnThis(),
+    orIgnore: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({}),
+  })),
+};
+
+describe('JobArchivalService', () => {
+  let service: JobArchivalService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobArchivalService,
+        { provide: getRepositoryToken(JobLog), useValue: mockJobLogRepo },
+        { provide: getRepositoryToken(JobLogArchive), useValue: mockArchiveRepo },
+      ],
+    }).compile();
+
+    service = module.get<JobArchivalService>(JobArchivalService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('archiveOldJobs', () => {
+    it('should archive 0 jobs when no eligible jobs exist', async () => {
+      const result = await service.archiveOldJobs();
+      expect(result.archived).toBe(0);
+      expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('purgeOldArchives', () => {
+    it('should purge 0 archives when no old archives exist', async () => {
+      const result = await service.purgeOldArchives();
+      expect(result.purged).toBe(0);
+    });
+  });
+
+  describe('runMaintenance', () => {
+    it('should run both archive and purge', async () => {
+      const result = await service.runMaintenance();
+      expect(result.archived).toBe(0);
+      expect(result.purged).toBe(0);
+      expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('should return zero counts when tables are empty', async () => {
+      const metrics = await service.getMetrics();
+      expect(metrics.activeCount).toBe(0);
+      expect(metrics.archivedCount).toBe(0);
+      expect(metrics.oldestActiveAge).toBeNull();
+      expect(metrics.oldestArchivedAge).toBeNull();
+    });
+  });
+});

--- a/BackEnd/src/modules/jobs/services/job-archival.service.ts
+++ b/BackEnd/src/modules/jobs/services/job-archival.service.ts
@@ -1,0 +1,228 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan, In } from 'typeorm';
+import { JobLog } from '../entities/job-log.entity';
+import { JobLogArchive } from '../entities/job-log-archive.entity';
+import { JobStatus } from '../job.types';
+
+export interface ArchivalResult {
+  archived: number;
+  purged: number;
+  elapsedMs: number;
+}
+
+/**
+ * Job Archival Service
+ *
+ * Moves completed/failed jobs older than the retention window from the
+ * active `job_logs` table into the `job_logs_archive` table, and
+ * permanently deletes archived rows past the archive retention limit.
+ *
+ * This keeps the active table small and fast while preserving history
+ * for compliance and debugging within the archive window.
+ */
+@Injectable()
+export class JobArchivalService {
+  private readonly logger = new Logger(JobArchivalService.name);
+
+  /** Default retention: 7 days for active table */
+  private static readonly DEFAULT_ACTIVE_RETENTION_DAYS = 7;
+
+  /** Default archive retention: 90 days */
+  private static readonly DEFAULT_ARCHIVE_RETENTION_DAYS = 90;
+
+  /** Maximum rows to process per archival batch to avoid long transactions */
+  private static readonly BATCH_SIZE = 500;
+
+  constructor(
+    @InjectRepository(JobLog)
+    private readonly jobLogRepository: Repository<JobLog>,
+    @InjectRepository(JobLogArchive)
+    private readonly archiveRepository: Repository<JobLogArchive>,
+  ) {}
+
+  /**
+   * Archive jobs older than `activeRetentionDays` (default 7).
+   * Completed and failed jobs are moved to the archive table in batches.
+   */
+  async archiveOldJobs(
+    activeRetentionDays: number = JobArchivalService.DEFAULT_ACTIVE_RETENTION_DAYS,
+  ): Promise<ArchivalResult> {
+    const start = Date.now();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - activeRetentionDays);
+
+    let totalArchived = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      const batch = await this.jobLogRepository.find({
+        where: {
+          createdAt: LessThan(cutoff),
+          status: In([JobStatus.COMPLETED, JobStatus.FAILED]),
+        },
+        order: { createdAt: 'ASC' },
+        take: JobArchivalService.BATCH_SIZE,
+      });
+
+      if (batch.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      const archiveEntities = batch.map((job) => this.toArchiveEntity(job));
+
+      await this.archiveRepository
+        .createQueryBuilder()
+        .insert()
+        .into(JobLogArchive)
+        .values(archiveEntities)
+        .orIgnore()
+        .execute();
+
+      const ids = batch.map((j) => j.id);
+      await this.jobLogRepository.delete(ids);
+
+      totalArchived += batch.length;
+      this.logger.log(
+        `Archived batch of ${batch.length} jobs (total: ${totalArchived})`,
+      );
+
+      // If we got a full batch, there may be more
+      hasMore = batch.length === JobArchivalService.BATCH_SIZE;
+    }
+
+    const elapsedMs = Date.now() - start;
+    this.logger.log(
+      `Archival complete: ${totalArchived} jobs archived in ${elapsedMs}ms`,
+    );
+    return { archived: totalArchived, purged: 0, elapsedMs };
+  }
+
+  /**
+   * Purge archived jobs older than `archiveRetentionDays` (default 90).
+   * These are permanently deleted and cannot be recovered.
+   */
+  async purgeOldArchives(
+    archiveRetentionDays: number = JobArchivalService.DEFAULT_ARCHIVE_RETENTION_DAYS,
+  ): Promise<ArchivalResult> {
+    const start = Date.now();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - archiveRetentionDays);
+
+    let totalPurged = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      const batch = await this.archiveRepository.find({
+        where: { createdAt: LessThan(cutoff) },
+        order: { createdAt: 'ASC' },
+        take: JobArchivalService.BATCH_SIZE,
+        select: ['id'],
+      });
+
+      if (batch.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      const ids = batch.map((j) => j.id);
+      await this.archiveRepository.delete(ids);
+      totalPurged += batch.length;
+
+      hasMore = batch.length === JobArchivalService.BATCH_SIZE;
+    }
+
+    const elapsedMs = Date.now() - start;
+    this.logger.log(
+      `Archive purge complete: ${totalPurged} archived jobs deleted in ${elapsedMs}ms`,
+    );
+    return { archived: 0, purged: totalPurged, elapsedMs };
+  }
+
+  /**
+   * Combined: archive active jobs, then purge old archives.
+   */
+  async runMaintenance(
+    activeRetentionDays?: number,
+    archiveRetentionDays?: number,
+  ): Promise<ArchivalResult> {
+    const archiveResult = await this.archiveOldJobs(activeRetentionDays);
+    const purgeResult = await this.purgeOldArchives(archiveRetentionDays);
+
+    return {
+      archived: archiveResult.archived,
+      purged: purgeResult.purged,
+      elapsedMs: archiveResult.elapsedMs + purgeResult.elapsedMs,
+    };
+  }
+
+  /**
+   * Get archival metrics — counts of active and archived jobs.
+   */
+  async getMetrics(): Promise<{
+    activeCount: number;
+    archivedCount: number;
+    oldestActiveAge: Date | null;
+    oldestArchivedAge: Date | null;
+  }> {
+    const [activeCount, archivedCount] = await Promise.all([
+      this.jobLogRepository.count(),
+      this.archiveRepository.count(),
+    ]);
+
+    const [oldestActive, oldestArchived] = await Promise.all([
+      this.jobLogRepository.findOne({
+        order: { createdAt: 'ASC' },
+        select: ['createdAt'],
+      }),
+      this.archiveRepository.findOne({
+        order: { createdAt: 'ASC' },
+        select: ['createdAt'],
+      }),
+    ]);
+
+    return {
+      activeCount,
+      archivedCount,
+      oldestActiveAge: oldestActive?.createdAt ?? null,
+      oldestArchivedAge: oldestArchived?.createdAt ?? null,
+    };
+  }
+
+  private toArchiveEntity(jobLog: JobLog): JobLogArchive {
+    const entity = new JobLogArchive();
+    entity.id = jobLog.id;
+    entity.jobType = jobLog.jobType;
+    entity.externalJobId = jobLog.externalJobId;
+    entity.status = jobLog.status;
+    entity.queueName = jobLog.queueName;
+    entity.attempt = jobLog.attempt;
+    entity.maxAttempts = jobLog.maxAttempts;
+    entity.payload = jobLog.payload;
+    entity.result = jobLog.result;
+    entity.errorMessage = jobLog.errorMessage;
+    entity.errorStack = jobLog.errorStack;
+    entity.durationMs = jobLog.durationMs;
+    entity.processedAtTimestamp = jobLog.processedAtTimestamp;
+    entity.correlationId = jobLog.correlationId;
+    entity.traceId = jobLog.traceId;
+    entity.organizationId = jobLog.organizationId;
+    entity.userId = jobLog.userId;
+    entity.tags = jobLog.tags;
+    entity.isRetryable = jobLog.isRetryable;
+    entity.parentJobId = jobLog.parentJobId;
+    entity.dependentJobIds = jobLog.dependentJobIds;
+    entity.progress = jobLog.progress;
+    entity.progressMessage = jobLog.progressMessage;
+    entity.scheduledAt = jobLog.scheduledAt;
+    entity.startedAt = jobLog.startedAt;
+    entity.completedAt = jobLog.completedAt;
+    entity.nextRetryAt = jobLog.nextRetryAt;
+    entity.createdAt = jobLog.createdAt;
+    entity.updatedAt = jobLog.updatedAt;
+    entity.expiresAt = jobLog.expiresAt;
+    entity.archivedAt = new Date();
+    return entity;
+  }
+}


### PR DESCRIPTION
Closes #1986
Closes #1987 

## Summary
Adds a batched archival service to move completed/failed jobs from the active `job_logs` table to a `job_logs_archive` table, and adds missing composite indexes for common query patterns.

## Changes
- **New** `JobLogArchive` entity — mirrors `JobLog` schema with `archivedAt` field
- **New** `JobArchivalService` — batched archive (500/batch), purge, combined maintenance, and metrics
- **Modified** `JobLog` entity — added 5 composite indexes:
  - `idx_job_logs_status_completed_created` (archival queries)
  - `idx_job_logs_org_status_created` (dashboard queries)
  - `idx_job_logs_user_status_created` (user job history)
  - `idx_job_logs_type_status_created` (type-based analytics)
  - `idx_job_logs_correlation` (correlation lookups)
- **Modified** `JobsController` — 4 new endpoints for archival operations
- **Modified** `JobsModule` — registered archive entity and archival service
- **New** `job-archival.service.spec.ts` — 5 unit tests

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | /jobs/archival/metrics | Active vs archived job counts |
| POST | /jobs/archival/archive | Archive jobs older than retention |
| POST | /jobs/archival/purge | Permanently delete old archives |
| POST | /jobs/archival/run | Run full maintenance cycle |

## Defaults
- Active retention: 7 days
- Archive retention: 90 days
- Batch size: 500 jobs per transaction