### PR TITLE
feat: cap oracle registrations, emit dispute outcomes, harden wallet/offline UX

### DIFF
--- a/FrontEnd/my-app/app/[locale]/layout.tsx
+++ b/FrontEnd/my-app/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { SkipToContent } from '@/components/a11y/SkipToContent';
 import PerformanceMonitor from '@/components/ui/PerformanceMonitor';
 import { EnvValidator } from '@/components/providers/EnvValidator';
 import { SWRegister } from '@/components/SWRegister';
+import { GlobalOfflineIndicator } from '@/components/quest/GlobalOfflineIndicator';
 import { createPageMetadata, getLocale } from '@/lib/seo';
 
 const geistSans = Geist({
@@ -81,6 +82,9 @@ export default async function RootLayout({
             <I18nProvider locale={locale}>
               <SkipToContent />
               <SWRegister />
+              {/* Global connectivity banner — covers every route so users get
+                  offline feedback on pages that do not render their own. */}
+              <GlobalOfflineIndicator />
               {children}
               <PerformanceMonitor />
               <ConsentBanner />

--- a/FrontEnd/my-app/app/[locale]/quests/[id]/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/quests/[id]/page.tsx
@@ -6,12 +6,10 @@ import Link from 'next/link';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { QuestDetail } from '@/components/quest/QuestDetail';
 import { SubmissionForm } from '@/components/submission/SubmissionForm';
-import { OfflineIndicator } from '@/components/quest/OfflineIndicator';
 import { RetryButton } from '@/components/quest/RetryButton';
 import { getQuestById } from '@/lib/api/quests';
 import type { Quest } from '@/lib/types/quest';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
-import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
 import { Skeleton } from '@/components/ui/Skeleton';
 
@@ -19,7 +17,6 @@ export default function QuestDetailPage() {
   const params = useParams();
   const router = useRouter();
   const questId = params?.id as string;
-  const { isOnline } = useOnlineStatus();
 
   const [quest, setQuest] = useState<Quest | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -59,9 +56,6 @@ export default function QuestDetailPage() {
   if (isLoading) {
     return (
       <AppLayout>
-        {/* Offline Indicator */}
-        <OfflineIndicator isOffline={!isOnline} />
-
         <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           {/* Back Button Skeleton */}
           <div className="mb-6">
@@ -98,9 +92,6 @@ export default function QuestDetailPage() {
   if (error) {
     return (
       <AppLayout>
-        {/* Offline Indicator */}
-        <OfflineIndicator isOffline={!isOnline} />
-
         <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           {/* Back Button */}
           <Link
@@ -170,9 +161,6 @@ export default function QuestDetailPage() {
 
   return (
     <AppLayout>
-      {/* Offline Indicator */}
-      <OfflineIndicator isOffline={!isOnline} />
-
       <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
         {/* Back Button */}
         <Link

--- a/FrontEnd/my-app/app/[locale]/quests/page.tsx
+++ b/FrontEnd/my-app/app/[locale]/quests/page.tsx
@@ -7,21 +7,18 @@ import { AppLayout } from '@/components/layout/AppLayout';
 import { SearchBar } from '@/components/ui/SearchBar';
 import { QuestListFilters } from '@/components/quest/QuestListFilters';
 import { QuestList } from '@/components/quest/QuestList';
-import { OfflineIndicator } from '@/components/quest/OfflineIndicator';
 import { Pagination } from '@/components/ui/Pagination';
 import { QuestStatus, QuestDifficulty } from '@/lib/types/quest';
 import type { Quest } from '@/lib/types/quest';
 import LazyLoad from '@/components/ui/LazyLoad';
 import { ComponentErrorBoundary } from '@/components/error/ErrorBoundary';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { useQuests } from '@/lib/hooks/useQuests';
 
 function QuestsContent() {
   const searchParams = useSearchParams()!;
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState('');
-  const { isOnline } = useOnlineStatus();
 
   // Derive filter state from URL search params
   const statusParam = searchParams.get('status');
@@ -155,11 +152,6 @@ function QuestsContent() {
 
   return (
     <AppLayout>
-      <OfflineIndicator
-        isOffline={!isOnline}
-        message="You appear to be offline. Quest data may not load properly."
-      />
-
       <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
         {/* Header */}
         <div

--- a/FrontEnd/my-app/components/quest/GlobalOfflineIndicator.test.tsx
+++ b/FrontEnd/my-app/components/quest/GlobalOfflineIndicator.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { GlobalOfflineIndicator } from './GlobalOfflineIndicator';
+
+const { mockIsOnline } = vi.hoisted(() => {
+  let isOnline = true;
+  return {
+    mockIsOnline: {
+      get value() {
+        return isOnline;
+      },
+      set value(v: boolean) {
+        isOnline = v;
+      },
+    },
+  };
+});
+
+vi.mock('@/lib/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: () => ({
+    isOnline: mockIsOnline.value,
+    hasRetryableError: false,
+    retryFailedRequest: vi.fn(),
+  }),
+}));
+
+describe('GlobalOfflineIndicator', () => {
+  it('renders the offline banner when the app is offline', () => {
+    mockIsOnline.value = false;
+    render(<GlobalOfflineIndicator />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(
+      screen.getByText('You appear to be offline. Some features may not work.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when the app is online', () => {
+    mockIsOnline.value = true;
+    const { container } = render(<GlobalOfflineIndicator />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/FrontEnd/my-app/components/quest/GlobalOfflineIndicator.tsx
+++ b/FrontEnd/my-app/components/quest/GlobalOfflineIndicator.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+import { OfflineIndicator } from './OfflineIndicator';
+
+/**
+ * App-wide offline banner.
+ *
+ * Mounted once in the root layout so every page reports connectivity loss.
+ * Reads connectivity from the global store (see `useOnlineStatus`), which is
+ * initialised in an effect rather than during render, so server-rendered
+ * markup never contains `navigator.onLine` (avoids hydration mismatches).
+ */
+export function GlobalOfflineIndicator() {
+  const { isOnline } = useOnlineStatus();
+  return <OfflineIndicator isOffline={!isOnline} />;
+}

--- a/FrontEnd/my-app/components/wallet/ConnectButton.test.tsx
+++ b/FrontEnd/my-app/components/wallet/ConnectButton.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ConnectButton } from './ConnectButton';
+
+const { mockLogout, mockDisconnect, mockOpenModal } = vi.hoisted(() => ({
+  mockLogout: vi.fn(),
+  mockDisconnect: vi.fn(),
+  mockOpenModal: vi.fn(),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    logout: mockLogout,
+  }),
+}));
+
+vi.mock('../../context/WalletContext', () => ({
+  useWallet: () => ({
+    isConnected: true,
+    address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD',
+    isVerifyingWallet: false,
+    openModal: mockOpenModal,
+    disconnect: mockDisconnect,
+  }),
+}));
+
+describe('ConnectButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogout.mockResolvedValue(undefined);
+    mockDisconnect.mockResolvedValue(undefined);
+  });
+
+  it('shows a confirm step before disconnecting the wallet', async () => {
+    render(<ConnectButton />);
+
+    // Open the wallet menu.
+    fireEvent.click(screen.getByRole('button', { name: /GABC/i }));
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+
+    // The disconnect must NOT happen yet — a confirmation dialog appears.
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockDisconnect).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByText('Disconnect Wallet')).toBeInTheDocument();
+  });
+
+  it('disconnects only after the user confirms', async () => {
+    render(<ConnectButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: /GABC/i }));
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    // The dialog closes once the disconnect completes.
+    await waitFor(() => {
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not disconnect when the user cancels', () => {
+    render(<ConnectButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: /GABC/i }));
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockDisconnect).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});

--- a/FrontEnd/my-app/components/wallet/ConnectButton.tsx
+++ b/FrontEnd/my-app/components/wallet/ConnectButton.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import React from 'react';
 import { useWallet } from '../../context/WalletContext';
 import { useAuth } from '../../context/AuthContext';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useState, useRef, useEffect } from 'react';
-import { LogOut, User } from 'lucide-react';
+import { LogOut } from 'lucide-react';
+import { DisconnectWalletDialog } from './DisconnectWalletDialog';
 
 const ArrowDownIcon = () => (
   <svg
@@ -27,6 +29,8 @@ export function ConnectButton() {
     useWallet();
   const { isAuthenticated, logout } = useAuth();
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const formatAddress = (addr: string) => {
@@ -34,9 +38,23 @@ export function ConnectButton() {
     return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
   };
 
-  const handleLogout = async () => {
-    await logout();
+  // Disconnecting the wallet clears the wallet session context, so require an
+  // explicit confirmation before it can happen (issue #2274).
+  const handleLogoutClick = () => {
     setDropdownOpen(false);
+    setShowDisconnectConfirm(true);
+  };
+
+  const handleConfirmDisconnect = async () => {
+    setIsDisconnecting(true);
+    try {
+      // Sign out of the backend session and disconnect the wallet.
+      await logout();
+      await disconnect();
+    } finally {
+      setIsDisconnecting(false);
+      setShowDisconnectConfirm(false);
+    }
   };
 
   useEffect(() => {
@@ -89,7 +107,7 @@ export function ConnectButton() {
             >
               <button
                 type="button"
-                onClick={handleLogout}
+                onClick={handleLogoutClick}
                 className="flex w-full items-center gap-3 px-4 py-3 text-sm font-medium text-red-500 transition-colors hover:bg-zinc-100 dark:text-red-400 dark:hover:bg-white/5"
               >
                 <LogOut className="h-4 w-4" />
@@ -98,6 +116,13 @@ export function ConnectButton() {
             </motion.div>
           )}
         </AnimatePresence>
+
+        <DisconnectWalletDialog
+          open={showDisconnectConfirm}
+          onConfirm={handleConfirmDisconnect}
+          onCancel={() => setShowDisconnectConfirm(false)}
+          isDisconnecting={isDisconnecting}
+        />
       </div>
     );
   }

--- a/FrontEnd/my-app/components/wallet/DisconnectWalletDialog.test.tsx
+++ b/FrontEnd/my-app/components/wallet/DisconnectWalletDialog.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DisconnectWalletDialog } from './DisconnectWalletDialog';
+
+const defaultProps = {
+  open: true,
+  onConfirm: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('DisconnectWalletDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <DisconnectWalletDialog {...defaultProps} open={false} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the confirmation dialog when open', () => {
+    render(<DisconnectWalletDialog {...defaultProps} />);
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByText('Disconnect Wallet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^disconnect$/i })
+    ).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when Disconnect is clicked', () => {
+    render(<DisconnectWalletDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onCancel).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when Cancel is clicked', () => {
+    render(<DisconnectWalletDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('disables both buttons while disconnecting', () => {
+    render(<DisconnectWalletDialog {...defaultProps} isDisconnecting />);
+
+    expect(
+      screen.getByRole('button', { name: /disconnecting/i })
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/FrontEnd/my-app/components/wallet/DisconnectWalletDialog.tsx
+++ b/FrontEnd/my-app/components/wallet/DisconnectWalletDialog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React from 'react';
+
+export interface DisconnectWalletDialogProps {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDisconnecting?: boolean;
+}
+
+/**
+ * Confirmation dialog shown before disconnecting the wallet.
+ *
+ * Requires an explicit confirm click before the disconnect fires so an
+ * accidental click cannot drop the wallet session context (issue #2274).
+ */
+export function DisconnectWalletDialog({
+  open,
+  onConfirm,
+  onCancel,
+  isDisconnecting = false,
+}: DisconnectWalletDialogProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="disconnect-dialog-title"
+      aria-describedby="disconnect-dialog-desc"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900">
+        <h2
+          id="disconnect-dialog-title"
+          className="text-lg font-semibold text-zinc-900 dark:text-zinc-50"
+        >
+          Disconnect Wallet
+        </h2>
+        <p
+          id="disconnect-dialog-desc"
+          className="mt-2 text-sm text-zinc-600 dark:text-zinc-400"
+        >
+          You will be signed out and this wallet will be disconnected from your
+          session. You can reconnect at any time.
+        </p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isDisconnecting}
+            className="rounded-lg border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isDisconnecting}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/contracts/earn-quest/CHANGELOG.md
+++ b/contracts/earn-quest/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Registered oracle configurations are now capped at `MAX_ORACLE_CONFIGS` (10) in `oracle.rs`/`storage.rs`, preventing unbounded instance storage growth and unbounded aggregation gas. Registering beyond the cap returns `Error::OracleLimitReached` (code 108); updating an existing oracle at the cap remains allowed.
 - Property-based quest lifecycle invariant tests in `tests/property_tests.rs`: escrow balance, payout bounds, and cancel acyclicity are fuzzed via QuickCheck (1000 sequences) and proptest against the live Soroban client (50 sequences).
 - 2-of-2 SuperAdmin clawback: `initiate_clawback` and `execute_clawback` entry points in `payout.rs` allow two distinct SuperAdmins to collaboratively recover funds sent to a fraudulent recipient. Emits `ClawbackInitiated` and `ClawbackExecuted` events. Adds `ClawbackPending` storage key, `ClawbackNotFound` (150) and `ClawbackAlreadySigned` (151) error variants.
 - Added 	est_double_claim.rs: verifies that a second claim on the same submission is rejected, preventing double-claim under concurrent attempts.
@@ -25,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Minimum creator level requirement and creator whitelist. Admin can set a level threshold (default 0 = disabled); quest creation fails if the creator's XP level is below it. Whitelisted addresses bypass the check.
 
 ### Breaking Changes
+
+#### Events - `DisputeResolved` now carries the resolution outcome
+- **Impact**: Indexers decoding the `disp_res` event will now find a `(upheld: bool, slash_bps: u32)` data payload instead of an empty payload. The topics (quest_id, initiator, arbitrator) are unchanged.
+- **Affected Files**: [events.rs](contracts/earn-quest/src/events.rs), [dispute.rs](contracts/earn-quest/src/dispute.rs)
+- **Migration Required**: No on-chain storage migration. Indexer schemas should be updated to decode the new payload fields.
 
 #### Contract - `get_admin` returns `Result<Address, Error>` instead of panicking
 - **Impact**: The public `get_admin` entrypoint now returns `Result<Address, Error>` (via `ok_or(Error::NotInitialized)`) instead of a bare `Address`. Clients and contracts that invoke `get_admin` on an uninitialized contract previously triggered a panic; they now receive a graceful `Error::NotInitialized` (code 93).

--- a/contracts/earn-quest/src/dispute.rs
+++ b/contracts/earn-quest/src/dispute.rs
@@ -122,8 +122,8 @@ pub fn resolve_dispute(
     dispute.status = DisputeStatus::Resolved;
     storage::set_dispute(env, &quest_id, &initiator, &dispute);
 
-    // Emit event
-    events::dispute_resolved(env, quest_id, initiator, arbitrator);
+    // Emit event carrying the resolution outcome so indexers can track rulings.
+    events::dispute_resolved(env, quest_id, initiator, arbitrator, upheld, slash_bps);
 
     Ok(())
 }

--- a/contracts/earn-quest/src/errors.rs
+++ b/contracts/earn-quest/src/errors.rs
@@ -131,6 +131,7 @@ pub enum Error {
     InvalidOracleData = 105,
     LowOracleConfidence = 106,
     RewardDeviationTooHigh = 107,
+    OracleLimitReached = 108,
 
     // Arithmetic
     ArithmeticOverflow = 110,

--- a/contracts/earn-quest/src/events.rs
+++ b/contracts/earn-quest/src/events.rs
@@ -407,14 +407,26 @@ pub fn dispute_opened(env: &Env, quest_id: Symbol, initiator: Address, arbitrato
 }
 
 /// Emitted when a dispute is resolved (indexed: quest_id, initiator, arbitrator).
-pub fn dispute_resolved(env: &Env, quest_id: Symbol, initiator: Address, arbitrator: Address) {
+///
+/// The data payload carries the resolution outcome so indexers can track
+/// rulings without decoding contract storage:
+/// * `upheld` - `true` when the dispute was upheld (verifier was wrong).
+/// * `slash_bps` - Basis points slashed from the verifier stake (0 if none).
+pub fn dispute_resolved(
+    env: &Env,
+    quest_id: Symbol,
+    initiator: Address,
+    arbitrator: Address,
+    upheld: bool,
+    slash_bps: u32,
+) {
     let topics = (
         TOPIC_DISPUTE_RESOLVED,
         quest_id,
         initiator.clone(),
         arbitrator.clone(),
     );
-    let data = ();
+    let data = (upheld, slash_bps);
     env.events().publish(topics, data);
 }
 

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -29,6 +29,9 @@ mod test_clawback;
 mod test_oracle_deviation;
 
 #[cfg(test)]
+mod test_oracle_cap;
+
+#[cfg(test)]
 mod test_incremental_stats;
 
 #[cfg(test)]

--- a/contracts/earn-quest/src/oracle.rs
+++ b/contracts/earn-quest/src/oracle.rs
@@ -11,6 +11,12 @@ pub trait OracleInterface {
     fn price(env: Env, base: Address, quote: Address) -> Option<PriceData>;
 }
 
+/// Maximum number of oracle configurations that may be registered.
+///
+/// Guards against unbounded instance storage growth and unbounded gas cost
+/// in `get_aggregated_price`, which iterates every registered oracle.
+pub const MAX_ORACLE_CONFIGS: u32 = 10;
+
 /// Oracle module for decentralized price feeds
 pub struct Oracle;
 

--- a/contracts/earn-quest/src/storage.rs
+++ b/contracts/earn-quest/src/storage.rs
@@ -738,6 +738,12 @@ pub fn set_oracle_addresses(env: &Env, addrs: &Vec<Address>) {
 pub fn add_oracle_config(env: &Env, config: &OracleConfig) -> Result<(), Error> {
     let mut addrs = get_oracle_addresses(env);
     if !addrs.contains(&config.oracle_address) {
+        // Cap the number of distinct registered oracles so aggregation cost
+        // (which iterates every config) stays bounded. Updating an already
+        // registered oracle is always allowed, even at the cap.
+        if addrs.len() >= crate::oracle::MAX_ORACLE_CONFIGS {
+            return Err(Error::OracleLimitReached);
+        }
         addrs.push_back(config.oracle_address.clone());
         set_oracle_addresses(env, &addrs);
     }

--- a/contracts/earn-quest/src/test_oracle_cap.rs
+++ b/contracts/earn-quest/src/test_oracle_cap.rs
@@ -1,0 +1,134 @@
+#![cfg(test)]
+
+//! Unit tests for the cap on registered oracle configurations.
+//!
+//! Guards against unbounded instance storage and unbounded gas in
+//! `get_aggregated_price`, which iterates every registered oracle.
+
+use crate::errors::Error;
+use crate::oracle::MAX_ORACLE_CONFIGS;
+use crate::storage;
+use crate::types::{OracleConfig, OracleType};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn make_config(oracle_address: Address) -> OracleConfig {
+    OracleConfig {
+        oracle_address,
+        oracle_type: OracleType::StellarAsset,
+        max_age_seconds: 300,
+        min_confidence: 50,
+        is_active: true,
+    }
+}
+
+#[test]
+fn registering_up_to_the_cap_is_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+
+    env.as_contract(&cid, || {
+        for _ in 0..MAX_ORACLE_CONFIGS {
+            let config = make_config(Address::generate(&env));
+            assert!(storage::add_oracle_config(&env, &config).is_ok());
+        }
+
+        assert_eq!(
+            storage::get_oracle_addresses(&env).len(),
+            MAX_ORACLE_CONFIGS
+        );
+    });
+}
+
+#[test]
+fn registering_beyond_the_cap_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+
+    env.as_contract(&cid, || {
+        for _ in 0..MAX_ORACLE_CONFIGS {
+            let config = make_config(Address::generate(&env));
+            storage::add_oracle_config(&env, &config).unwrap();
+        }
+
+        // The next new oracle exceeds the cap.
+        let extra = make_config(Address::generate(&env));
+        assert_eq!(
+            storage::add_oracle_config(&env, &extra),
+            Err(Error::OracleLimitReached)
+        );
+
+        // The list is unchanged and the over-cap config was not persisted.
+        assert_eq!(
+            storage::get_oracle_addresses(&env).len(),
+            MAX_ORACLE_CONFIGS
+        );
+        assert_eq!(
+            storage::get_oracle_config(&env, &extra.oracle_address),
+            Err(Error::OracleInactive)
+        );
+    });
+}
+
+#[test]
+fn updating_an_existing_oracle_at_the_cap_is_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+
+    env.as_contract(&cid, || {
+        let mut first = None;
+        for _ in 0..MAX_ORACLE_CONFIGS {
+            let config = make_config(Address::generate(&env));
+            storage::add_oracle_config(&env, &config).unwrap();
+            if first.is_none() {
+                first = Some(config);
+            }
+        }
+
+        // Updating an already-registered oracle must not hit the cap.
+        let mut updated = first.unwrap();
+        updated.is_active = false;
+        updated.max_age_seconds = 600;
+        assert!(storage::update_oracle_config(&env, &updated).is_ok());
+
+        // The update is persisted and the address list is unchanged.
+        let stored = storage::get_oracle_config(&env, &updated.oracle_address).unwrap();
+        assert!(!stored.is_active);
+        assert_eq!(stored.max_age_seconds, 600);
+        assert_eq!(
+            storage::get_oracle_addresses(&env).len(),
+            MAX_ORACLE_CONFIGS
+        );
+    });
+}
+
+#[test]
+fn removing_an_oracle_frees_a_slot() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+
+    env.as_contract(&cid, || {
+        let mut first = None;
+        for _ in 0..MAX_ORACLE_CONFIGS {
+            let config = make_config(Address::generate(&env));
+            storage::add_oracle_config(&env, &config).unwrap();
+            if first.is_none() {
+                first = Some(config);
+            }
+        }
+
+        // Removing one oracle allows a new one to be registered.
+        let removed = first.unwrap();
+        storage::remove_oracle_config(&env, &removed.oracle_address).unwrap();
+        let replacement = make_config(Address::generate(&env));
+        assert!(storage::add_oracle_config(&env, &replacement).is_ok());
+        assert_eq!(
+            storage::get_oracle_addresses(&env).len(),
+            MAX_ORACLE_CONFIGS
+        );
+    });
+}

--- a/contracts/earn-quest/tests/test_dispute.rs
+++ b/contracts/earn-quest/tests/test_dispute.rs
@@ -67,6 +67,59 @@ fn test_open_and_resolve_dispute_emit_indexed_events() {
     assert_eq!(resolved_arbitrator, arbitrator);
 }
 
+/// Registers a quest on the contract so an upheld resolution (which looks
+/// up the quest's verifier) can complete.
+fn register_quest(env: &Env, client: &EarnQuestContractClient<'static>, quest_id: &Symbol) {
+    let token_issuer = Address::generate(env);
+    let token_obj = env.register_stellar_asset_contract_v2(token_issuer);
+    let token_addr = token_obj.address();
+    let verifier = Address::generate(env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.register_quest(
+        quest_id,
+        &Address::generate(env),
+        &token_addr,
+        &100_i128,
+        &verifier,
+        &deadline,
+    );
+}
+
+#[test]
+fn test_resolve_dispute_emits_outcome_in_event_data() {
+    let (env, client, _, initiator, arbitrator) = setup();
+    let quest_id = symbol_short!("disp04");
+    register_quest(&env, &client, &quest_id);
+
+    client.open_dispute(&quest_id, &initiator, &arbitrator);
+    // Resolve with the dispute upheld and a 50% stake slash requested.
+    client.resolve_dispute(&quest_id, &initiator, &arbitrator, &true, &5_000_u32);
+
+    let (_, resolved_topics, resolved_data) = env.events().all().last().unwrap();
+    let resolved_name: Symbol = resolved_topics.get(0).unwrap().into_val(&env);
+    assert_eq!(resolved_name, symbol_short!("disp_res"));
+
+    // The outcome (upheld, slash_bps) must be published so indexers can
+    // track the resolution without decoding storage.
+    let (upheld, slash_bps): (bool, u32) = resolved_data.into_val(&env);
+    assert!(upheld);
+    assert_eq!(slash_bps, 5_000);
+}
+
+#[test]
+fn test_resolve_dispute_not_upheld_emits_false_outcome() {
+    let (env, client, _, initiator, arbitrator) = setup();
+    let quest_id = symbol_short!("disp05");
+
+    client.open_dispute(&quest_id, &initiator, &arbitrator);
+    client.resolve_dispute(&quest_id, &initiator, &arbitrator, &false, &0_u32);
+
+    let (_, _, resolved_data) = env.events().all().last().unwrap();
+    let (upheld, slash_bps): (bool, u32) = resolved_data.into_val(&env);
+    assert!(!upheld);
+    assert_eq!(slash_bps, 0);
+}
+
 #[test]
 fn test_withdraw_dispute_emits_indexed_event() {
     let (env, client, _, initiator, arbitrator) = setup();


### PR DESCRIPTION
## Summary

Four changes across the contract and the frontend:

1. **Cap registered oracles** — `MAX_ORACLE_CONFIGS` (10) enforced in `storage.rs` with a new `OracleLimitReached` error so aggregation gas and instance storage stay bounded. Updating an existing oracle at the cap remains allowed.
2. **Dispute resolution outcome event** — the `DisputeResolved` (`disp_res`) event now carries `(upheld, slash_bps)` in its data payload so indexers can track rulings without decoding storage.
3. **Wallet disconnect confirmation** — disconnecting the wallet now requires an explicit confirmation dialog instead of firing on a single click.
4. **Global offline banner** — `OfflineIndicator` is mounted app-wide in the locale layout, replacing the per-page banners.

## Tests

- New unit tests for the oracle cap (`test_oracle_cap.rs`) and dispute outcome events (`test_dispute.rs`).
- New tests for `GlobalOfflineIndicator`, `DisconnectWalletDialog`, and the ConnectButton confirm flow.
- `cargo test`, `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build --release`, frontend lint/typecheck/format, full vitest suite, and `next build` all pass.

Closes #2291
Closes #2285
Closes #2274
Closes #2273