### PR TITLE
fix: hide webhook processing error details

### DIFF
--- a/BackEnd/src/modules/webhooks/CHANGELOG.md
+++ b/BackEnd/src/modules/webhooks/CHANGELOG.md
@@ -8,6 +8,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `WebhooksService.processWebhook` now returns a generic caller-facing processing failure message while keeping internal exception details in server logs.
 - Removed the non-functional `POST /webhooks/events` route (it referenced the nonexistent `WebhooksService.processEvent`), removed a duplicate `WebhookPayloadDto` import, and removed a stray brace in `webhook-event.dto.ts`.
 
 ### Changed

--- a/BackEnd/src/modules/webhooks/webhooks.service.spec.ts
+++ b/BackEnd/src/modules/webhooks/webhooks.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -224,11 +225,14 @@ describe('WebhooksService', () => {
       const result = await service.processWebhook(event);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('Failed to process webhook');
+      expect(result.message).toBe('webhook processing failed');
     });
 
     it('should return a failure response when a handler rejects unexpectedly', async () => {
       const event = buildEvent();
+      const loggerErrorSpy = jest
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation();
       jest
         .spyOn(githubHandler, 'handleEvent')
         .mockRejectedValueOnce(new Error('downstream failure'));
@@ -236,8 +240,11 @@ describe('WebhooksService', () => {
       const result = await service.processWebhook(event);
 
       expect(result.success).toBe(false);
-      expect(result.message).toBe(
-        'Failed to process webhook: downstream failure',
+      expect(result.message).toBe('webhook processing failed');
+      expect(result.message).not.toContain('downstream failure');
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to process webhook ${event.id}:`),
+        expect.stringContaining('downstream failure'),
       );
     });
 
@@ -299,6 +306,8 @@ describe('WebhooksService', () => {
         }),
       );
       const saved = repo.save.mock.calls[0][0] as FailedWebhookEvent;
+      expect(saved.failureReason).toBe('webhook processing failed');
+      expect(saved.errorHistory[0].error).toBe('webhook processing failed');
       expect(saved.nextRetryAt).not.toBeNull();
     });
 

--- a/BackEnd/src/modules/webhooks/webhooks.service.ts
+++ b/BackEnd/src/modules/webhooks/webhooks.service.ts
@@ -43,6 +43,7 @@ const NON_RETRYABLE_MESSAGES = [
   'Invalid webhook signature',
   'Unsupported webhook source',
 ];
+const WEBHOOK_PROCESSING_FAILED_MESSAGE = 'webhook processing failed';
 
 @Injectable()
 export class WebhooksService {
@@ -156,7 +157,7 @@ export class WebhooksService {
       return {
         success: false,
         eventId: event.id,
-        message: `Failed to process webhook: ${error.message}`,
+        message: WEBHOOK_PROCESSING_FAILED_MESSAGE,
         processedAt: new Date(),
         traceId: currentTraceId(),
       };


### PR DESCRIPTION
## Summary
- return a generic webhook processing failure message to callers
- keep detailed exception information in server logs
- update WebhooksService tests to ensure internal error text is not exposed

## Validation
- `npm.cmd test -- webhooks.service.spec.ts --runInBand` (32 passed)
- `npx.cmd eslint src/modules/webhooks/webhooks.service.ts src/modules/webhooks/webhooks.service.spec.ts` (0 errors; existing warnings remain in `webhooks.service.ts`)

Closes #1891