### PR TITLE
fix(contract): implement reward/oracle deviation check in validate_reward_with_oracle

### DIFF
--- a/contracts/earn-quest/src/errors.rs
+++ b/contracts/earn-quest/src/errors.rs
@@ -130,6 +130,7 @@ pub enum Error {
     StaleOracleData = 104,
     InvalidOracleData = 105,
     LowOracleConfidence = 106,
+    RewardDeviationTooHigh = 107,
 
     // Arithmetic
     ArithmeticOverflow = 110,

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -1442,7 +1442,10 @@ impl EarnQuestContract {
         }
 
         // The oracle-reported fair price, as i128 for comparison.
-        let oracle_price = price.weighted_price.to_u128().ok_or(Error::AmountTooLarge)? as i128;
+        let oracle_price = price
+            .weighted_price
+            .to_u128()
+            .ok_or(Error::AmountTooLarge)? as i128;
 
         check_reward_deviation(reward_amount, oracle_price, max_deviation_percent)
     }

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -25,6 +25,9 @@ mod test_token;
 #[cfg(test)]
 mod test_clawback;
 
+#[cfg(test)]
+mod test_oracle_deviation;
+
 use crate::errors::Error;
 use crate::storage::{get_badge_type, list_badge_types};
 
@@ -48,6 +51,37 @@ fn bump_instance_ttl(env: &Env) {
     env.storage()
         .instance()
         .extend_ttl(crate::ttl::DEFAULT_TTL_THRESHOLD, target);
+}
+
+/// Rejects a reward amount that deviates from the oracle-reported fair price by
+/// more than `max_deviation_percent` percent.
+///
+/// The check is integer-only (no floating point): it rejects when
+/// `|reward_amount - oracle_price| * 100 > oracle_price * max_deviation_percent`.
+/// A deviation exactly equal to `max_deviation_percent` is accepted.
+fn check_reward_deviation(
+    reward_amount: i128,
+    oracle_price: i128,
+    max_deviation_percent: u32,
+) -> Result<(), Error> {
+    if reward_amount < 0 {
+        return Err(Error::InvalidRewardAmount);
+    }
+    if oracle_price <= 0 {
+        return Err(Error::InvalidOracleData);
+    }
+
+    let diff = reward_amount.abs_diff(oracle_price);
+    let lhs = diff.checked_mul(100).ok_or(Error::ArithmeticOverflow)?;
+    let rhs = (oracle_price as u128)
+        .checked_mul(u128::from(max_deviation_percent))
+        .ok_or(Error::ArithmeticOverflow)?;
+
+    if lhs > rhs {
+        return Err(Error::RewardDeviationTooHigh);
+    }
+
+    Ok(())
 }
 
 #[contract]
@@ -1391,25 +1425,26 @@ impl EarnQuestContract {
     /// * `reward_asset` - The asset used for rewards.
     /// * `reward_amount` - The reward amount to validate.
     /// * `reference_asset` - The reference asset (e.g., USD stablecoin).
-    /// * `max_deviation_percent` - Maximum allowed deviation from the oracle price.
+    /// * `max_deviation_percent` - Maximum allowed deviation (in percent) of the
+    ///   reward amount from the oracle-reported price.
     pub fn validate_reward_with_oracle(
         env: Env,
         reward_asset: Address,
-        _reward_amount: i128,
+        reward_amount: i128,
         reference_asset: Address,
-        _max_deviation_percent: u32,
+        max_deviation_percent: u32,
     ) -> Result<(), Error> {
         let price = Self::get_price(env, reward_asset, reference_asset, 300)?;
 
-        // Check if price confidence is sufficient
+        // Reject prices the oracle isn't confident enough about.
         if price.confidence_score < 80 {
             return Err(Error::LowOracleConfidence);
         }
 
-        // Additional validation logic could be added here
-        // For example, checking against historical prices, volatility limits, etc.
+        // The oracle-reported fair price, as i128 for comparison.
+        let oracle_price = price.weighted_price.to_u128().ok_or(Error::AmountTooLarge)? as i128;
 
-        Ok(())
+        check_reward_deviation(reward_amount, oracle_price, max_deviation_percent)
     }
 
     // ─────────────────────────────────────────────────────────────────────────────

--- a/contracts/earn-quest/src/test_oracle_deviation.rs
+++ b/contracts/earn-quest/src/test_oracle_deviation.rs
@@ -1,0 +1,60 @@
+#![cfg(test)]
+
+//! Unit tests for the reward/oracle-price deviation check used by
+//! `validate_reward_with_oracle`.
+
+use crate::check_reward_deviation;
+use crate::errors::Error;
+
+#[test]
+fn within_tolerance_passes() {
+    // Oracle price 1000, reward 1050 -> 5% deviation, 10% allowed.
+    assert!(check_reward_deviation(1050, 1000, 10).is_ok());
+    assert!(check_reward_deviation(950, 1000, 10).is_ok());
+}
+
+#[test]
+fn exact_boundary_passes() {
+    // Exactly 10% deviation on either side is accepted.
+    assert!(check_reward_deviation(1100, 1000, 10).is_ok());
+    assert!(check_reward_deviation(900, 1000, 10).is_ok());
+}
+
+#[test]
+fn exceeding_tolerance_is_rejected() {
+    // 20% deviation with 10% allowed.
+    assert_eq!(
+        check_reward_deviation(1200, 1000, 10),
+        Err(Error::RewardDeviationTooHigh)
+    );
+    // Just over the boundary (10.1%).
+    assert_eq!(
+        check_reward_deviation(1101, 1000, 10),
+        Err(Error::RewardDeviationTooHigh)
+    );
+}
+
+#[test]
+fn zero_percent_rejects_any_difference() {
+    assert!(check_reward_deviation(1000, 1000, 0).is_ok());
+    assert_eq!(
+        check_reward_deviation(1001, 1000, 0),
+        Err(Error::RewardDeviationTooHigh)
+    );
+}
+
+#[test]
+fn negative_reward_is_rejected() {
+    assert_eq!(
+        check_reward_deviation(-1, 1000, 10),
+        Err(Error::InvalidRewardAmount)
+    );
+}
+
+#[test]
+fn non_positive_oracle_price_is_rejected() {
+    assert_eq!(
+        check_reward_deviation(1000, 0, 10),
+        Err(Error::InvalidOracleData)
+    );
+}

--- a/contracts/earn-quest/tests/test_oracle.rs
+++ b/contracts/earn-quest/tests/test_oracle.rs
@@ -603,7 +603,9 @@ fn test_validate_reward_with_oracle_confidence_limits() {
         },
     );
 
-    // Case 1: Oracle confidence is 85. Aggregation avg confidence will be 85 (>= 80 threshold in validate_reward)
+    // Case 1: Oracle confidence is 85 (>= 80 threshold in validate_reward) and
+    // the reward amount matches the oracle price (0% deviation, within the 5%
+    // tolerance), so validation succeeds.
     oracle_client.set_price_data(
         &reward_asset,
         &reference_asset,
@@ -612,7 +614,7 @@ fn test_validate_reward_with_oracle_confidence_limits() {
         &1000,
         &85,
     );
-    client.validate_reward_with_oracle(&reward_asset, &100, &reference_asset, &5);
+    client.validate_reward_with_oracle(&reward_asset, &10_000_000, &reference_asset, &5);
 
     // Case 2: Oracle confidence is 75 (valid for config, but average confidence 75 < 80 threshold in validate_reward)
     oracle_client.set_price_data(


### PR DESCRIPTION
## Summary

`validate_reward_with_oracle` previously prefixed `reward_amount` and
`max_deviation_percent` with `_` and never used them — it only checked
`confidence_score >= 80`, so the anti-manipulation validation its name and
doc comment promised was a silent no-op.

This wires both parameters into a real deviation check:

- After the confidence check, the oracle's `weighted_price` is taken as the
  fair price and compared against `reward_amount`.
- A new integer-only helper `check_reward_deviation` rejects the reward when
  `|reward_amount - oracle_price| * 100 > oracle_price * max_deviation_percent`
  (a deviation exactly equal to `max_deviation_percent` is accepted). It also
  rejects a negative reward (`InvalidRewardAmount`) and a non-positive oracle
  price (`InvalidOracleData`), and guards the multiplications with
  `checked_mul` (`ArithmeticOverflow`).
- Adds a new `Error::RewardDeviationTooHigh = 107` variant.
- Updates the doc comment to describe the actual behavior.

## Tests

`src/test_oracle_deviation.rs` covers the deviation helper directly:
within-tolerance passes, exact-boundary passes (both sides), exceeding
tolerance rejected, `0%` tolerance rejects any difference, negative reward
rejected, and non-positive oracle price rejected.

Closes #1918