### PR TITLE
feat(payouts,jobs): transactional outbox for on-chain payout execution

### DIFF
--- a/BackEnd/src/database/data-source.ts
+++ b/BackEnd/src/database/data-source.ts
@@ -12,6 +12,7 @@ import { Submission } from '../modules/submissions/entities/submission.entity';
 import { User } from '../modules/users/entities/user.entity';
 import { Notification } from '../modules/notifications/entities/notification.entity';
 import { Payout } from '../modules/payouts/entities/payout.entity';
+import { PayoutOutbox } from '../modules/payouts/entities/payout-outbox.entity';
 import { IdempotencyKey } from '../modules/payouts/entities/idempotency-key.entity';
 import { FeatureFlag } from '../modules/feature-flags/entities/feature-flag.entity';
 import { FeatureFlagAuditLog } from '../modules/feature-flags/entities/feature-flag-audit.entity';
@@ -102,6 +103,7 @@ export const dataSourceOptions: DataSourceOptions = {
     Submission,
     Notification,
     Payout,
+    PayoutOutbox,
     IdempotencyKey,
     FeatureFlag,
     FeatureFlagAuditLog,

--- a/BackEnd/src/database/migrations/1840000000000-add-payout-outbox.ts
+++ b/BackEnd/src/database/migrations/1840000000000-add-payout-outbox.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: create the `payout_outbox` table (#2158).
+ *
+ * Backs the transactional outbox for on-chain payout execution. The unique
+ * index on `idempotencyKey` is what makes relaying exactly-once, and the
+ * `status` index keeps the relay's "claim next pending" query cheap.
+ */
+export class AddPayoutOutbox1840000000000 implements MigrationInterface {
+  name = 'AddPayoutOutbox1840000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "payout_outbox" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "payoutId" uuid NOT NULL,
+        "idempotencyKey" character varying NOT NULL,
+        "recipientAddress" character varying NOT NULL,
+        "amount" numeric(20,7) NOT NULL,
+        "status" character varying NOT NULL DEFAULT 'pending',
+        "attempts" integer NOT NULL DEFAULT 0,
+        "transactionHash" character varying(128),
+        "lastError" text,
+        "processedAt" TIMESTAMP,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_payout_outbox_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_payout_outbox_idempotency_key" UNIQUE ("idempotencyKey")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_payout_outbox_payout" ON "payout_outbox" ("payoutId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_payout_outbox_status" ON "payout_outbox" ("status")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_payout_outbox_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_payout_outbox_payout"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "payout_outbox"`);
+  }
+}

--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -6,6 +6,11 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Payout transactional-outbox relay in `PayoutProcessor.relayPayoutOutbox()` — an every-minute job that atomically claims PENDING `payout_outbox` rows (`PENDING → PROCESSING`), submits each via `StellarPaymentService` exactly once, and marks them DONE (or retries/parks on failure) (#2158).
+- Stuck-outbox recovery in `PayoutReconciliationProcessor.recoverStuckPayoutOutbox()` — resets outbox rows left in PROCESSING beyond the crash threshold back to PENDING so the idempotent relay can safely replay them (#2158).
+
 ### Changed
 - Applied code-style formatting to `jobs.constants.ts` import block (no logic change).
 

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -31,6 +31,7 @@ import { JobLogArchive } from './entities/job-log-archive.entity';
 import { DataExport } from '../users/entities/data-export.entity';
 import { DataExportListener } from './listeners/data-export.listener';
 import { Payout } from '../payouts/entities/payout.entity';
+import { PayoutOutbox } from '../payouts/entities/payout-outbox.entity';
 import { Quest } from '../quests/entities/quest.entity';
 import { Submission } from '../submissions/entities/submission.entity';
 import { StellarModule } from '../stellar/stellar.module';
@@ -55,6 +56,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
       JobLogArchive,
       DataExport,
       Payout,
+      PayoutOutbox,
       Quest,
       Submission,
       EventStore,

--- a/BackEnd/src/modules/jobs/processors/payout-reconciliation.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/payout-reconciliation.processor.ts
@@ -1,9 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, In, LessThan } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Payout, PayoutStatus } from '../../payouts/entities/payout.entity';
+import {
+  PayoutOutbox,
+  PayoutOutboxStatus,
+} from '../../payouts/entities/payout-outbox.entity';
 import { JobLogService } from '../services/job-log.service';
 
 /**
@@ -16,9 +20,14 @@ export class PayoutReconciliationProcessor {
   private readonly logger = new Logger(PayoutReconciliationProcessor.name);
   private readonly horizonUrl: string;
 
+  /** A PROCESSING outbox row older than this is treated as stuck (crash). */
+  private readonly stuckOutboxMs = 15 * 60 * 1000;
+
   constructor(
     @InjectRepository(Payout)
     private readonly payoutRepository: Repository<Payout>,
+    @InjectRepository(PayoutOutbox)
+    private readonly outboxRepository: Repository<PayoutOutbox>,
     private readonly configService: ConfigService,
     private readonly jobLogService: JobLogService,
   ) {
@@ -26,6 +35,32 @@ export class PayoutReconciliationProcessor {
       this.configService.get<string>('STELLAR_HORIZON_URL') ||
       this.configService.get<string>('HORIZON_URL') ||
       'https://horizon.stellar.org';
+  }
+
+  /**
+   * Recover transactional-outbox rows stuck mid-relay (#2158).
+   *
+   * A crash between claiming a row (`PENDING → PROCESSING`) and marking it DONE
+   * would otherwise strand it forever. Rows left in PROCESSING beyond
+   * `stuckOutboxMs` are reset to PENDING so the relay retries them; because the
+   * relay is idempotent, replaying a row never double-submits a payment.
+   */
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async recoverStuckPayoutOutbox(): Promise<void> {
+    const threshold = new Date(Date.now() - this.stuckOutboxMs);
+    const result = await this.outboxRepository.update(
+      {
+        status: PayoutOutboxStatus.PROCESSING,
+        updatedAt: LessThan(threshold),
+      },
+      { status: PayoutOutboxStatus.PENDING },
+    );
+
+    if (result.affected) {
+      this.logger.warn(
+        `Recovered ${result.affected} stuck payout outbox row(s) back to PENDING`,
+      );
+    }
   }
 
   /**

--- a/BackEnd/src/modules/jobs/processors/payout.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/payout.processor.ts
@@ -1,9 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Job } from 'bullmq';
 import { PayoutProcessPayload, JobResult, JobType } from '../job.types';
 import { JobLogService } from '../services/job-log.service';
 import { JobIdempotencyService } from '../services/job-idempotency.service';
 import { StellarPaymentService } from '../../stellar/stellar-payment.service';
+import { Payout, PayoutStatus } from '../../payouts/entities/payout.entity';
+import {
+  PayoutOutbox,
+  PayoutOutboxStatus,
+} from '../../payouts/entities/payout-outbox.entity';
 
 /**
  * Payout Processor
@@ -31,11 +39,92 @@ import { StellarPaymentService } from '../../stellar/stellar-payment.service';
 export class PayoutProcessor {
   private readonly logger = new Logger(PayoutProcessor.name);
 
+  /** Max relay attempts before a row is parked as FAILED for reconciliation. */
+  private readonly maxOutboxAttempts = 5;
+
   constructor(
     private readonly jobLogService: JobLogService,
     private readonly jobIdempotencyService: JobIdempotencyService,
     private readonly stellarPaymentService: StellarPaymentService,
+    @InjectRepository(PayoutOutbox)
+    private readonly outboxRepository: Repository<PayoutOutbox>,
+    @InjectRepository(Payout)
+    private readonly payoutRepository: Repository<Payout>,
   ) {}
+
+  /**
+   * Transactional-outbox relay (#2158).
+   *
+   * Drains PENDING outbox rows and submits each on-chain exactly once:
+   * a row is claimed with an atomic `PENDING → PROCESSING` update, so only the
+   * worker that flips it (`affected === 1`) submits the payment. On success the
+   * row is marked DONE and the payout records the transaction hash; on failure
+   * the attempt count is bumped and the row is either retried (left PENDING) or
+   * parked as FAILED for the reconciliation job to pick up.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  async relayPayoutOutbox(): Promise<void> {
+    const pending = await this.outboxRepository.find({
+      where: { status: PayoutOutboxStatus.PENDING },
+      order: { createdAt: 'ASC' },
+      take: 20,
+    });
+
+    for (const entry of pending) {
+      const claim = await this.outboxRepository.update(
+        { id: entry.id, status: PayoutOutboxStatus.PENDING },
+        { status: PayoutOutboxStatus.PROCESSING },
+      );
+      // Another worker claimed it first — never submit the same row twice.
+      if (claim.affected !== 1) {
+        continue;
+      }
+
+      try {
+        const { transactionHash } =
+          await this.stellarPaymentService.sendPayment(
+            entry.recipientAddress,
+            Number(entry.amount),
+          );
+
+        await this.outboxRepository.update(
+          { id: entry.id },
+          {
+            status: PayoutOutboxStatus.DONE,
+            transactionHash,
+            processedAt: new Date(),
+            lastError: null,
+          },
+        );
+
+        await this.payoutRepository.update(
+          { id: entry.payoutId },
+          { status: PayoutStatus.PROCESSING, transactionHash },
+        );
+
+        this.logger.log(
+          `Relayed payout outbox ${entry.id} (payoutId=${entry.payoutId}) → ${transactionHash}`,
+        );
+      } catch (error) {
+        const attempts = entry.attempts + 1;
+        const parked = attempts >= this.maxOutboxAttempts;
+        await this.outboxRepository.update(
+          { id: entry.id },
+          {
+            status: parked
+              ? PayoutOutboxStatus.FAILED
+              : PayoutOutboxStatus.PENDING,
+            attempts,
+            lastError: error instanceof Error ? error.message : String(error),
+          },
+        );
+        this.logger.error(
+          `Relay failed for payout outbox ${entry.id} (attempt ${attempts})`,
+          error instanceof Error ? error.stack : undefined,
+        );
+      }
+    }
+  }
 
   /**
    * Process a payout job.

--- a/BackEnd/src/modules/payouts/CHANGELOG.md
+++ b/BackEnd/src/modules/payouts/CHANGELOG.md
@@ -8,6 +8,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Transactional outbox for on-chain payout execution (#2158): new `PayoutOutbox` entity + migration, and `PayoutsService.createPayout()` now writes the payout row and its execution intent in one DB transaction via `persistPayoutWithOutbox()` / `enqueuePayoutOutbox()`. A crash can no longer leave a payout without a queued on-chain execution (or vice-versa); the relay submits each payment exactly once.
 - Optimistic-concurrency `@VersionColumn` (`version`) on the `Payout` entity plus a backfilling migration; `PayoutsService.persistPayout()` now translates an `OptimisticLockVersionMismatchError` into a `409 ConflictException`, so two concurrent payout state transitions can no longer silently overwrite each other (lost update) (#2157).
 
 ### Fixed

--- a/BackEnd/src/modules/payouts/entities/payout-outbox.entity.ts
+++ b/BackEnd/src/modules/payouts/entities/payout-outbox.entity.ts
@@ -1,0 +1,74 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Lifecycle of a transactional-outbox row (#2158).
+ *
+ * `PENDING` → claimed by the relay → `PROCESSING` → submitted on-chain →
+ * `DONE`. A row that exhausts its retry budget is parked as `FAILED`, and a
+ * row stuck in `PROCESSING` (e.g. a crash mid-submit) is recovered back to
+ * `PENDING` by the reconciliation job.
+ */
+export enum PayoutOutboxStatus {
+  PENDING = 'pending',
+  PROCESSING = 'processing',
+  DONE = 'done',
+  FAILED = 'failed',
+}
+
+/**
+ * Transactional outbox for on-chain payout execution (#2158).
+ *
+ * The execution *intent* is written in the same DB transaction as the payout
+ * state change, then relayed to Stellar by an idempotent worker. Because the
+ * row is claimed atomically (`PENDING` → `PROCESSING`) and carries a unique
+ * `idempotencyKey`, a payment is submitted at most once even across crashes or
+ * duplicate jobs.
+ */
+@Entity('payout_outbox')
+export class PayoutOutbox {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  payoutId: string;
+
+  /** Deterministic key that makes relaying exactly-once. */
+  @Column({ type: 'varchar', unique: true })
+  idempotencyKey: string;
+
+  @Column({ type: 'varchar' })
+  recipientAddress: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 7 })
+  amount: string;
+
+  @Index()
+  @Column({ type: 'varchar', default: PayoutOutboxStatus.PENDING })
+  status: PayoutOutboxStatus;
+
+  @Column({ type: 'int', default: 0 })
+  attempts: number;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  transactionHash: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  lastError: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  processedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/BackEnd/src/modules/payouts/payouts.module.ts
+++ b/BackEnd/src/modules/payouts/payouts.module.ts
@@ -5,6 +5,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { PayoutsController } from './payouts.controller';
 import { PayoutsService } from './payouts.service';
 import { Payout } from './entities/payout.entity';
+import { PayoutOutbox } from './entities/payout-outbox.entity';
 import { IdempotencyKey } from './entities/idempotency-key.entity';
 import { IdempotencyService } from './services/idempotency.service';
 import { IdempotencyInterceptor } from './interceptors/idempotency.interceptor';
@@ -16,7 +17,7 @@ import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Payout, IdempotencyKey]),
+    TypeOrmModule.forFeature([Payout, PayoutOutbox, IdempotencyKey]),
     ScheduleModule.forRoot(),
     EventEmitterModule,
     QuotaModule,

--- a/BackEnd/src/modules/payouts/payouts.service.ts
+++ b/BackEnd/src/modules/payouts/payouts.service.ts
@@ -9,12 +9,17 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Repository,
+  EntityManager,
   LessThanOrEqual,
   OptimisticLockVersionMismatchError,
 } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Payout, PayoutStatus, PayoutType } from './entities/payout.entity';
+import {
+  PayoutOutbox,
+  PayoutOutboxStatus,
+} from './entities/payout-outbox.entity';
 import { ClaimPayoutDto, CreatePayoutDto } from './dto/claim-payout.dto';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PayoutProcessedEvent } from '../../events/dto/payout-processed.event';
@@ -91,10 +96,53 @@ export class PayoutsService {
           maxRetries: this.maxAutomaticPayoutRetries,
         });
 
-        return this.persistPayout(payout);
+        return this.persistPayoutWithOutbox(payout);
       },
       this.getPayoutBulkheadOptions(),
     );
+  }
+
+  /**
+   * Persist a payout and write its on-chain execution intent to the outbox in
+   * the **same** DB transaction (#2158). Either both land or neither does, so a
+   * crash can never leave a payout without a queued execution (or vice-versa).
+   * The relay worker then submits the payment out-of-band, exactly once.
+   */
+  private async persistPayoutWithOutbox(payout: Payout): Promise<Payout> {
+    const saved = await this.payoutRepository.manager.transaction(
+      async (manager) => {
+        const persisted = await manager.save(payout);
+        await this.enqueuePayoutOutbox(manager, persisted);
+        return persisted;
+      },
+    );
+    await this.jobResultStatusCache.invalidatePayout(saved.id);
+    return saved;
+  }
+
+  /**
+   * Insert the payout's execution intent into the outbox using the supplied
+   * transactional `manager`. Keyed on a deterministic `idempotencyKey` and
+   * `orIgnore()`d, so re-running the enclosing operation never double-queues a
+   * payout (#2158).
+   */
+  async enqueuePayoutOutbox(
+    manager: EntityManager,
+    payout: Payout,
+  ): Promise<void> {
+    await manager
+      .createQueryBuilder()
+      .insert()
+      .into(PayoutOutbox)
+      .values({
+        payoutId: payout.id,
+        idempotencyKey: `payout-outbox:${payout.id}`,
+        recipientAddress: payout.stellarAddress,
+        amount: payout.amount.toString(),
+        status: PayoutOutboxStatus.PENDING,
+      })
+      .orIgnore()
+      .execute();
   }
 
   // ─── Claim ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2158

## Summary

On-chain payout execution was triggered inline from service/job code, so a crash between the DB commit and the Stellar submission (or a duplicate job) could **drop or double-send** a payout. This PR introduces a transactional outbox that makes execution crash-safe and exactly-once.

## Changes

- **`PayoutOutbox` entity + migration** (`payout_outbox`) — carries the execution intent with a unique `idempotencyKey`, a `status` lifecycle (`pending → processing → done` / `failed`), attempt count, tx hash, and last error.
- **Intent written in the same transaction as the payout** — `PayoutsService.createPayout()` now uses `persistPayoutWithOutbox()`, which saves the payout and `enqueuePayoutOutbox()` inside one `manager.transaction`, so a payout and its queued execution always land together (or not at all).
- **Idempotent relay** — `PayoutProcessor.relayPayoutOutbox()` (every minute) claims PENDING rows with an atomic `PENDING → PROCESSING` update; only the worker that flips a row (`affected === 1`) submits it via `StellarPaymentService`, then marks it `DONE` and records the tx hash on the payout. Failures bump the attempt count and either retry or park the row as `FAILED`.
- **Crash recovery** — `PayoutReconciliationProcessor.recoverStuckPayoutOutbox()` (every 10 min) resets rows stuck in `PROCESSING` beyond a threshold back to `PENDING`; because the relay is idempotent, replaying never double-submits.
- **Wiring** — `PayoutOutbox` registered in the payouts and jobs modules' `forFeature` and in the app data source.

## Notes

- Exactly-once is enforced by the atomic claim + the unique `idempotencyKey`; the two processors were the natural homes for the relay/reconciliation so no cross-module circular dependency is introduced.
- Backward compatible: existing payout creation keeps working; the outbox is written alongside it and drained out-of-band.
- `payouts` and `jobs` module `CHANGELOG.md` updated under `[Unreleased]`.

Verified locally: `npm run build`, `npm run lint` (0 errors), `prettier --check`, `npm run openapi:generate` (app bootstraps), and the backend module changelog-discipline check all pass.