### PR TITLE
perf(wallet): memoize WalletContext value to prevent unnecessary consumer re-renders

### DIFF
--- a/FrontEnd/my-app/context/WalletContext.memo.test.tsx
+++ b/FrontEnd/my-app/context/WalletContext.memo.test.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { useSyncExternalStore } from 'react';
+import { WalletProvider, useWallet } from './WalletContext';
+
+// ── Regression tests for #2149 ──────────────────────────────────────────────
+// The provider used to allocate a fresh context `value` object (plus fresh
+// callback and supportedWallets identities) on every render, forcing every
+// useWallet() consumer to re-render whenever the provider re-rendered — even
+// when no exposed wallet state had changed. These tests pin the memoized
+// behaviour: consumers must bail out when nothing they read has changed, and
+// must still update when real wallet state changes.
+
+const { mockStoreState, mockStoreActions, emitStoreChange, subscribeStore } =
+  vi.hoisted(() => {
+    const listeners = new Set<() => void>();
+    const subscribeStore = (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    };
+    const emitStoreChange = () => {
+      listeners.forEach((l) => l());
+    };
+
+    const mockStoreState: Record<string, any> = {};
+    const mockStoreActions = {
+      setWalletAddress: vi.fn(),
+      setIsConnecting: vi.fn(),
+      setIsVerifyingWallet: vi.fn(),
+      setSelectedWalletId: vi.fn(),
+      setWalletModalOpen: vi.fn(),
+      setWalletError: vi.fn(),
+      disconnectWallet: vi.fn(),
+    };
+
+    return {
+      mockStoreState,
+      mockStoreActions,
+      emitStoreChange,
+      subscribeStore,
+    };
+  });
+
+vi.mock('../lib/store', () => ({
+  useStore: Object.assign(
+    (selector?: any) =>
+      useSyncExternalStore(
+        subscribeStore,
+        () => (selector ? selector(mockStoreState) : mockStoreState),
+        () => (selector ? selector(mockStoreState) : mockStoreState)
+      ),
+    {
+      getState: () => mockStoreState,
+      persist: { hasHydrated: () => true, onFinishHydration: () => () => {} },
+    }
+  ),
+}));
+
+vi.mock('../lib/hooks/useHydrated', () => ({ useHydrated: () => true }));
+vi.mock('../lib/api/auth', () => ({ logout: vi.fn() }));
+vi.mock('@creit.tech/stellar-wallets-kit', () => ({
+  StellarWalletsKit: vi.fn(),
+  WalletNetwork: { TESTNET: 'testnet' },
+  FREIGHTER_ID: 'freighter',
+  allowAllModules: () => [],
+}));
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+/**
+ * Consumer that records every committed render: how many times it rendered
+ * and which context object identity it saw.
+ */
+function makeConsumer() {
+  const samples: { value: ReturnType<typeof useWallet> }[] = [];
+
+  function Consumer() {
+    const value = useWallet();
+    // No dep array — runs after every committed render of this component.
+    useEffect(() => {
+      samples.push({ value });
+    });
+    return <div data-testid="consumer">{value.address ?? 'none'}</div>;
+  }
+
+  return { Consumer, samples };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(mockStoreState, {
+    address: null,
+    isConnected: false,
+    isConnecting: false,
+    isVerifyingWallet: false,
+    selectedWalletId: null,
+    isModalOpen: false,
+    walletError: null,
+  });
+  Object.assign(mockStoreState, mockStoreActions);
+});
+
+describe('WalletProvider — memoized context value (#2149)', () => {
+  it('does not re-render consumers when the provider re-renders with unchanged wallet state', () => {
+    const { Consumer, samples } = makeConsumer();
+
+    // Stable children element identity across parent re-renders mirrors a
+    // real app tree, where the provider's children come from above and do
+    // not change when the provider itself re-renders.
+    const children = <Consumer />;
+
+    function App({ tick }: { tick: number }) {
+      return (
+        <div data-tick={tick}>
+          <WalletProvider>{children}</WalletProvider>
+        </div>
+      );
+    }
+
+    const view = render(<App tick={0} />);
+    expect(samples).toHaveLength(1);
+
+    // 25 unrelated parent re-renders — none of them touch wallet state.
+    for (let tick = 1; tick <= 25; tick++) {
+      act(() => {
+        view.rerender(<App tick={tick} />);
+      });
+    }
+
+    // The consumer mounted once and never re-committed: the memoized value
+    // kept its identity, so React could bail out of the subtree.
+    expect(samples).toHaveLength(1);
+  });
+
+  it('keeps callback identities stable across provider re-renders with unchanged state', () => {
+    const { Consumer, samples } = makeConsumer();
+    const children = <Consumer />;
+
+    function App({ tick }: { tick: number }) {
+      return (
+        <div data-tick={tick}>
+          <WalletProvider>{children}</WalletProvider>
+        </div>
+      );
+    }
+
+    const view = render(<App tick={0} />);
+    for (let tick = 1; tick <= 10; tick++) {
+      act(() => {
+        view.rerender(<App tick={tick} />);
+      });
+    }
+
+    expect(samples.length).toBeGreaterThanOrEqual(1);
+    const first = samples[0].value;
+    for (const { value } of samples) {
+      expect(value.connect).toBe(first.connect);
+      expect(value.disconnect).toBe(first.disconnect);
+      expect(value.openModal).toBe(first.openModal);
+      expect(value.closeModal).toBe(first.closeModal);
+      expect(value.signMessage).toBe(first.signMessage);
+      expect(value.signTransaction).toBe(first.signTransaction);
+      expect(value.supportedWallets).toBe(first.supportedWallets);
+    }
+  });
+
+  it('still re-renders consumers when exposed wallet state actually changes', () => {
+    const { Consumer, samples } = makeConsumer();
+
+    const view = render(
+      <WalletProvider>
+        <Consumer />
+      </WalletProvider>
+    );
+    expect(samples).toHaveLength(1);
+
+    // Simulate a store update flowing through the real subscription path.
+    act(() => {
+      mockStoreState.address = 'GNEWADDRESS';
+      mockStoreState.isConnected = true;
+      emitStoreChange();
+    });
+
+    // The consumer re-committed exactly once, with a new context identity
+    // carrying the updated address.
+    expect(samples).toHaveLength(2);
+    expect(samples[1].value.address).toBe('GNEWADDRESS');
+    expect(samples[1].value.isConnected).toBe(true);
+    expect(view.getByTestId('consumer').textContent).toBe('GNEWADDRESS');
+  });
+
+  it('benchmark: 100 provider re-renders with unchanged state cause 0 extra consumer commits', () => {
+    const { Consumer, samples } = makeConsumer();
+    const children = <Consumer />;
+
+    function App({ tick }: { tick: number }) {
+      return (
+        <div data-tick={tick}>
+          <WalletProvider>{children}</WalletProvider>
+        </div>
+      );
+    }
+
+    const view = render(<App tick={0} />);
+
+    const start = performance.now();
+    for (let tick = 1; tick <= 100; tick++) {
+      act(() => {
+        view.rerender(<App tick={tick} />);
+      });
+    }
+    const elapsedMs = performance.now() - start;
+
+    // eslint-disable-next-line no-console
+    console.info(
+      `[wallet-context benchmark] 100 provider re-renders → ${samples.length} consumer commit(s), ${elapsedMs.toFixed(1)}ms`
+    );
+
+    // Regression guard for #2149: before memoization this produced one
+    // consumer commit per provider render (101 total); after memoization the
+    // consumer commits only on mount. Keep as an exact assertion so any
+    // future change that re-introduces per-render value allocation fails.
+    expect(samples).toHaveLength(1);
+  });
+});

--- a/FrontEnd/my-app/context/WalletContext.tsx
+++ b/FrontEnd/my-app/context/WalletContext.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import React, { createContext, useContext, useEffect } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from 'react';
 import { useStore } from '@/lib/store';
 import { useHydrated } from '@/lib/hooks/useHydrated';
 import * as authApi from '@/lib/api/auth';
@@ -26,6 +32,19 @@ interface WalletContextType {
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+// ── Static wallet catalogue ─────────────────────────────────────────────────
+// This list never changes at runtime, so it is hoisted to module scope.
+// Allocating it inside the provider used to hand every consumer a brand-new
+// array identity on each render, which (together with the fresh `value`
+// object) defeated any consumer-side memoization.
+const SUPPORTED_WALLETS: WalletContextType['supportedWallets'] = [
+  { id: 'freighter', name: 'Freighter', icon: '/icons/freighter.png' },
+  { id: 'albedo', name: 'Albedo', icon: '/icons/albedo.png' },
+  { id: 'xbull', name: 'xBull', icon: '/icons/xbull.png' },
+  { id: 'rabet', name: 'Rabet', icon: '/icons/rabet.png' },
+  { id: 'lobstr', name: 'Lobstr', icon: '/icons/lobstr.png' },
+];
 
 // ── Lazy, cached wallet kit loader ──────────────────────────────────────────
 // The @creit.tech/stellar-wallets-kit SDK is heavy, so it must not load until
@@ -184,39 +203,41 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
     verify();
   }, [hydrated]);
 
-  const supportedWallets = [
-    { id: 'freighter', name: 'Freighter', icon: '/icons/freighter.png' },
-    { id: 'albedo', name: 'Albedo', icon: '/icons/albedo.png' },
-    { id: 'xbull', name: 'xBull', icon: '/icons/xbull.png' },
-    { id: 'rabet', name: 'Rabet', icon: '/icons/rabet.png' },
-    { id: 'lobstr', name: 'Lobstr', icon: '/icons/lobstr.png' },
-  ];
+  const connect = useCallback(
+    async (moduleId: string) => {
+      setIsConnecting(true);
+      setWalletError(null);
 
-  const connect = async (moduleId: string) => {
-    setIsConnecting(true);
-    setWalletError(null);
+      try {
+        // Loads the kit on first use if the mount-time verification effect
+        // never ran (no persisted session) — otherwise reuses the same
+        // cached instance it already loaded.
+        const kitInstance = kit ?? (await loadWalletKit());
+        if (!kit) setKit(kitInstance);
 
-    try {
-      // Loads the kit on first use if the mount-time verification effect
-      // never ran (no persisted session) — otherwise reuses the same
-      // cached instance it already loaded.
-      const kitInstance = kit ?? (await loadWalletKit());
-      if (!kit) setKit(kitInstance);
+        kitInstance.setWallet(moduleId);
+        const { address: walletAddress } = await kitInstance.getAddress();
+        setWalletAddress(walletAddress);
+        setSelectedWalletId(moduleId);
+        setWalletModalOpen(false);
+      } catch (err: any) {
+        setWalletError(err?.message ?? 'Connection failed');
+        console.error('Wallet connection failed:', err);
+      } finally {
+        setIsConnecting(false);
+      }
+    },
+    [
+      kit,
+      setIsConnecting,
+      setWalletError,
+      setWalletAddress,
+      setSelectedWalletId,
+      setWalletModalOpen,
+    ]
+  );
 
-      kitInstance.setWallet(moduleId);
-      const { address: walletAddress } = await kitInstance.getAddress();
-      setWalletAddress(walletAddress);
-      setSelectedWalletId(moduleId);
-      setWalletModalOpen(false);
-    } catch (err: any) {
-      setWalletError(err?.message ?? 'Connection failed');
-      console.error('Wallet connection failed:', err);
-    } finally {
-      setIsConnecting(false);
-    }
-  };
-
-  const disconnect = async () => {
+  const disconnect = useCallback(async () => {
     if (kit) {
       try {
         await kit.disconnect();
@@ -225,7 +246,17 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
       }
     }
     disconnectWallet();
-  };
+  }, [kit, disconnectWallet]);
+
+  const openModal = useCallback(() => {
+    setWalletError(null);
+    setWalletModalOpen(true);
+  }, [setWalletError, setWalletModalOpen]);
+
+  const closeModal = useCallback(() => {
+    setWalletError(null);
+    setWalletModalOpen(false);
+  }, [setWalletError, setWalletModalOpen]);
 
   const getNetworkPassphrase = () => {
     const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
@@ -234,72 +265,96 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
       : 'Test SDF Network ; September 2015';
   };
 
-  const signMessage = async (message: string) => {
-    if (!kit) {
-      throw new Error('Wallet kit not loaded');
-    }
-    if (!address) {
-      throw new Error('Wallet not connected');
-    }
-    try {
-      const { result } = await kit.sign({
-        payload: message,
-      });
-      return result;
-    } catch (err: any) {
-      console.error('Signing failed:', err);
-      throw new Error(err?.message || 'Signing failed');
-    }
-  };
+  const signMessage = useCallback(
+    async (message: string) => {
+      if (!kit) {
+        throw new Error('Wallet kit not loaded');
+      }
+      if (!address) {
+        throw new Error('Wallet not connected');
+      }
+      try {
+        const { result } = await kit.sign({
+          payload: message,
+        });
+        return result;
+      } catch (err: any) {
+        console.error('Signing failed:', err);
+        throw new Error(err?.message || 'Signing failed');
+      }
+    },
+    [kit, address]
+  );
 
-  const signTransaction = async (
-    xdr: string,
-    opts: { networkPassphrase: string; address: string }
-  ) => {
-    if (!kit) {
-      throw new Error('Wallet kit not loaded');
-    }
-    try {
-      const { signedTxXdr } = await kit.signTransaction(xdr, {
-        networkPassphrase: opts.networkPassphrase,
-        address: opts.address,
-      });
-      return signedTxXdr;
-    } catch (err: any) {
-      console.error('Transaction signing failed:', err);
-      const message = err?.message || 'Transaction signing failed';
-      setWalletError(message);
-      throw new Error(message);
-    }
-  };
+  const signTransaction = useCallback(
+    async (
+      xdr: string,
+      opts: { networkPassphrase: string; address: string }
+    ) => {
+      if (!kit) {
+        throw new Error('Wallet kit not loaded');
+      }
+      try {
+        const { signedTxXdr } = await kit.signTransaction(xdr, {
+          networkPassphrase: opts.networkPassphrase,
+          address: opts.address,
+        });
+        return signedTxXdr;
+      } catch (err: any) {
+        console.error('Transaction signing failed:', err);
+        const message = err?.message || 'Transaction signing failed';
+        setWalletError(message);
+        throw new Error(message);
+      }
+    },
+    [kit, setWalletError]
+  );
+
+  // ── Memoized context value ────────────────────────────────────────────────
+  // The provider re-renders whenever *any* subscribed store slice changes
+  // (including transient ones like isConnecting/isVerifyingWallet). Without
+  // useMemo, every one of those renders allocated a fresh `value` object and
+  // forced every useWallet() consumer to re-render too — even when the data
+  // a consumer actually reads had not changed. Keying the memo on the exact
+  // wallet state fields + stabilized callbacks means the context value only
+  // gets a new identity when some part of the exposed wallet state truly
+  // changed.
+  const value = useMemo<WalletContextType>(
+    () => ({
+      connect,
+      disconnect,
+      address,
+      isConnected,
+      isConnecting,
+      isVerifyingWallet,
+      selectedWalletId,
+      openModal,
+      closeModal,
+      isModalOpen,
+      supportedWallets: SUPPORTED_WALLETS,
+
+      error: walletError,
+      signMessage,
+      signTransaction,
+    }),
+    [
+      connect,
+      disconnect,
+      address,
+      isConnected,
+      isConnecting,
+      isVerifyingWallet,
+      selectedWalletId,
+      openModal,
+      closeModal,
+      isModalOpen,
+      walletError,
+      signMessage,
+      signTransaction,
+    ]
+  );
 
   return (
-    <WalletContext.Provider
-      value={{
-        connect,
-        disconnect,
-        address,
-        isConnected,
-        isConnecting,
-        isVerifyingWallet,
-        selectedWalletId,
-        openModal: () => {
-          setWalletError(null);
-          setWalletModalOpen(true);
-        },
-        closeModal: () => {
-          setWalletError(null);
-          setWalletModalOpen(false);
-        },
-        isModalOpen,
-        supportedWallets,
-
-        error: walletError,
-        signMessage,
-        signTransaction,
-      }}
-    >
-      {children}
-    </WalletContext.Provider>
+    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
   );
 };

--- a/FrontEnd/my-app/docs/performance-optimizations.md
+++ b/FrontEnd/my-app/docs/performance-optimizations.md
@@ -85,3 +85,40 @@ quest or submission updates (e.g. quest cards no longer subscribe to
 status events (or replay socket traffic), and compare commit count with the
 previous behaviour; network tab should show fewer redundant `subscribe` frames
 on quest list pages that only refresh quest metadata.
+
+## 6. Memoized WalletContext value (#2149)
+
+`context/WalletContext.tsx` used to allocate a brand-new context `value`
+object (plus fresh `connect`/`disconnect`/`openModal`/`closeModal`/
+`signMessage`/`signTransaction` callback identities and a fresh
+`supportedWallets` array) on **every** provider render. Because Object.is on
+the old value always failed, every component calling `useWallet()` re-rendered
+whenever the provider re-rendered — even when no wallet state the consumer
+reads had changed.
+
+The provider now:
+
+- wraps the context value in `useMemo`, keyed on the exact exposed wallet
+  state fields (`address`, `isConnected`, `isConnecting`,
+  `isVerifyingWallet`, `selectedWalletId`, `isModalOpen`, `walletError`) and
+  the stabilized callbacks;
+- stabilizes all callbacks with `useCallback`;
+- hoists the static `supportedWallets` catalogue to module scope.
+
+The provider still re-renders when any subscribed store slice changes, but
+consumers now bail out unless something they actually read got a new identity.
+Stable callback/array identities also let downstream `React.memo` components
+and hook dependency arrays work as intended (e.g. a memoized button that only
+takes `onConnect` no longer re-renders on unrelated wallet-state churn).
+
+**Before/after (unit regression + benchmark, Vitest —
+`context/WalletContext.memo.test.tsx`):** 100 provider re-renders with
+unchanged wallet state (jsdom, React 19):
+
+| Metric                                       | Before | After     |
+| -------------------------------------------- | ------ | --------- |
+| Consumer commits for 100 provider re-renders | 101    | 1         |
+| Benchmark wall-clock time                    | ~79 ms | ~48–65 ms |
+
+The committed test asserts the "after" behaviour exactly (1 commit), so any
+future change that re-introduces per-render value allocation fails CI.


### PR DESCRIPTION
Close #2149

## Summary

`WalletProvider` (`FrontEnd/my-app/context/WalletContext.tsx`) allocated a freshly-built context `value` object on **every** render. Since `Object.is` on the previous value always failed, React propagated a new context identity on each provider render and **every component consuming `useWallet()` re-rendered**, even when no wallet state it reads had changed. Freshly-allocated `connect`/`disconnect`/`openModal`/`closeModal`/`signMessage`/`signTransaction` callbacks and a fresh `supportedWallets` array per render also defeated downstream `React.memo` boundaries and hook dependency arrays.

## Changes

- **Memoized context value** — the provider `value` is now wrapped in `useMemo`, keyed on the exact exposed wallet state fields (`address`, `isConnected`, `isConnecting`, `isVerifyingWallet`, `selectedWalletId`, `isModalOpen`, `walletError`) plus the stabilized callbacks. The value only gets a new identity when some part of the exposed wallet state truly changed.
- **Stabilized callbacks** — `connect`, `disconnect`, `openModal`, `closeModal`, `signMessage`, and `signTransaction` are wrapped in `useCallback` with complete dependency lists (exhaustive-deps clean).
- **Hoisted static data** — the immutable `supportedWallets` catalogue moved to module scope (`SUPPORTED_WALLETS`), so consumers receive a stable array identity.
- **Regression tests + benchmark** — new `context/WalletContext.memo.test.tsx`:
  - consumers do not re-render across 25 unrelated provider re-renders;
  - callback / `supportedWallets` identities stay stable across re-renders;
  - consumers still re-render exactly once when real wallet state changes (guards against over-memoization);
  - benchmark test asserting 100 provider re-renders with unchanged state cause exactly **1** consumer commit (fails on the pre-fix implementation).
- **Documentation** — added section "6. Memoized WalletContext value (#2149)" to `docs/performance-optimizations.md`.

## Before / After

Measured with the committed Vitest benchmark (jsdom, React 19; 100 provider re-renders triggered from a parent while wallet state is unchanged):

| Metric | Before | After |
| ------ | ------ | ----- |
| Consumer commits for 100 provider re-renders | **101** | **1** |
| Benchmark wall-clock time | ~79 ms | ~48–65 ms |

The pre-fix implementation fails 3 of the 4 new regression tests, confirming they capture the issue.

## Acceptance criteria

- [x] Measurable performance improvement demonstrated with before/after numbers (101 → 1 consumer commits)
- [x] No regression in existing functionality — all existing `WalletContext` tests pass unchanged; connect/disconnect/verify/sign flows untouched
- [x] Tests pass and code follows project standards — `npm run lint` (0 errors), `npx tsc --noEmit` (no new errors), `prettier --check` clean
- [x] Change is documented in `docs/performance-optimizations.md`

## Test plan

- \`npx vitest run context/\` — 15/15 pass (9 existing + 2 connect/disconnect + 4 new)
- \`npm run test:unit\` — 792 passed; only the 3 pre-existing failures on \`main\` (\`app/layout.test.tsx\`, \`lib/hooks/useClaim.test.ts\`, \`lib/hooks/useReputation.test.tsx\`), verified identical on a clean checkout
- \`npm run lint\` — 0 errors
- \`npm run typecheck\` — same 6 pre-existing errors as \`main\`, none in touched files