### PR TITLE
feat(stellar): cache Soroban contract reads and type the wallet kit (#1975, #1932)

### DIFF
--- a/BackEnd/docs/SOROBAN_READ_CACHE.md
+++ b/BackEnd/docs/SOROBAN_READ_CACHE.md
@@ -1,0 +1,42 @@
+# Soroban Contract Read Caching
+
+## Overview
+This document describes the short-TTL cache added for idempotent Soroban contract reads (`get_quest` / `get_user_stats`) in `SorobanQuestReaderService`.
+
+## Problem Statement
+Every UI request that needs on-chain quest or user state triggered a fresh Soroban RPC simulation. RPC reads are slow (network round-trips) and subject to rate limits, so repeated reads for the same quest/user — e.g. the hourly quest-state reconciliation job or page loads that re-query the same quest — paid the full cost every time.
+
+## Solution Architecture
+`SorobanQuestReaderService` now caches read results in memory with a short TTL:
+
+- **Key**: `contractId:questId` for `get_quest`, `contractId:user:<address>` for `get_user_stats`.
+- **TTL**: `SOROBAN_READ_CACHE_TTL_MS` (default `15000` ms / 15s) bounds how stale a served value can be.
+- **Null results are cached too**, so repeated reads of a missing quest do not keep hitting the RPC.
+- **Cache misses** perform the normal traced RPC simulation and then store the result.
+- **Invalidation**:
+  - `invalidateQuest(contractId, questId)` — called after `approve_submission` succeeds (the approval bumps the quest's on-chain `total_claims`).
+  - `invalidateContract(contractId)` — drops all entries for a contract.
+  - `clearCache()` — clears everything.
+
+`getQuestsBatch` benefits automatically: each per-quest `getQuest` call consults the cache, so a warm batch performs zero RPC simulations.
+
+### Key Configuration
+- `SOROBAN_READ_CACHE_TTL_MS`: Cache duration in milliseconds (Default: `15000` ms / 15s).
+
+### Metrics
+| Metric | Type | Meaning |
+| ------ | ---- | ------- |
+| `stellar_contract_read_cache_hits_total` | counter | Reads served from the cache |
+| `stellar_contract_read_cache_misses_total` | counter | Reads that required an RPC simulation |
+| `stellar_contract_read_cache_entries` | gauge | Number of cached entries |
+
+## Benchmark Results
+Run `npm run benchmark:soroban-read-cache` (simulates a 50ms Soroban RPC round-trip, 1000 reads):
+
+- **Uncached Run** (RPC per read): ~50ms per read, ~20 ops/sec.
+- **Cached Run** (in-memory read): <0.01ms per read, ~100,000+ ops/sec.
+- **Impact**: the RPC round-trip is removed from repeated reads; the cache hit ratio approaches 100% within the TTL window while `approve_submission` keeps the affected quest's entry fresh.
+
+## Verification
+- Unit tests: `npx jest src/modules/stellar/soroban-quest-reader.service.spec.ts`
+- Regression: `npx jest src/modules/stellar --silent`

--- a/BackEnd/package.json
+++ b/BackEnd/package.json
@@ -30,6 +30,7 @@
     "benchmark:moderation-config": "ts-node scripts/benchmark-moderation-config-cache.ts",
     "benchmark:job-result-status-cache": "ts-node scripts/benchmark-job-result-status-cache.ts",
     "benchmark:stellar-fee-cache": "ts-node scripts/benchmark-stellar-fee-cache.ts",
+    "benchmark:soroban-read-cache": "ts-node scripts/benchmark-soroban-read-cache.ts",
     "db:backup": "ts-node scripts/db-backup.ts",
     "db:rollback": "ts-node scripts/db-rollback.ts",
     "typeorm": "typeorm-ts-node-commonjs -d src/database/data-source.ts",

--- a/BackEnd/scripts/benchmark-soroban-read-cache.ts
+++ b/BackEnd/scripts/benchmark-soroban-read-cache.ts
@@ -1,0 +1,125 @@
+import 'reflect-metadata';
+import { performance } from 'node:perf_hooks';
+import * as StellarSdk from 'stellar-sdk';
+import { ConfigService } from '@nestjs/config';
+import { MetricsService } from '../src/common/services/metrics.service';
+import { TracingService } from '../src/common/tracing/tracing.service';
+import { SorobanQuestReaderService } from '../src/modules/stellar/soroban-quest-reader.service';
+
+/**
+ * Benchmark: cached vs uncached Soroban contract reads (#1975).
+ *
+ * Before this change every `get_quest` / `get_user_stats` read paid a full
+ * Soroban RPC round-trip. After this change reads are served from a
+ * short-TTL in-memory cache, so repeated reads are effectively free.
+ *
+ * This script simulates the RPC latency and measures both paths:
+ *
+ *   SOROBAN_READ_BENCHMARK_ITERATIONS        iterations per path (default 1000)
+ *   SOROBAN_READ_BENCHMARK_LATENCY_MS        simulated RPC round-trip (default 50)
+ *
+ * Run: npm run benchmark:soroban-read-cache
+ */
+class SimulatedRpc {
+  constructor(private readonly latencyMs: number) {}
+
+  async simulateTransaction(): Promise<unknown> {
+    await new Promise((resolve) => setTimeout(resolve, this.latencyMs));
+    return { result: { retval: { _type: 'struct' } } };
+  }
+}
+
+interface BenchmarkResult {
+  label: string;
+  totalMs: number;
+  opsPerSecond: number;
+  perOpMs: number;
+}
+
+const iterations = Number.parseInt(
+  process.env.SOROBAN_READ_BENCHMARK_ITERATIONS || '1000',
+  10,
+);
+const latencyMs = Number.parseInt(
+  process.env.SOROBAN_READ_BENCHMARK_LATENCY_MS || '50',
+  10,
+);
+
+async function run(
+  label: string,
+  operation: () => Promise<unknown>,
+): Promise<BenchmarkResult> {
+  let checksum = 0;
+  const startedAt = performance.now();
+  for (let i = 0; i < iterations; i += 1) {
+    const value = await operation();
+    checksum += value ? 1 : 0;
+  }
+  const totalMs = performance.now() - startedAt;
+  return {
+    label,
+    totalMs,
+    opsPerSecond: Math.round((iterations / totalMs) * 1000),
+    perOpMs: Math.round((totalMs / iterations) * 100) / 100,
+  };
+}
+
+async function main(): Promise<void> {
+  const config = new ConfigService({
+    SOROBAN_READ_CACHE_TTL_MS: '15000',
+    SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+    STELLAR_NETWORK: 'TESTNET',
+  });
+  const metrics = new MetricsService();
+  const tracing = {
+    trace: async (_name: string, fn: any, _attrs?: any) => {
+      return fn({ attributes: {} as Record<string, any>, status: 'ok' });
+    },
+  } as unknown as TracingService;
+  const simulatedRpc = new SimulatedRpc(latencyMs);
+  const clientPool = {
+    getRpcServer: () => simulatedRpc,
+  } as any;
+
+  const reader = new SorobanQuestReaderService(config, tracing, metrics, clientPool);
+  const contractId = StellarSdk.StrKey.encodeContract(Buffer.alloc(32));
+  const questId = 'quest_1';
+
+  // "Before": uncached — every read pays the RPC round-trip (cache cleared
+  // before each iteration so each read is a genuine miss).
+  const before = await run('uncached (RPC per read)', async () => {
+    reader.clearCache();
+    return reader.getQuest(contractId, questId);
+  });
+
+  // "After": cached — warm the entry once, then read from memory.
+  await reader.getQuest(contractId, questId);
+  const after = await run('cached (in-memory read)', () =>
+    reader.getQuest(contractId, questId),
+  );
+
+  const speedup = before.perOpMs / after.perOpMs;
+
+  console.log('\n=== Soroban read-cache benchmark ===');
+  console.log(
+    `iterations: ${iterations} | simulated RPC latency: ${latencyMs}ms`,
+  );
+  console.table([before, after]);
+  console.log(
+    `\nSpeedup: ${speedup.toFixed(1)}x faster (${before.perOpMs}ms/op vs ${after.perOpMs}ms/op)`,
+  );
+
+  const snapshot = metrics.getSnapshot().metrics as Record<string, unknown>;
+  const cacheMetrics = Object.fromEntries(
+    Object.entries(snapshot).filter(([name]) =>
+      name.startsWith('stellar_contract_read_cache_'),
+    ),
+  );
+  console.log('\n=== Captured cache metrics ===');
+  console.log(JSON.stringify(cacheMetrics, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/BackEnd/src/modules/stellar/CHANGELOG.md
+++ b/BackEnd/src/modules/stellar/CHANGELOG.md
@@ -8,6 +8,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - `StellarFeeService`: precomputes and caches the Stellar network base fee from Horizon `/fee_stats` with a short TTL (`STELLAR_FEE_CACHE_TTL_MS`, default 30s) and background refresh, exposing hit/miss/fetch-duration metrics and falling back to `STELLAR_BASE_FEE` when the network is unavailable. `StellarService`, `StellarPaymentService`, and `StellarSubmissionService` now build transactions with the cached estimate, removing the per-transaction fee network round-trip from the payout hot path. Closes #1980.
+- Short-TTL in-memory cache for idempotent Soroban contract reads in `SorobanQuestReaderService` (`get_quest` / `get_user_stats`), keyed by contract + args (`SOROBAN_READ_CACHE_TTL_MS`, default 15s), with hit/miss/entry metrics, `invalidateQuest`/`invalidateContract` invalidation (wired into `approveSubmission`), and a benchmark script (`npm run benchmark:soroban-read-cache`). Closes #1975.
 
 ### Fixed
 

--- a/BackEnd/src/modules/stellar/soroban-quest-reader.service.spec.ts
+++ b/BackEnd/src/modules/stellar/soroban-quest-reader.service.spec.ts
@@ -50,6 +50,9 @@ describe('SorobanQuestReaderService', () => {
   const mockMetrics = {
     incrementCounter: jest.fn(),
     observeHistogram: jest.fn(),
+    registerCounter: jest.fn(),
+    registerGauge: jest.fn(),
+    setGauge: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -275,6 +278,108 @@ describe('SorobanQuestReaderService', () => {
       expect(res[1]?.id).toBe('q2');
       expect(res[2]?.id).toBe('q3');
       expect(service.getQuest).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('read cache', () => {
+    const setupQuestRead = () => {
+      const mockRetval = { _type: 'struct' };
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: { retval: mockRetval },
+      });
+      StellarSdk.rpc.Api.isSimulationError = jest.fn().mockReturnValue(false);
+      StellarSdk.rpc.Api.isSimulationSuccess = jest.fn().mockReturnValue(true);
+      mockScValToNative.mockReturnValue({
+        id: 'quest_1',
+        creator: 'GABC',
+        reward_asset: 'XLM',
+        reward_amount: 1000n,
+        verifier: 'GVERIFIER',
+        deadline: 123456n,
+        status: 'Active',
+        total_claims: 2,
+      });
+    };
+
+    it('should serve repeated reads from the cache without hitting the RPC', async () => {
+      setupQuestRead();
+
+      const first = await service.getQuest(validContractId, 'quest_1');
+      const second = await service.getQuest(validContractId, 'quest_1');
+      const third = await service.getQuest(validContractId, 'quest_1');
+
+      expect(first).not.toBeNull();
+      expect(second).toEqual(first);
+      expect(third).toEqual(first);
+      expect(mockRpcServer.simulateTransaction).toHaveBeenCalledTimes(1);
+      expect(metricsService.incrementCounter).toHaveBeenCalledWith(
+        'stellar_contract_read_cache_hits_total',
+      );
+    });
+
+    it('should refetch after invalidateQuest', async () => {
+      setupQuestRead();
+
+      await service.getQuest(validContractId, 'quest_1');
+      service.invalidateQuest(validContractId, 'quest_1');
+      await service.getQuest(validContractId, 'quest_1');
+
+      expect(mockRpcServer.simulateTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refetch after the TTL expires', async () => {
+      setupQuestRead();
+
+      await service.getQuest(validContractId, 'quest_1');
+      // Force the stored entry to be stale.
+      const entry = (service as any).readCache.get(
+        `${validContractId}:quest_1`,
+      );
+      entry.expiresAt = Date.now() - 1;
+      await service.getQuest(validContractId, 'quest_1');
+
+      expect(mockRpcServer.simulateTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should cache null results for missing quests', async () => {
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: { retval: null },
+      });
+      StellarSdk.rpc.Api.isSimulationError = jest.fn().mockReturnValue(false);
+      StellarSdk.rpc.Api.isSimulationSuccess = jest.fn().mockReturnValue(true);
+
+      const first = await service.getQuest(validContractId, 'missing');
+      const second = await service.getQuest(validContractId, 'missing');
+
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(mockRpcServer.simulateTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch and cache user stats', async () => {
+      mockRpcServer.simulateTransaction.mockResolvedValue({
+        result: { retval: { _type: 'struct' } },
+      });
+      StellarSdk.rpc.Api.isSimulationError = jest.fn().mockReturnValue(false);
+      StellarSdk.rpc.Api.isSimulationSuccess = jest.fn().mockReturnValue(true);
+      mockScValToNative.mockReturnValue({
+        xp: 2500n,
+        level: 7,
+        quests_completed: 12,
+      });
+
+      const userAddress =
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+      const first = await service.getUserStats(validContractId, userAddress);
+      const second = await service.getUserStats(validContractId, userAddress);
+
+      expect(first).toEqual({
+        xp: 2500n,
+        level: 7,
+        quests_completed: 12,
+      });
+      expect(second).toEqual(first);
+      expect(mockRpcServer.simulateTransaction).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/BackEnd/src/modules/stellar/soroban-quest-reader.service.ts
+++ b/BackEnd/src/modules/stellar/soroban-quest-reader.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   Account,
+  Address,
   Operation,
   TransactionBuilder,
   rpc,
@@ -25,6 +26,12 @@ export interface OnChainQuestState {
   total_claims: number;
 }
 
+export interface UserOnChainStats {
+  xp: bigint;
+  level: number;
+  quests_completed: number;
+}
+
 /**
  * SorobanQuestReaderService
  * Read-only contract helpers for fetching quest state from the Earn Quest contract.
@@ -36,6 +43,11 @@ export class SorobanQuestReaderService {
   private readonly rpcServer: rpc.Server;
   private readonly networkPassphrase: string;
   private readonly clientPool: SorobanRpcClientPoolService;
+  private readonly readCache = new Map<
+    string,
+    { value: unknown; expiresAt: number }
+  >();
+  private readonly cacheTtlMs: number;
 
   constructor(
     private readonly configService: ConfigService,
@@ -45,6 +57,24 @@ export class SorobanQuestReaderService {
   ) {
     this.clientPool =
       clientPool ?? new SorobanRpcClientPoolService(this.configService);
+
+    this.cacheTtlMs = parseInt(
+      this.configService.get<string>('SOROBAN_READ_CACHE_TTL_MS') || '15000',
+      10,
+    );
+
+    this.metrics.registerCounter(
+      'stellar_contract_read_cache_hits_total',
+      'Soroban contract read cache hits',
+    );
+    this.metrics.registerCounter(
+      'stellar_contract_read_cache_misses_total',
+      'Soroban contract read cache misses',
+    );
+    this.metrics.registerGauge(
+      'stellar_contract_read_cache_entries',
+      'Number of entries in the Soroban contract read cache',
+    );
 
     const network =
       this.configService.get<string>('STELLAR_NETWORK') ||
@@ -60,6 +90,71 @@ export class SorobanQuestReaderService {
     this.rpcServer = this.clientPool.getRpcServer();
   }
 
+  // ── Read cache ─────────────────────────────────────────────────────────────
+  // Idempotent contract reads (get_quest / get_user_stats) are cached with a
+  // short TTL keyed by contract + args so repeated reads (per-UI-request or
+  // per reconciliation pass) don't each pay a Soroban RPC round-trip. Writes
+  // invalidate the affected keys via {@link invalidateQuest} /
+  // {@link invalidateContract}.
+
+  private cacheKey(contractId: string, argsKey: string): string {
+    return `${contractId}:${argsKey}`;
+  }
+
+  private getCached<T>(key: string): { hit: boolean; value: T | null } {
+    const entry = this.readCache.get(key);
+    if (entry && entry.expiresAt > Date.now()) {
+      this.metrics.incrementCounter('stellar_contract_read_cache_hits_total');
+      return { hit: true, value: entry.value as T | null };
+    }
+    this.metrics.incrementCounter('stellar_contract_read_cache_misses_total');
+    return { hit: false, value: null };
+  }
+
+  private setCached<T>(key: string, value: T | null): void {
+    this.readCache.set(key, { value, expiresAt: Date.now() + this.cacheTtlMs });
+    this.metrics.setGauge(
+      'stellar_contract_read_cache_entries',
+      this.readCache.size,
+    );
+  }
+
+  /**
+   * Drop the cached state for a single quest. Call this after an on-chain
+   * write that changes that quest's state (e.g. an approval that bumps
+   * `total_claims`).
+   */
+  invalidateQuest(contractId: string, questId: string): void {
+    this.readCache.delete(this.cacheKey(contractId, questId));
+    this.metrics.setGauge(
+      'stellar_contract_read_cache_entries',
+      this.readCache.size,
+    );
+  }
+
+  /** Drop all cached reads for a contract (e.g. after a batch of writes). */
+  invalidateContract(contractId: string): void {
+    const prefix = `${contractId}:`;
+    for (const key of this.readCache.keys()) {
+      if (key.startsWith(prefix)) {
+        this.readCache.delete(key);
+      }
+    }
+    this.metrics.setGauge(
+      'stellar_contract_read_cache_entries',
+      this.readCache.size,
+    );
+  }
+
+  clearCache(): void {
+    this.readCache.clear();
+    this.metrics.setGauge('stellar_contract_read_cache_entries', 0);
+  }
+
+  /**
+   * Fetch a quest's on-chain state via `get_quest`, cached with a short TTL
+   * keyed by contract + quest id.
+   */
   async getQuest(
     contractId: string,
     questId: string,
@@ -67,6 +162,21 @@ export class SorobanQuestReaderService {
     if (!contractId) throw new Error('Missing contractId');
     if (!questId) throw new Error('Missing questId');
 
+    const key = this.cacheKey(contractId, questId);
+    const cached = this.getCached<OnChainQuestState | null>(key);
+    if (cached.hit) {
+      return cached.value;
+    }
+
+    const value = await this.fetchQuestFromContract(contractId, questId);
+    this.setCached(key, value);
+    return value;
+  }
+
+  private async fetchQuestFromContract(
+    contractId: string,
+    questId: string,
+  ): Promise<OnChainQuestState | null> {
     return this.tracing.trace(
       'stellar.contract.get_quest',
       async (span) => {
@@ -279,5 +389,185 @@ export class SorobanQuestReaderService {
     );
 
     return results;
+  }
+
+  /**
+   * Fetch a user's on-chain stats (`xp`, `level`, `quests_completed`) via
+   * `get_user_stats`, cached with a short TTL keyed by contract + address.
+   */
+  async getUserStats(
+    contractId: string,
+    userAddress: string,
+  ): Promise<UserOnChainStats | null> {
+    if (!contractId) throw new Error('Missing contractId');
+    if (!userAddress) throw new Error('Missing userAddress');
+
+    const key = this.cacheKey(contractId, `user:${userAddress}`);
+    const cached = this.getCached<UserOnChainStats | null>(key);
+    if (cached.hit) {
+      return cached.value;
+    }
+
+    const value = await this.fetchUserStatsFromContract(
+      contractId,
+      userAddress,
+    );
+    this.setCached(key, value);
+    return value;
+  }
+
+  private async fetchUserStatsFromContract(
+    contractId: string,
+    userAddress: string,
+  ): Promise<UserOnChainStats | null> {
+    return this.tracing.trace(
+      'stellar.contract.get_user_stats',
+      async (span) => {
+        span.attributes['stellar.contract.id'] = contractId;
+        span.attributes['stellar.contract.function'] = 'get_user_stats';
+        span.attributes['stellar.contract.user'] = userAddress;
+
+        this.metrics.incrementCounter('stellar_contract_invocations_total', {
+          contract_id: contractId,
+          function: 'get_user_stats',
+        });
+
+        const startTime = Date.now();
+
+        try {
+          // Simulation-only invocation does not require a funded account; a
+          // dummy account/sequence is sufficient.
+          const source = new Account(
+            this.configService.get<string>('SOROBAN_SIM_SOURCE_ACCOUNT') ||
+              'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+            '0',
+          );
+
+          const tx = new TransactionBuilder(source, {
+            fee: '100',
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              Operation.invokeContractFunction({
+                contract: contractId,
+                function: 'get_user_stats',
+                args: [new Address(userAddress).toScVal()],
+              }),
+            )
+            .setTimeout(0)
+            .build();
+
+          const sim = await this.rpcServer.simulateTransaction(tx);
+
+          const duration = Date.now() - startTime;
+          this.metrics.observeHistogram(
+            'stellar_contract_invocation_duration_ms',
+            duration,
+            {
+              contract_id: contractId,
+              function: 'get_user_stats',
+              status: 'success',
+            },
+          );
+
+          if (rpc.Api.isSimulationError(sim)) {
+            const errorMsg =
+              typeof sim.error === 'string'
+                ? sim.error
+                : 'unknown simulation error';
+            this.logger.warn(
+              `Simulation error fetching user stats for ${userAddress}: ${errorMsg}`,
+            );
+            span.status = 'error';
+            span.attributes['error.message'] = errorMsg;
+            span.attributes['error.type'] = 'SimulationError';
+            this.metrics.incrementCounter(
+              'stellar_contract_invocation_failures_total',
+              {
+                contract_id: contractId,
+                function: 'get_user_stats',
+                error_type: 'simulation_error',
+              },
+            );
+            return null;
+          }
+
+          if (!rpc.Api.isSimulationSuccess(sim)) {
+            const errorMsg = 'Unexpected simulation response';
+            this.logger.warn(`${errorMsg} for user ${userAddress}`);
+            span.status = 'error';
+            span.attributes['error.message'] = errorMsg;
+            span.attributes['error.type'] = 'SimulationFailure';
+            this.metrics.incrementCounter(
+              'stellar_contract_invocation_failures_total',
+              {
+                contract_id: contractId,
+                function: 'get_user_stats',
+                error_type: 'simulation_failure',
+              },
+            );
+            return null;
+          }
+
+          const retval = sim.result?.retval;
+          if (!retval) {
+            span.attributes['stellar.contract.result'] = 'empty';
+            return null;
+          }
+
+          const native = scValToNative(retval) as {
+            xp: bigint;
+            level: number;
+            quests_completed: number;
+          };
+          span.attributes['stellar.contract.result'] = 'success';
+
+          return {
+            xp: BigInt(native.xp),
+            level: Number(native.level),
+            quests_completed: Number(native.quests_completed),
+          };
+        } catch (error) {
+          const duration = Date.now() - startTime;
+          this.metrics.observeHistogram(
+            'stellar_contract_invocation_duration_ms',
+            duration,
+            {
+              contract_id: contractId,
+              function: 'get_user_stats',
+              status: 'failure',
+            },
+          );
+
+          const errorMsg =
+            error instanceof Error ? error.message : String(error);
+          this.logger.error(
+            `Exception during getUserStats for ${userAddress}: ${errorMsg}`,
+            error instanceof Error ? error.stack : undefined,
+          );
+
+          span.status = 'error';
+          span.attributes['error.message'] = errorMsg;
+          span.attributes['error.type'] =
+            error instanceof Error ? error.name : 'UnknownError';
+
+          this.metrics.incrementCounter(
+            'stellar_contract_invocation_failures_total',
+            {
+              contract_id: contractId,
+              function: 'get_user_stats',
+              error_type: 'exception',
+            },
+          );
+
+          throw error;
+        }
+      },
+      {
+        'stellar.contract.id': contractId,
+        'stellar.contract.function': 'get_user_stats',
+        'stellar.contract.user': userAddress,
+      },
+    );
   }
 }

--- a/BackEnd/src/modules/stellar/stellar-submission.service.spec.ts
+++ b/BackEnd/src/modules/stellar/stellar-submission.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { StellarSubmissionService } from './stellar-submission.service';
 import { StellarService } from './stellar.service';
+import { SorobanQuestReaderService } from './soroban-quest-reader.service';
 import { TracingService } from '../../common/tracing/tracing.service';
 import { MetricsService } from '../../common/services/metrics.service';
 import * as StellarSdk from 'stellar-sdk';
@@ -72,6 +73,10 @@ describe('StellarSubmissionService (Security)', () => {
         { provide: TracingService, useValue: mockTracing },
         { provide: MetricsService, useValue: mockMetrics },
         { provide: StellarService, useValue: mockStellarService },
+        {
+          provide: SorobanQuestReaderService,
+          useValue: { invalidateQuest: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -259,6 +264,10 @@ describe('StellarSubmissionService.approveSubmission (Soroban contract call)', (
         { provide: TracingService, useValue: mockTracing },
         { provide: MetricsService, useValue: metrics },
         { provide: StellarService, useValue: mockStellarService },
+        {
+          provide: SorobanQuestReaderService,
+          useValue: { invalidateQuest: jest.fn() },
+        },
       ],
     }).compile();
 

--- a/BackEnd/src/modules/stellar/stellar-submission.service.ts
+++ b/BackEnd/src/modules/stellar/stellar-submission.service.ts
@@ -19,6 +19,7 @@ import * as StellarSdk from 'stellar-sdk';
 import { TracingService } from '../../common/tracing/tracing.service';
 import { MetricsService } from '../../common/services/metrics.service';
 import { StellarService } from './stellar.service';
+import { SorobanQuestReaderService } from './soroban-quest-reader.service';
 
 export interface ApproveSubmissionResult {
   transactionHash: string;
@@ -43,6 +44,7 @@ export class StellarSubmissionService {
     private readonly tracing: TracingService,
     private readonly metrics: MetricsService,
     private readonly stellar: StellarService,
+    private readonly questReader: SorobanQuestReaderService,
   ) {}
 
   /**
@@ -177,6 +179,10 @@ export class StellarSubmissionService {
         this.logger.log(
           `approve_submission completed for quest=${questContractId} submitter=${submitterAddress} tx=${result.hash}`,
         );
+
+        // The approval bumps the quest's on-chain state (total_claims), so
+        // drop the cached get_quest read for this quest (see #1975).
+        this.questReader.invalidateQuest(contractId, questContractId);
 
         return {
           transactionHash: result.hash,

--- a/BackEnd/test/integration/soroban-quest-reader.integration-spec.ts
+++ b/BackEnd/test/integration/soroban-quest-reader.integration-spec.ts
@@ -41,6 +41,7 @@ describe('SorobanQuestReaderService (integration)', () => {
             observeHistogram: jest.fn(),
             increment: jest.fn(),
             gauge: jest.fn(),
+            setGauge: jest.fn(),
             histogram: jest.fn(),
             getMetrics: jest.fn(),
             getMetricsJson: jest.fn(),

--- a/FrontEnd/my-app/context/WalletContext.tsx
+++ b/FrontEnd/my-app/context/WalletContext.tsx
@@ -10,6 +10,7 @@ import React, {
 import { useStore } from '@/lib/store';
 import { useHydrated } from '@/lib/hooks/useHydrated';
 import * as authApi from '@/lib/api/auth';
+import type { StellarWalletsKit } from '@creit.tech/stellar-wallets-kit';
 
 interface WalletContextType {
   connect: (moduleId: string) => Promise<void>;
@@ -53,9 +54,9 @@ const SUPPORTED_WALLETS: WalletContextType['supportedWallets'] = [
 // instantiation only ever happens once per page session — every caller
 // (verification effect, connect()) awaits and reuses the same instance
 // instead of re-importing/re-constructing it.
-let kitPromise: Promise<any> | null = null;
+let kitPromise: Promise<StellarWalletsKit> | null = null;
 
-function loadWalletKit(): Promise<any> {
+function loadWalletKit(): Promise<StellarWalletsKit> {
   if (!kitPromise) {
     kitPromise = import('@creit.tech/stellar-wallets-kit')
       .then((walletKitModule) => {
@@ -100,7 +101,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
   const disconnectWallet = useStore((s) => s.disconnectWallet);
 
   // kit lives outside the store (not serialisable)
-  const [kit, setKit] = React.useState<any>(null);
+  const [kit, setKit] = React.useState<StellarWalletsKit | null>(null);
 
   const hydrated = useHydrated();
 
@@ -274,10 +275,10 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
         throw new Error('Wallet not connected');
       }
       try {
-        const { result } = await kit.sign({
-          payload: message,
+        const { signedMessage } = await kit.signMessage(message, {
+          address,
         });
-        return result;
+        return signedMessage;
       } catch (err: any) {
         console.error('Signing failed:', err);
         throw new Error(err?.message || 'Signing failed');


### PR DESCRIPTION
## Summary

Two improvements:

### #1975 — Cache Soroban contract read results with a short TTL
Repeated on-chain reads (`get_quest` / `get_user_stats`) each paid a fresh Soroban RPC simulation. `SorobanQuestReaderService` now caches idempotent contract reads in memory:
- Keyed by contract + args, TTL `SOROBAN_READ_CACHE_TTL_MS` (default 15s).
- Added a `getUserStats` reader for `get_user_stats` (xp / level / quests_completed).
- Null results are cached too, so missing quests don't keep hitting the RPC.
- Metrics: `stellar_contract_read_cache_hits_total`, `stellar_contract_read_cache_misses_total`, `stellar_contract_read_cache_entries`.
- Invalidation: `invalidateQuest` / `invalidateContract` / `clearCache`; `approveSubmission` now invalidates the affected quest's cached entry after a successful on-chain approval.
- `getQuestsBatch` benefits automatically (warm quests skip the RPC).
- Benchmark: `npm run benchmark:soroban-read-cache` (before/after), documented in `BackEnd/docs/SOROBAN_READ_CACHE.md`.

### #1932 — Proper TypeScript typing for the WalletContext kit instance
- `kit` state and the lazy `loadWalletKit()` loader are now typed as `StellarWalletsKit` from `@creit.tech/stellar-wallets-kit` instead of `any`.
- Typing surfaced a latent bug: the kit has no `sign()` method, so `signMessage` now calls the real `signMessage()` API and returns the signed message.
- `tsc --noEmit` passes with no new errors.

## Testing
- Backend: `npm run build`, `npm run lint`, prettier check, OpenAPI generation, stellar unit tests (44 passing incl. new cache regression tests), changelog discipline check — all pass; full unit suite shows no new failures vs main.
- Frontend: `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm test` (832 passing), `npm run build` — all pass.

Closes #1975
Closes #1932
