### PR TITLE
feat(submissions): add pagination controls to submissions table

### DIFF
--- a/FrontEnd/my-app/components/submission/SubmissionsTable.test.tsx
+++ b/FrontEnd/my-app/components/submission/SubmissionsTable.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { SubmissionsTable } from './SubmissionsTable';
+import type { Submission } from '@/lib/types/submission';
+
+vi.mock('./StatusBadge', () => ({
+  StatusBadge: ({ status }: { status: string }) => status,
+}));
+
+function makeSubmissions(count: number): Submission[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `submission-${index + 1}`,
+    questId: `quest-${index + 1}`,
+    userId: 'user-1',
+    status: 'Pending',
+    proof: {},
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    quest: {
+      id: `quest-${index + 1}`,
+      title: `Quest ${index + 1}`,
+      rewardAmount: '10',
+      rewardAsset: 'XLM',
+    },
+  }));
+}
+
+describe('SubmissionsTable pagination', () => {
+  it('shows the first ten submissions and pagination controls by default', () => {
+    render(<SubmissionsTable submissions={makeSubmissions(25)} />);
+
+    expect(screen.getByText('Quest 1')).toBeInTheDocument();
+    expect(screen.getByText('Quest 10')).toBeInTheDocument();
+    expect(screen.queryByText('Quest 11')).not.toBeInTheDocument();
+    expect(screen.getByTestId('submissions-table-range')).toHaveTextContent(
+      'Showing 1–10 of 25'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Previous page' })
+    ).toBeDisabled();
+  });
+
+  it('moves between pages and updates the displayed range', () => {
+    render(<SubmissionsTable submissions={makeSubmissions(25)} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+
+    expect(screen.getByText('Quest 11')).toBeInTheDocument();
+    expect(screen.queryByText('Quest 1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('submissions-table-range')).toHaveTextContent(
+      'Showing 11–20 of 25'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous page' }));
+
+    expect(screen.getByText('Quest 1')).toBeInTheDocument();
+  });
+
+  it('returns to the first page when the submission results change', () => {
+    const submissions = makeSubmissions(25);
+    const { rerender } = render(<SubmissionsTable submissions={submissions} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    rerender(<SubmissionsTable submissions={[...submissions]} />);
+
+    expect(screen.getByTestId('submissions-table-range')).toHaveTextContent(
+      'Showing 1–10 of 25'
+    );
+    expect(screen.getByText('Quest 1')).toBeInTheDocument();
+  });
+
+  it('does not show controls when all submissions fit on one page', () => {
+    render(<SubmissionsTable submissions={makeSubmissions(10)} />);
+
+    expect(
+      screen.queryByTestId('submissions-table-range')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Next page' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/FrontEnd/my-app/components/submission/SubmissionsTable.tsx
+++ b/FrontEnd/my-app/components/submission/SubmissionsTable.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { memo } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 import { StatusBadge } from './StatusBadge';
 import type { Submission } from '@/lib/types/submission';
 import { formatShortDate } from '@/lib/utils/date';
+import { Pagination } from '@/components/ui/Pagination';
+
+const PAGE_SIZE = 10;
 
 interface SubmissionsTableProps {
   submissions: Submission[];
@@ -27,6 +30,21 @@ export const SubmissionsTable = memo(function SubmissionsTable({
   submissions,
   onSubmissionClick,
 }: SubmissionsTableProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = Math.max(1, Math.ceil(submissions.length / PAGE_SIZE));
+  const activePage = Math.min(currentPage, totalPages);
+  const visibleSubmissions = useMemo(() => {
+    const start = (activePage - 1) * PAGE_SIZE;
+    return submissions.slice(start, start + PAGE_SIZE);
+  }, [activePage, submissions]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [submissions]);
+
+  const startRow = (activePage - 1) * PAGE_SIZE + 1;
+  const endRow = Math.min(activePage * PAGE_SIZE, submissions.length);
+
   return (
     <div className="overflow-x-auto rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
       <table className="w-full divide-y divide-zinc-200 dark:divide-zinc-800">
@@ -71,7 +89,7 @@ export const SubmissionsTable = memo(function SubmissionsTable({
           </tr>
         </thead>
         <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-800 dark:bg-zinc-900">
-          {submissions.map((submission) => {
+          {visibleSubmissions.map((submission) => {
             const proofDisplay = getProofDisplay(submission.proof);
             const hasProof = proofDisplay !== '-';
 
@@ -169,6 +187,22 @@ export const SubmissionsTable = memo(function SubmissionsTable({
           })}
         </tbody>
       </table>
+
+      {totalPages > 1 && (
+        <div className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">
+          <p
+            className="text-sm text-zinc-500 dark:text-zinc-400"
+            data-testid="submissions-table-range"
+          >
+            Showing {startRow}–{endRow} of {submissions.length}
+          </p>
+          <Pagination
+            currentPage={activePage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+      )}
     </div>
   );
 });

--- a/FrontEnd/my-app/components/ui/Pagination.tsx
+++ b/FrontEnd/my-app/components/ui/Pagination.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import React from 'react';
+
 /**
  * Props for the pagination control used across lists and discovery screens.
  */


### PR DESCRIPTION
## Linked Issue

Closes #2268

## Description

**What changed?**
Added client-side pagination controls to `SubmissionsTable`, including a 10-row page size, accessible previous/next/page navigation, and a visible result range. Pagination resets when the submission results change.

**Why was it changed?**
Large submission result sets were rendered as one unpaginated table.

**How was it implemented?**
The table now slices its submitted results and reuses the existing shared `Pagination` component.

## Type of Change

- [x] New feature (non-breaking change)
- [x] Tests added

## Test Evidence

- [x] Focused pagination tests (4 passed)
- [x] Full frontend tests (90 files, 836 tests passed)
- [x] Type-check passed
- [x] Lint passed with existing warnings and no errors
- [x] Path-alias validation passed
- [x] Prettier format check passed
- [x] Secret `.env` guard passed

## Known Limitations / CI Notes

The local production build was attempted but could not resolve `fonts.googleapis.com` in the environment. No unrelated working-tree changes were included.