### PR TITLE
Regression tests: cursor pagination, quest-list caching, wizard/wallet a11y, claim flow

### DIFF
--- a/BackEnd/src/modules/quests/quests-cache.spec.ts
+++ b/BackEnd/src/modules/quests/quests-cache.spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { QuestsService } from './quests.service';
+import { Quest } from './entities/quest.entity';
+import { CacheService } from '../cache/cache.service';
+import { ModerationService } from '../moderation/moderation.service';
+import { QuotaService } from '../quota/quota.service';
+
+// Closes #1964: regression coverage for the GET /quests Redis caching layer.
+describe('QuestsService list caching', () => {
+  let service: QuestsService;
+  let cache: any;
+  let repo: any;
+
+  beforeEach(async () => {
+    cache = { get: jest.fn(), set: jest.fn(), deletePattern: jest.fn() };
+    repo = { createQueryBuilder: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QuestsService,
+        { provide: getRepositoryToken(Quest), useValue: repo },
+        { provide: CacheService, useValue: cache },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        { provide: ModerationService, useValue: {} },
+        { provide: QuotaService, useValue: {} },
+      ],
+    }).compile();
+    service = module.get(QuestsService);
+  });
+
+  it('returns the cached response without querying the DB on a cache hit', async () => {
+    const cached = { data: [], limit: 10 };
+    cache.get.mockResolvedValue(cached);
+    const result = await service.findAll({ limit: 10 } as any);
+    expect(result).toBe(cached);
+    expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('queries the DB and populates the cache on a miss', async () => {
+    cache.get.mockResolvedValue(null);
+    const qb = { andWhere: jest.fn().mockReturnThis(), orderBy: jest.fn().mockReturnThis(), take: jest.fn().mockReturnThis(), getMany: jest.fn().mockResolvedValue([]) };
+    repo.createQueryBuilder.mockReturnValue(qb);
+    await service.findAll({ limit: 10 } as any);
+    expect(cache.set).toHaveBeenCalled();
+  });
+});

--- a/BackEnd/src/modules/quests/quests-pagination.spec.ts
+++ b/BackEnd/src/modules/quests/quests-pagination.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { QuestsService } from './quests.service';
+import { Quest } from './entities/quest.entity';
+import { CacheService } from '../cache/cache.service';
+import { ModerationService } from '../moderation/moderation.service';
+import { QuotaService } from '../quota/quota.service';
+
+// Closes #1965: regression coverage for keyset (cursor) pagination.
+const q = (id: string, d: Date) => ({ id, title: id, description: 'd', rewardAmount: 1, status: 'ACTIVE', createdBy: 'u', createdAt: d, updatedAt: d });
+
+describe('QuestsService cursor pagination', () => {
+  let service: QuestsService;
+  let qb: any;
+
+  beforeEach(async () => {
+    qb = { andWhere: jest.fn().mockReturnThis(), orderBy: jest.fn().mockReturnThis(), take: jest.fn().mockReturnThis(), getMany: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QuestsService,
+        { provide: getRepositoryToken(Quest), useValue: { createQueryBuilder: jest.fn().mockReturnValue(qb) } },
+        { provide: CacheService, useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn(), deletePattern: jest.fn() } },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        { provide: ModerationService, useValue: {} },
+        { provide: QuotaService, useValue: {} },
+      ],
+    }).compile();
+    service = module.get(QuestsService);
+  });
+
+  it('sets nextCursor when more rows exist than the limit', async () => {
+    qb.getMany.mockResolvedValue([q('1', new Date('2026-01-03')), q('2', new Date('2026-01-02')), q('3', new Date('2026-01-01'))]);
+    const result = await service.findAll({ limit: 2 } as any);
+    expect(result.data).toHaveLength(2);
+    expect(result.nextCursor).toBe(new Date('2026-01-02').toISOString());
+  });
+
+  it('omits nextCursor on the last page', async () => {
+    qb.getMany.mockResolvedValue([q('1', new Date('2026-01-01'))]);
+    expect((await service.findAll({ limit: 5 } as any)).nextCursor).toBeUndefined();
+  });
+
+  it('applies the cursor as a createdAt filter, not an offset', async () => {
+    qb.getMany.mockResolvedValue([]);
+    await service.findAll({ cursor: '2026-01-01T00:00:00.000Z', limit: 10 } as any);
+    expect(qb.andWhere).toHaveBeenCalledWith('quest.createdAt < :cursor', { cursor: '2026-01-01T00:00:00.000Z' });
+  });
+});

--- a/FrontEnd/my-app/lib/hooks/useClaim.test.ts
+++ b/FrontEnd/my-app/lib/hooks/useClaim.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useClaim } from './useClaim';
+import * as claimModule from '../stellar/claim';
+import * as walletModule from '@/context/WalletContext';
+import * as toastModule from '@/components/notifications/Toast';
+
+// Closes #1939: unit coverage for the payout/claim reward flow.
+vi.mock('../stellar/claim');
+vi.mock('@/context/WalletContext');
+vi.mock('@/components/notifications/Toast');
+
+describe('useClaim', () => {
+  beforeEach(() => {
+    vi.mocked(walletModule.useWallet).mockReturnValue({
+      address: 'GADDR',
+      signTransaction: vi.fn(),
+    } as any);
+    vi.mocked(toastModule.useToast).mockReturnValue({ showToast: vi.fn() } as any);
+  });
+
+  it('claims successfully and reports the success status', async () => {
+    vi.mocked(claimModule.claimReward).mockResolvedValue({ success: true } as any);
+    const { result } = renderHook(() => useClaim());
+    await act(async () => {
+      await result.current.claim('reward-1', 10);
+    });
+    expect(result.current.status).toBe('success');
+  });
+
+  it('surfaces an error status when the wallet rejects the claim', async () => {
+    vi.mocked(claimModule.claimReward).mockRejectedValue(new Error('User rejected'));
+    const { result } = renderHook(() => useClaim());
+    await act(async () => {
+      await result.current.claim('reward-1', 10);
+    });
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toContain('rejected');
+  });
+
+  it('rejects the claim when no wallet is connected', async () => {
+    vi.mocked(walletModule.useWallet).mockReturnValue({ address: null, signTransaction: vi.fn() } as any);
+    const { result } = renderHook(() => useClaim());
+    const outcome = await act(async () => result.current.claim('reward-1', 10));
+    expect(outcome).toBeNull();
+    expect(result.current.status).toBe('error');
+  });
+});

--- a/FrontEnd/my-app/tests/a11y/quest-wizard-wallet-modal.test.ts
+++ b/FrontEnd/my-app/tests/a11y/quest-wizard-wallet-modal.test.ts
@@ -1,0 +1,41 @@
+import { test } from '@playwright/test';
+import { expectAxeToPass } from './axe-helper';
+
+// Closes #1941: a11y coverage for the quest wizard and wallet connect modal.
+test.describe('Accessibility: quest wizard + wallet connect modal', () => {
+  test('quest creation wizard has no critical axe violations', async ({ page }) => {
+    await expectAxeToPass({ page, url: '/en/quests/create' });
+  });
+
+  test('quest wizard remains accessible after advancing a step', async ({ page }) => {
+    await page.goto('/en/quests/create', { waitUntil: 'networkidle' });
+    const nextButton = page.getByRole('button', { name: /next|continue/i }).first();
+    if (await nextButton.isVisible()) {
+      await nextButton.click();
+      await expectAxeToPass({ page });
+    }
+  });
+
+  test('wallet connect modal has no critical axe violations when opened', async ({ page }) => {
+    await page.goto('/en', { waitUntil: 'networkidle' });
+    const connectButton = page
+      .getByRole('button', { name: /connect|wallet|sign in/i })
+      .first();
+    if (await connectButton.isVisible()) {
+      await connectButton.click();
+      await expectAxeToPass({ page });
+    }
+  });
+
+  test('wallet connect modal closes on Escape without trapping focus permanently', async ({ page }) => {
+    await page.goto('/en', { waitUntil: 'networkidle' });
+    const connectButton = page
+      .getByRole('button', { name: /connect|wallet|sign in/i })
+      .first();
+    if (await connectButton.isVisible()) {
+      await connectButton.click();
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Escape');
+    }
+  });
+});


### PR DESCRIPTION
Four small, additive test files — no existing files modified, so this should apply without conflicts.

### What's included
- `BackEnd/src/modules/quests/quests-pagination.spec.ts` — verifies the existing keyset/cursor pagination in `QuestsService.findAll` sets/omits `nextCursor` correctly and filters by `createdAt` rather than an offset.
- `BackEnd/src/modules/quests/quests-cache.spec.ts` — verifies `GET /quests` results are served from the Redis cache on a hit (no DB query) and populate the cache on a miss.
- `FrontEnd/my-app/tests/a11y/quest-wizard-wallet-modal.test.ts` — axe-core coverage for the quest creation wizard (`/en/quests/create`) and the wallet connect modal, picked up automatically by the existing a11y Playwright config alongside `axe-smoke.test.ts`/`modal-focus.test.ts`.
- `FrontEnd/my-app/lib/hooks/useClaim.test.ts` — unit coverage for the claim hook's success, wallet-rejection, and no-wallet-connected paths.

### Issues closed
Closes #1965
Closes #1964
Closes #1941
Closes #1939
