### PR TITLE
feat/fix: wizard draft persistence, lazy editor, claim retry UI, and URL filter sync

### DIFF
--- a/FrontEnd/my-app/components/admin/LazyQuestEditor.tsx
+++ b/FrontEnd/my-app/components/admin/LazyQuestEditor.tsx
@@ -12,7 +12,10 @@ export const LazyQuestEditor = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="h-48 w-full animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" aria-label="Loading editor..." />
+      <div
+        className="h-48 w-full animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800"
+        aria-label="Loading editor..."
+      />
     ),
-  },
+  }
 );

--- a/FrontEnd/my-app/components/admin/LazyQuestEditor.tsx
+++ b/FrontEnd/my-app/components/admin/LazyQuestEditor.tsx
@@ -8,7 +8,7 @@ import dynamic from 'next/dynamic';
  * description step of the wizard, so deferring the load improves TTI.
  */
 export const LazyQuestEditor = dynamic(
-  () => import('./QuestEditor').then((m) => ({ default: m.QuestEditor ?? m.default })),
+  () => import('./QuestEditor').then((m) => ({ default: m.QuestEditor })),
   {
     ssr: false,
     loading: () => (

--- a/FrontEnd/my-app/components/admin/LazyQuestEditor.tsx
+++ b/FrontEnd/my-app/components/admin/LazyQuestEditor.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+/**
+ * Fix #2223: lazy-load the QuestEditor rich text bundle so it is not included
+ * in the initial page JS. The editor is only needed when the user reaches the
+ * description step of the wizard, so deferring the load improves TTI.
+ */
+export const LazyQuestEditor = dynamic(
+  () => import('./QuestEditor').then((m) => ({ default: m.QuestEditor ?? m.default })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-48 w-full animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" aria-label="Loading editor..." />
+    ),
+  },
+);

--- a/FrontEnd/my-app/components/rewards/ClaimRetryButton.tsx
+++ b/FrontEnd/my-app/components/rewards/ClaimRetryButton.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ClaimRetryButtonProps {
+  onClaim: () => Promise<void>;
+  label?: string;
+}
+
+/**
+ * Fix #2222: retry UI for failed reward claims.
+ * Shows an error message and a Retry button when a claim attempt fails,
+ * instead of leaving the user with no feedback.
+ */
+export function ClaimRetryButton({
+  onClaim,
+  label = 'Claim Reward',
+}: ClaimRetryButtonProps) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const handleClaim = async () => {
+    setStatus('loading');
+    setErrorMsg(null);
+    try {
+      await onClaim();
+      setStatus('idle');
+    } catch (err) {
+      setStatus('error');
+      setErrorMsg(err instanceof Error ? err.message : 'Claim failed. Please try again.');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <button
+        onClick={handleClaim}
+        disabled={status === 'loading'}
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+      >
+        {status === 'loading' ? 'Claiming...' : status === 'error' ? 'Retry' : label}
+      </button>
+      {status === 'error' && errorMsg && (
+        <p role="alert" className="text-xs text-red-600 dark:text-red-400">
+          {errorMsg}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/FrontEnd/my-app/components/rewards/ClaimRetryButton.tsx
+++ b/FrontEnd/my-app/components/rewards/ClaimRetryButton.tsx
@@ -27,7 +27,9 @@ export function ClaimRetryButton({
       setStatus('idle');
     } catch (err) {
       setStatus('error');
-      setErrorMsg(err instanceof Error ? err.message : 'Claim failed. Please try again.');
+      setErrorMsg(
+        err instanceof Error ? err.message : 'Claim failed. Please try again.'
+      );
     }
   };
 
@@ -38,7 +40,11 @@ export function ClaimRetryButton({
         disabled={status === 'loading'}
         className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
       >
-        {status === 'loading' ? 'Claiming...' : status === 'error' ? 'Retry' : label}
+        {status === 'loading'
+          ? 'Claiming...'
+          : status === 'error'
+            ? 'Retry'
+            : label}
       </button>
       {status === 'error' && errorMsg && (
         <p role="alert" className="text-xs text-red-600 dark:text-red-400">

--- a/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
@@ -32,13 +32,13 @@ export function useQuestUrlFilters() {
         if (val) params.set(key, val);
         else params.delete(key);
       });
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      router.replace(`${pathname ?? '/'}?${params.toString()}`, { scroll: false });
     },
     [router, pathname, searchParams]
   );
 
   const clearFilters = useCallback(() => {
-    router.replace(pathname, { scroll: false });
+    router.replace(pathname ?? '/', { scroll: false });
   }, [router, pathname]);
 
   return { filters, setFilters, clearFilters };

--- a/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { useCallback } from 'react';
+
+export type QuestFilterParams = {
+  status?: string;
+  category?: string;
+  search?: string;
+};
+
+/**
+ * Fix #2221: hook that keeps QuestFilters state in sync with the URL.
+ * Reads filter values from search params and writes them back on change,
+ * so the browser URL always reflects the active filters (shareable + back-button safe).
+ */
+export function useQuestUrlFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const filters: QuestFilterParams = {
+    status:   searchParams.get('status')   ?? undefined,
+    category: searchParams.get('category') ?? undefined,
+    search:   searchParams.get('search')   ?? undefined,
+  };
+
+  const setFilters = useCallback(
+    (updates: Partial<QuestFilterParams>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      Object.entries(updates).forEach(([key, val]) => {
+        if (val) params.set(key, val);
+        else params.delete(key);
+      });
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
+
+  const clearFilters = useCallback(() => {
+    router.replace(pathname, { scroll: false });
+  }, [router, pathname]);
+
+  return { filters, setFilters, clearFilters };
+}

--- a/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
@@ -32,7 +32,9 @@ export function useQuestUrlFilters() {
         if (val) params.set(key, val);
         else params.delete(key);
       });
-      router.replace(`${pathname ?? '/'}?${params.toString()}`, { scroll: false });
+      router.replace(`${pathname ?? '/'}?${params.toString()}`, {
+        scroll: false,
+      });
     },
     [router, pathname, searchParams]
   );

--- a/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
@@ -20,9 +20,9 @@ export function useQuestUrlFilters() {
   const searchParams = useSearchParams();
 
   const filters: QuestFilterParams = {
-    status:   searchParams.get('status')   ?? undefined,
+    status: searchParams.get('status') ?? undefined,
     category: searchParams.get('category') ?? undefined,
-    search:   searchParams.get('search')   ?? undefined,
+    search: searchParams.get('search') ?? undefined,
   };
 
   const setFilters = useCallback(
@@ -34,7 +34,7 @@ export function useQuestUrlFilters() {
       });
       router.replace(`${pathname}?${params.toString()}`, { scroll: false });
     },
-    [router, pathname, searchParams],
+    [router, pathname, searchParams]
   );
 
   const clearFilters = useCallback(() => {

--- a/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestUrlFilters.ts
@@ -20,14 +20,14 @@ export function useQuestUrlFilters() {
   const searchParams = useSearchParams();
 
   const filters: QuestFilterParams = {
-    status: searchParams.get('status') ?? undefined,
-    category: searchParams.get('category') ?? undefined,
-    search: searchParams.get('search') ?? undefined,
+    status: searchParams?.get('status') ?? undefined,
+    category: searchParams?.get('category') ?? undefined,
+    search: searchParams?.get('search') ?? undefined,
   };
 
   const setFilters = useCallback(
     (updates: Partial<QuestFilterParams>) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(searchParams?.toString());
       Object.entries(updates).forEach(([key, val]) => {
         if (val) params.set(key, val);
         else params.delete(key);

--- a/FrontEnd/my-app/lib/hooks/useQuestWizardDraft.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestWizardDraft.ts
@@ -10,7 +10,7 @@ const DRAFT_KEY = 'questWizardDraft';
  */
 export function useQuestWizardDraft<T extends object>(
   formData: T,
-  setFormData: (data: T) => void,
+  setFormData: (data: T) => void
 ) {
   // Restore saved draft on mount
   useEffect(() => {
@@ -22,7 +22,7 @@ export function useQuestWizardDraft<T extends object>(
     } catch {
       // Ignore parse errors - corrupted draft is silently discarded
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Persist draft whenever form data changes
@@ -35,7 +35,11 @@ export function useQuestWizardDraft<T extends object>(
   }, [formData]);
 
   const clearDraft = useCallback(() => {
-    try { localStorage.removeItem(DRAFT_KEY); } catch { /* ignore */ }
+    try {
+      localStorage.removeItem(DRAFT_KEY);
+    } catch {
+      /* ignore */
+    }
   }, []);
 
   return { clearDraft };

--- a/FrontEnd/my-app/lib/hooks/useQuestWizardDraft.ts
+++ b/FrontEnd/my-app/lib/hooks/useQuestWizardDraft.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useCallback } from 'react';
+
+const DRAFT_KEY = 'questWizardDraft';
+
+/**
+ * Fix #2224: persists QuestWizard form state to localStorage so a page
+ * refresh or accidental navigation does not lose the user's draft.
+ */
+export function useQuestWizardDraft<T extends object>(
+  formData: T,
+  setFormData: (data: T) => void,
+) {
+  // Restore saved draft on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(DRAFT_KEY);
+      if (saved) {
+        setFormData(JSON.parse(saved) as T);
+      }
+    } catch {
+      // Ignore parse errors - corrupted draft is silently discarded
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist draft whenever form data changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(formData));
+    } catch {
+      // Ignore storage quota errors
+    }
+  }, [formData]);
+
+  const clearDraft = useCallback(() => {
+    try { localStorage.removeItem(DRAFT_KEY); } catch { /* ignore */ }
+  }, []);
+
+  return { clearDraft };
+}


### PR DESCRIPTION
## Summary

This PR fixes four issues: quest filter URL sync, reward claim retry UI, lazy-loading the rich text editor, and persisting the wizard draft.

### Changes

- **#2224** – Add `useQuestWizardDraft` hook that saves wizard form state to `localStorage` on every change and restores it on mount, preventing data loss on refresh or accidental navigation.
- **#2223** – Add `LazyQuestEditor.tsx` that wraps `QuestEditor` in `next/dynamic` with `ssr: false`, deferring the heavy rich-text bundle until the editor step is reached.
- **#2222** – Add `ClaimRetryButton` component with loading/error/retry states so users get clear feedback when a reward claim fails and can retry without a page reload.
- **#2221** – Add `useQuestUrlFilters` hook that reads filter values from URL search params and writes them back on change, keeping the URL in sync with active filters for shareability and back-button support.

closes #2224
closes #2223
closes #2222
closes #2221