### PR TITLE
fix(earn-quest)!: return Error::NotInitialized instead of panicking in get_admin

### DIFF
--- a/contracts/earn-quest/API_DOCUMENTATION.md
+++ b/contracts/earn-quest/API_DOCUMENTATION.md
@@ -106,12 +106,12 @@ let version = client.get_version();
 
 ### get_admin
 ```rust
-pub fn get_admin(env: Env) -> Address
+pub fn get_admin(env: Env) -> Result<Address, Error>
 ```
-Retrieves the contract administrator address.
+Retrieves the contract administrator address. Returns `Err(Error::NotInitialized)` if the contract has not been initialized yet.
 **Example:**
 ```rust
-let admin = client.get_admin();
+let admin = client.try_get_admin()?;
 ```
 
 ---

--- a/contracts/earn-quest/CHANGELOG.md
+++ b/contracts/earn-quest/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Quest registration now increments platform stats counters (`total_quests_created`, `total_rewards_distributed`).
 - Resolved appealed disputes no longer call `require_auth` twice on the admin arbitrator, which caused `Auth(ExistingValue)` failures.
+- `get_admin` no longer panics with `.expect("Contract not initialized")` when the contract has not been initialized; it now returns `Error::NotInitialized` (code 93).
 
 ### Added
 
@@ -22,6 +23,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Initialized this changelog so future contract releases have a single source of truth.
 - Added `gas_budget.rs` module defining explicit instruction-count ceilings per entrypoint (`init`, `reg_qst`, `sub_prf`, `appr_sub`, `clm_rwd`) and a `within_budget` helper for regression checks.
 - Minimum creator level requirement and creator whitelist. Admin can set a level threshold (default 0 = disabled); quest creation fails if the creator's XP level is below it. Whitelisted addresses bypass the check.
+
+### Breaking Changes
+
+#### Contract - `get_admin` returns `Result<Address, Error>` instead of panicking
+- **Impact**: The public `get_admin` entrypoint now returns `Result<Address, Error>` (via `ok_or(Error::NotInitialized)`) instead of a bare `Address`. Clients and contracts that invoke `get_admin` on an uninitialized contract previously triggered a panic; they now receive a graceful `Error::NotInitialized` (code 93).
+- **Affected Files**: [storage.rs](contracts/earn-quest/src/storage.rs), [lib.rs](contracts/earn-quest/src/lib.rs), [init.rs](contracts/earn-quest/src/init.rs)
+- **Migration Required**: No storage migration required. Integrations reading the admin address should switch to the `try_get_admin` client method (or otherwise handle the `Result`) and treat `Error::NotInitialized` as the uninitialized-state error.
 
 ---
 

--- a/contracts/earn-quest/src/init.rs
+++ b/contracts/earn-quest/src/init.rs
@@ -23,6 +23,5 @@ pub fn initialize(env: &Env, config: InitConfig) {
 }
 
 pub fn upgrade_authorize(env: &Env, caller: &Address) -> bool {
-    let admin = storage::get_admin(env);
-    caller == &admin
+    storage::get_admin(env).is_ok_and(|admin| caller == &admin)
 }

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -156,14 +156,15 @@ impl EarnQuestContract {
     ///
     /// # Returns
     ///
-    /// The `Address` of the current contract administrator.
+    /// `Ok(admin)` with the `Address` of the current contract administrator, or
+    /// `Err(Error::NotInitialized)` if the contract has not been initialized yet.
     ///
     /// # Example
     ///
     /// ```rust
-    /// let admin = client.get_admin();
+    /// let admin = client.try_get_admin()?;
     /// ```
-    pub fn get_admin(env: Env) -> Address {
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
         storage::get_admin(&env)
     }
 

--- a/contracts/earn-quest/src/storage.rs
+++ b/contracts/earn-quest/src/storage.rs
@@ -1124,11 +1124,11 @@ pub fn mark_initialized(env: &Env) {
     env.storage().instance().set(&DataKey::Initialized, &true);
 }
 
-pub fn get_admin(env: &Env) -> Address {
+pub fn get_admin(env: &Env) -> Result<Address, Error> {
     env.storage()
         .instance()
         .get(&DataKey::ContractAdmin)
-        .expect("Contract not initialized")
+        .ok_or(Error::NotInitialized)
 }
 
 pub fn set_contract_admin(env: &Env, address: &Address) {

--- a/contracts/earn-quest/test_snapshots/test_get_admin_before_initialization_returns_not_initialized.1.json
+++ b/contracts/earn-quest/test_snapshots/test_get_admin_before_initialization_returns_not_initialized.1.json
@@ -1,0 +1,185 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_admin"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_admin"
+              }
+            ],
+            "data": {
+              "error": {
+                "contract": 93
+              }
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 93
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating Ok(ScErrorType::Contract) frame-exit to Err"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 93
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_admin"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/earn-quest/tests/test_edge_cases.rs
+++ b/contracts/earn-quest/tests/test_edge_cases.rs
@@ -16,6 +16,7 @@
 
 extern crate earn_quest;
 
+use earn_quest::errors::Error;
 use earn_quest::types::{BatchApprovalInput, BatchQuestInput};
 use earn_quest::validation;
 use earn_quest::{EarnQuestContract, EarnQuestContractClient};
@@ -73,6 +74,22 @@ fn test_initialize_sets_admin_and_roles() {
 
     assert_eq!(client.get_admin(), admin);
     assert!(client.is_admin(&admin));
+}
+
+#[test]
+fn test_get_admin_before_initialization_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    // Reading the admin before initialization must surface Error::NotInitialized
+    // instead of panicking on missing contract state.
+    assert!(matches!(
+        client.try_get_admin(),
+        Err(Ok(Error::NotInitialized))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1944

---

## Description

**What changed?**

`storage::get_admin` no longer panics via `.expect("Contract not initialized")`. It now returns `Result<Address, Error>` using `ok_or(Error::NotInitialized)`, and the public `get_admin` entrypoint propagates that result. The internal `upgrade_authorize` helper treats an uninitialized contract as unauthorized instead of panicking.

**Why was it changed?**

Reading contract state before initialization used to panic, which is inconsistent with the `Result<_, Error>`-based error model used everywhere else in the contract. Callers now get a graceful, well-defined `Error::NotInitialized` (code 93) instead of an unrecoverable panic.

**How was it implemented?**

- `src/storage.rs`: `get_admin` now returns `Result<Address, Error>` via `.ok_or(Error::NotInitialized)`.
- `src/lib.rs`: the `get_admin` entrypoint signature and doc comment updated to `Result<Address, Error>`.
- `src/init.rs`: `upgrade_authorize` uses `is_ok_and(...)` so an uninitialized contract simply fails authorization.
- `tests/test_edge_cases.rs`: added `test_get_admin_before_initialization_returns_not_initialized`, which invokes `get_admin` before initialization and asserts `Error::NotInitialized` (no panic). Added a deterministic test snapshot capturing the graceful error.
- `API_DOCUMENTATION.md` and `CHANGELOG.md` updated to reflect the new return type.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Security fix
- [ ] Refactor (no functional change)
- [x] Documentation update
- [x] Tests only
- [ ] Configuration / DevOps change

---

## Contract Changelog Discipline

> **Required for changes under `contracts/earn-quest/src/**` or any contract storage, event, or interface change.**

- [ ] No contract implementation changes - not applicable
- [x] Updated `contracts/earn-quest/CHANGELOG.md` under `## [Unreleased]`
- [x] If breaking, added a `### Breaking Changes` entry with impact, affected files, and migration steps
- [x] If breaking, used Conventional Commit breaking metadata (`type(scope)!:`) in the PR title or commit history
- [x] If breaking, included a `BREAKING CHANGE:` explanation below

**BREAKING CHANGE details (required for breaking contract changes):**

```text
BREAKING CHANGE: get_admin now returns Result<Address, Error> instead of a bare Address. Integrations should use the try_get_admin client method or handle the Result; reading the admin on an uninitialized contract now returns Error::NotInitialized (code 93) instead of panicking. No storage migration is required.
```

---

## Test Evidence

> **Required:** All PRs must include test evidence. PRs missing this section will be blocked from merging.

### Unit Tests

- [x] New unit tests added for changed logic
- [x] All existing unit tests pass (`cargo test`)
- [ ] Coverage does not regress (`npm run test:cov`) — N/A (Rust contract; no coverage gate)

**Test output / screenshot:**

```text
$ cargo test test_get_admin_before_initialization_returns_not_initialized
running 1 test
test test_get_admin_before_initialization_returns_not_initialized ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 43 filtered out

$ cargo test
... all suites pass (0 failures) ...

$ cargo fmt --all -- --check        # ok
$ cargo clippy --all-targets --all-features -- -D warnings   # ok
$ cargo build --release --target wasm32-unknown-unknown      # ok
$ cargo test test_gas_regression    # ok (no gas regression)
```

### E2E / Integration Tests

- [x] E2E tests added or updated — the new test exercises the contract entrypoint before initialization via the Soroban test client
- [ ] Tested manually against a local environment — N/A (no network interaction required)

---

## Swagger / API Documentation

> **Required for any endpoint changes.**

- [x] No API changes - Swagger update not applicable (Soroban contract entrypoint; `API_DOCUMENTATION.md` updated instead)

---

## Database / Migration

- [x] No database changes - not applicable

---

## Final Pre-Merge Checklist

- [x] Branch is up to date with `main` / `master`
- [x] Linting passes (`cargo clippy`)
- [x] Formatting passes (`cargo fmt --check`)
- [x] No `console.log` / debug statements left in production code
- [x] No hardcoded secrets, API keys, or environment-specific values in source code
- [x] Self-review completed - I have read through every line of the diff

---

## Additional Notes for Reviewer

The `get_admin` return-type change is the only public interface change. Note that the soroban-sdk generated test client exposes both `get_admin` (unwrapped `Address`, panics on error) and `try_get_admin` (full `Result`), so existing test call sites remain source-compatible. The new test deliberately uses `try_get_admin` to assert the graceful `Error::NotInitialized` path.
