### PR TITLE
fix: gate demo routes in production and split admin module (#1922, #1907)

### DIFF
--- a/BackEnd/src/modules/admin/CHANGELOG.md
+++ b/BackEnd/src/modules/admin/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Split the monolithic `admin.module.ts` into separate `admin.controller.ts`, `admin.service.ts`, and `admin.module.ts` files, matching the file-per-concern layout used by the other modules. No behavior change. Closes #1907.
+
 ### Fixed
 
 - `AdminService.getUserById` now throws `NotFoundException` (HTTP 404)

--- a/BackEnd/src/modules/admin/admin.controller.spec.ts
+++ b/BackEnd/src/modules/admin/admin.controller.spec.ts
@@ -7,7 +7,8 @@ import {
   ArgumentMetadata,
 } from '@nestjs/common';
 
-import { AdminController, AdminService } from './admin.module';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
 import { GetUsersQueryDto } from './dto/get-users-query.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';

--- a/BackEnd/src/modules/admin/admin.controller.ts
+++ b/BackEnd/src/modules/admin/admin.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { IpWhitelistGuard } from '../../common/guards/ip-whitelist.guard';
+import { AdminService } from './admin.service';
+import { GetUsersQueryDto } from './dto/get-users-query.dto';
+
+@UseGuards(IpWhitelistGuard, JwtAuthGuard, RolesGuard)
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get('users')
+  getUsers(@Query() query: GetUsersQueryDto = {}) {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    return this.adminService.getUsers(page, limit);
+  }
+
+  @Get('users/:id')
+  getUserById(@Param('id') id: string) {
+    return this.adminService.getUserById(id);
+  }
+
+  @Get('stats')
+  getPlatformStats() {
+    return this.adminService.getPlatformStats();
+  }
+}

--- a/BackEnd/src/modules/admin/admin.module.ts
+++ b/BackEnd/src/modules/admin/admin.module.ts
@@ -1,95 +1,10 @@
-import {
-  Controller,
-  Get,
-  Param,
-  Query,
-  UseGuards,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { RolesGuard } from '../auth/guards/roles.guard';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
 import { IpWhitelistGuard } from '../../common/guards/ip-whitelist.guard';
 import { User } from '../users/entities/user.entity';
-import { Role } from '../../common/enums/role.enum';
-import { GetUsersQueryDto } from './dto/get-users-query.dto';
-
-// ── Service ──────────────────────────────────────────────────────────────────
-
-@Injectable()
-export class AdminService {
-  private statsCache: { data: any; expiresAt: number } | null = null;
-  private readonly STATS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-
-  constructor(
-    @InjectRepository(User)
-    private readonly userRepo: Repository<User>,
-  ) {}
-
-  async getUsers(page: number, limit: number) {
-    const [users, total] = await this.userRepo.findAndCount({
-      skip: (page - 1) * limit,
-      take: limit,
-      order: { createdAt: 'DESC' },
-    });
-    return { users, total, page, limit };
-  }
-
-  async getUserById(id: string) {
-    const user = await this.userRepo.findOne({ where: { id } });
-    if (!user) {
-      throw new NotFoundException(`User ${id} not found`);
-    }
-    return user;
-  }
-
-  async getPlatformStats() {
-    const now = Date.now();
-    if (this.statsCache && now < this.statsCache.expiresAt) {
-      return this.statsCache.data;
-    }
-
-    const totalUsers = await this.userRepo.count();
-    const adminCount = await this.userRepo.count({
-      where: { role: Role.ADMIN },
-    });
-    const data = { totalUsers, adminCount };
-    this.statsCache = { data, expiresAt: now + this.STATS_CACHE_TTL_MS };
-    return data;
-  }
-}
-
-// ── Controller ────────────────────────────────────────────────────────────────
-
-@UseGuards(IpWhitelistGuard, JwtAuthGuard, RolesGuard)
-@Controller('admin')
-export class AdminController {
-  constructor(private readonly adminService: AdminService) {}
-
-  @Get('users')
-  getUsers(@Query() query: GetUsersQueryDto = {}) {
-    const page = query.page ?? 1;
-    const limit = query.limit ?? 20;
-    return this.adminService.getUsers(page, limit);
-  }
-
-  @Get('users/:id')
-  getUserById(@Param('id') id: string) {
-    return this.adminService.getUserById(id);
-  }
-
-  @Get('stats')
-  getPlatformStats() {
-    return this.adminService.getPlatformStats();
-  }
-}
-
-// ── Module ────────────────────────────────────────────────────────────────────
 
 @Module({
   imports: [TypeOrmModule.forFeature([User]), ConfigModule],

--- a/BackEnd/src/modules/admin/admin.service.spec.ts
+++ b/BackEnd/src/modules/admin/admin.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { AdminService } from './admin.module';
+import { AdminService } from './admin.service';
 import { User } from '../users/entities/user.entity';
 import { HttpStatus } from '@nestjs/common';
 import { Role } from '../../common/enums/role.enum';

--- a/BackEnd/src/modules/admin/admin.service.ts
+++ b/BackEnd/src/modules/admin/admin.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+import { Role } from '../../common/enums/role.enum';
+
+@Injectable()
+export class AdminService {
+  private statsCache: { data: any; expiresAt: number } | null = null;
+  private readonly STATS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  async getUsers(page: number, limit: number) {
+    const [users, total] = await this.userRepo.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { createdAt: 'DESC' },
+    });
+    return { users, total, page, limit };
+  }
+
+  async getUserById(id: string) {
+    const user = await this.userRepo.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException(`User ${id} not found`);
+    }
+    return user;
+  }
+
+  async getPlatformStats() {
+    const now = Date.now();
+    if (this.statsCache && now < this.statsCache.expiresAt) {
+      return this.statsCache.data;
+    }
+
+    const totalUsers = await this.userRepo.count();
+    const adminCount = await this.userRepo.count({
+      where: { role: Role.ADMIN },
+    });
+    const data = { totalUsers, adminCount };
+    this.statsCache = { data, expiresAt: now + this.STATS_CACHE_TTL_MS };
+    return data;
+  }
+}

--- a/FrontEnd/my-app/app/[locale]/error-panel-demo/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/error-panel-demo/page.tsx
@@ -11,8 +11,14 @@
  */
 
 import { useState, useEffect } from 'react';
+import { notFound } from 'next/navigation';
 
 export default function ErrorPanelDemoPage() {
+  // Debug/demo route — never publicly reachable in production (see #1922).
+  if (process.env.NODE_ENV === 'production') {
+    notFound();
+  }
+
   const [isValidating, setIsValidating] = useState(true);
 
   useEffect(() => {

--- a/FrontEnd/my-app/app/[locale]/test-error/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/test-error/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { notFound } from 'next/navigation';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
 import { ErrorMessage } from '@/components/error/ErrorMessage';
 import { useErrorHandler } from '@/lib/hooks/useErrorHandler';
@@ -81,6 +82,11 @@ function TestWithErrorHandler() {
 
 // Main test page
 export default function ErrorHandlingTest() {
+  // Debug/test route — never publicly reachable in production (see #1922).
+  if (process.env.NODE_ENV === 'production') {
+    notFound();
+  }
+
   return (
     <div className="min-h-screen bg-zinc-900 p-8">
       <div className="max-w-4xl mx-auto">

--- a/FrontEnd/my-app/app/robots.ts
+++ b/FrontEnd/my-app/app/robots.ts
@@ -17,6 +17,9 @@ export default function robots(): MetadataRoute.Robots {
         '/*/rewards',
         '/*/settings',
         '/*/submissions',
+        // Debug/demo routes (also gated off in production, see #1922)
+        '/*/error-panel-demo',
+        '/*/test-error',
       ],
     },
     sitemap: new URL('/sitemap.xml', siteUrl).toString(),


### PR DESCRIPTION
## Summary

Two improvements:

### #1922 — Gate demo/debug routes off in production
The `error-panel-demo` and `test-error` debug routes were shipping in the production build with no auth gate and no `noindex` metadata.
- Both routes now call `notFound()` when `NODE_ENV === 'production'`, so they are not publicly reachable in production (still available for local and E2E testing).
- Added both paths to the `robots.txt` disallow list (`/*/error-panel-demo`, `/*/test-error`) so they are never indexed.

### #1907 — Split monolithic `admin.module.ts` into per-concern files
- Extracted `AdminService` into `admin.service.ts` and `AdminController` into `admin.controller.ts`, following the file-per-concern convention used across `src/modules/`.
- `admin.module.ts` now only declares the module wiring; `app.module.ts` import is unchanged.
- Updated the admin unit specs to import from the new files. No behavior change.

## Testing
- Backend: `npm run build`, `npm run lint`, prettier check, OpenAPI generation, admin unit tests (18 passing) — all pass
- Frontend: `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm test` (832 passing), `npm run build` — all pass
- Backend module changelog discipline check — passes

Closes #1922
Closes #1907
