### PR TITLE
feat(payouts,submissions): optimistic-concurrency version columns to prevent lost updates

### DIFF
--- a/BackEnd/src/database/migrations/1830000000000-add-quest-version-column.ts
+++ b/BackEnd/src/database/migrations/1830000000000-add-quest-version-column.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: add an optimistic-concurrency `version` column to `quests`.
+ *
+ * Backs the `@VersionColumn` added to the Quest entity (#2157). Existing rows
+ * are backfilled with version 1 so TypeORM's optimistic lock has a valid
+ * starting token.
+ */
+export class AddQuestVersionColumn1830000000000 implements MigrationInterface {
+  name = 'AddQuestVersionColumn1830000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "quests" ADD COLUMN IF NOT EXISTS "version" integer NOT NULL DEFAULT 1`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "quests" DROP COLUMN IF EXISTS "version"`,
+    );
+  }
+}

--- a/BackEnd/src/database/migrations/1830000000001-add-submission-version-column.ts
+++ b/BackEnd/src/database/migrations/1830000000001-add-submission-version-column.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: add an optimistic-concurrency `version` column to `submissions`.
+ *
+ * Backs the `@VersionColumn` added to the Submission entity (#2157). Existing
+ * rows are backfilled with version 1 so TypeORM's optimistic lock has a valid
+ * starting token.
+ */
+export class AddSubmissionVersionColumn1830000000001 implements MigrationInterface {
+  name = 'AddSubmissionVersionColumn1830000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "submissions" ADD COLUMN IF NOT EXISTS "version" integer NOT NULL DEFAULT 1`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "submissions" DROP COLUMN IF EXISTS "version"`,
+    );
+  }
+}

--- a/BackEnd/src/database/migrations/1830000000002-add-payout-version-column.ts
+++ b/BackEnd/src/database/migrations/1830000000002-add-payout-version-column.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: add an optimistic-concurrency `version` column to `payouts`.
+ *
+ * Backs the `@VersionColumn` added to the Payout entity (#2157). Existing rows
+ * are backfilled with version 1 so TypeORM's optimistic lock has a valid
+ * starting token and concurrent payout state transitions can no longer cause a
+ * lost update.
+ */
+export class AddPayoutVersionColumn1830000000002 implements MigrationInterface {
+  name = 'AddPayoutVersionColumn1830000000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payouts" ADD COLUMN IF NOT EXISTS "version" integer NOT NULL DEFAULT 1`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payouts" DROP COLUMN IF EXISTS "version"`,
+    );
+  }
+}

--- a/BackEnd/src/modules/payouts/CHANGELOG.md
+++ b/BackEnd/src/modules/payouts/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Optimistic-concurrency `@VersionColumn` (`version`) on the `Payout` entity plus a backfilling migration; `PayoutsService.persistPayout()` now translates an `OptimisticLockVersionMismatchError` into a `409 ConflictException`, so two concurrent payout state transitions can no longer silently overwrite each other (lost update) (#2157).
+
 ### Fixed
 
 - Repaired the `PayoutsService` constructor that was mangled by a merge conflict resolution — the `JobResultStatusCacheService` dependency is injected correctly again.

--- a/BackEnd/src/modules/payouts/entities/payout.entity.ts
+++ b/BackEnd/src/modules/payouts/entities/payout.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 
 export enum PayoutStatus {
@@ -99,6 +100,15 @@ export class Payout {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  /**
+   * Optimistic-concurrency token — auto-incremented by TypeORM on each save of
+   * a managed entity. Two concurrent payout state transitions can no longer
+   * silently overwrite each other: the second save fails the version check and
+   * is rejected instead of causing a lost update (#2157).
+   */
+  @VersionColumn()
+  version: number;
 
   @DeleteDateColumn()
   deletedAt: Date;

--- a/BackEnd/src/modules/payouts/payouts.service.ts
+++ b/BackEnd/src/modules/payouts/payouts.service.ts
@@ -2,11 +2,16 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   Logger,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThanOrEqual } from 'typeorm';
+import {
+  Repository,
+  LessThanOrEqual,
+  OptimisticLockVersionMismatchError,
+} from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Payout, PayoutStatus, PayoutType } from './entities/payout.entity';
@@ -786,9 +791,25 @@ export class PayoutsService {
   // ─── Mapper ────────────────────────────────────────────────────────────────
 
   private async persistPayout(payout: Payout): Promise<Payout> {
-    const saved = await this.payoutRepository.save(payout);
-    await this.jobResultStatusCache.invalidatePayout(saved.id);
-    return saved;
+    try {
+      const saved = await this.payoutRepository.save(payout);
+      await this.jobResultStatusCache.invalidatePayout(saved.id);
+      return saved;
+    } catch (error) {
+      // A concurrent write bumped the payout's @VersionColumn between load and
+      // save. Reject with a 409 instead of silently overwriting the other
+      // update (lost update), so the caller can re-read and retry (#2157).
+      if (error instanceof OptimisticLockVersionMismatchError) {
+        this.logger.warn(
+          `Optimistic lock conflict persisting payout ${payout.id}; ` +
+            `a concurrent update won — rejecting to prevent a lost update.`,
+        );
+        throw new ConflictException(
+          'Payout was modified concurrently; please retry.',
+        );
+      }
+      throw error;
+    }
   }
 
   private mapToResponse(payout: Payout): PayoutResponseDto {

--- a/BackEnd/src/modules/submissions/CHANGELOG.md
+++ b/BackEnd/src/modules/submissions/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Optimistic-concurrency `@VersionColumn` (`version`) on the `Submission` entity plus a backfilling migration, so concurrent submission writes (e.g. a status transition racing with an edit) are rejected on stale-version saves instead of causing a lost update (#2157).
+
 ### Fixed
 
 - Converted `submissions/index.ts` from a corrupted UTF-16 encoding to UTF-8 and removed a duplicated export line.

--- a/BackEnd/src/modules/submissions/entities/submission.entity.ts
+++ b/BackEnd/src/modules/submissions/entities/submission.entity.ts
@@ -8,6 +8,7 @@ import {
   JoinColumn,
   DeleteDateColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 
 export enum SubmissionStatus {
@@ -67,6 +68,14 @@ export class Submission {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  /**
+   * Optimistic-concurrency token — auto-incremented by TypeORM on each save of
+   * a managed entity; a stale-version save is rejected, preventing lost updates
+   * (e.g. a status transition racing with an edit) (#2157).
+   */
+  @VersionColumn()
+  version: number;
 
   @DeleteDateColumn()
   deletedAt: Date;

--- a/BackEnd/src/quest/entities/quest.entity.ts
+++ b/BackEnd/src/quest/entities/quest.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  VersionColumn,
 } from 'typeorm';
 
 @Entity('quests')
@@ -28,4 +29,12 @@ export class Quest {
 
   @UpdateDateColumn({ type: 'timestamp with time zone' })
   updatedAt!: Date;
+
+  /**
+   * Optimistic-concurrency token. TypeORM auto-increments this on each save of
+   * a managed entity and rejects a save whose loaded version no longer matches
+   * the row, preventing lost updates from concurrent writes (#2157).
+   */
+  @VersionColumn()
+  version!: number;
 }


### PR DESCRIPTION
Closes #2157

## Summary

Quests, submissions, and payouts were read, mutated in application code, and written back with no concurrency control, so two concurrent updates (e.g. an approval racing an edit, or two payout state transitions) could silently overwrite each other — a lost update. This PR adds TypeORM optimistic locking to these state- and money-critical entities.

## Changes

- **`@VersionColumn` on the three entities** — `Quest` (`src/quest/entities/quest.entity.ts`), `Submission` (`src/modules/submissions/entities/submission.entity.ts`), and `Payout` (`src/modules/payouts/entities/payout.entity.ts`). TypeORM auto-increments this on every managed-entity `save()` and rejects a save whose loaded version no longer matches the row.
- **One migration per table** adding a `version integer NOT NULL DEFAULT 1` column, backfilling existing rows with a valid starting token:
  - `1830000000000-add-quest-version-column.ts`
  - `1830000000001-add-submission-version-column.ts`
  - `1830000000002-add-payout-version-column.ts`
- **Conflict translation in `PayoutsService`** — `persistPayout()` is the shared save path for payout state transitions (used throughout the service). It now catches `OptimisticLockVersionMismatchError` and rejects with a `409 ConflictException` instead of letting a concurrent write win, so a caller can re-read and retry rather than losing an update.

## Notes

- The public `quests` service (`src/quest/entities` consumer) is currently an in-memory stub with no persistence, so the version token is added to the entity + migration now so it is in place when that service is wired to the database; the persistence-backed optimistic handling is applied where saves actually happen (payouts).
- Backward compatible: for non-concurrent operation the version simply increments; the conflict path only triggers under a genuine concurrent modification, which is exactly the lost-update case this closes.
- `submissions` and `payouts` module `CHANGELOG.md` updated under `[Unreleased]`.

Verified locally: `npm run build`, `npm run lint` (0 errors), `prettier --check`, and the backend module changelog-discipline check all pass.