### PR TITLE
fix: return not initialized admin error

### DIFF
--- a/contracts/earn-quest/src/init.rs
+++ b/contracts/earn-quest/src/init.rs
@@ -23,6 +23,8 @@ pub fn initialize(env: &Env, config: InitConfig) {
 }
 
 pub fn upgrade_authorize(env: &Env, caller: &Address) -> bool {
-    let admin = storage::get_admin(env);
-    caller == &admin
+    match storage::get_admin(env) {
+        Ok(admin) => caller == &admin,
+        Err(_) => false,
+    }
 }

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -125,7 +125,7 @@ impl EarnQuestContract {
     /// ```rust
     /// let admin = client.get_admin();
     /// ```
-    pub fn get_admin(env: Env) -> Address {
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
         storage::get_admin(&env)
     }
 

--- a/contracts/earn-quest/src/storage.rs
+++ b/contracts/earn-quest/src/storage.rs
@@ -1124,11 +1124,11 @@ pub fn mark_initialized(env: &Env) {
     env.storage().instance().set(&DataKey::Initialized, &true);
 }
 
-pub fn get_admin(env: &Env) -> Address {
+pub fn get_admin(env: &Env) -> Result<Address, Error> {
     env.storage()
         .instance()
         .get(&DataKey::ContractAdmin)
-        .expect("Contract not initialized")
+        .ok_or(Error::NotInitialized)
 }
 
 pub fn set_contract_admin(env: &Env, address: &Address) {

--- a/contracts/earn-quest/tests/test_edge_cases.rs
+++ b/contracts/earn-quest/tests/test_edge_cases.rs
@@ -16,6 +16,7 @@
 
 extern crate earn_quest;
 
+use earn_quest::errors::Error;
 use earn_quest::types::{BatchApprovalInput, BatchQuestInput};
 use earn_quest::validation;
 use earn_quest::{EarnQuestContract, EarnQuestContractClient};
@@ -71,8 +72,17 @@ fn register_quest(
 fn test_initialize_sets_admin_and_roles() {
     let (_env, client, admin, _token) = setup();
 
-    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_admin(), Ok(admin.clone()));
     assert!(client.is_admin(&admin));
+}
+
+#[test]
+fn test_get_admin_before_initialize_returns_not_initialized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_admin(), Err(Error::NotInitialized));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Replace the `get_admin` storage panic with `Error::NotInitialized`
- Expose `get_admin` as a `Result<Address, Error>` so pre-initialization reads fail gracefully
- Keep upgrade authorization conservative by returning `false` when admin storage is missing
- Add regression coverage for calling `get_admin` before initialization

## Validation

- `git diff --check`
- Not run: `cargo fmt --check` / focused `cargo test` because `cargo` is not installed on this machine

Closes #1944.