### PR TITLE
feat(i18n): persist selected locale to cookie in middleware

### DIFF
--- a/FrontEnd/my-app/lib/i18n/__tests__/i18n-cookie.test.ts
+++ b/FrontEnd/my-app/lib/i18n/__tests__/i18n-cookie.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { locales, defaultLocale, localeCookie } from '@/lib/i18n';
+
+describe('i18n config', () => {
+  test('exports localeCookie with correct cookie name', () => {
+    expect(localeCookie.name).toBe('NEXT_LOCALE');
+  });
+
+  test('exports localeCookie with a 1-year maxAge', () => {
+    expect(localeCookie.maxAge).toBe(31_536_000);
+  });
+
+  test('exports localeCookie with lax sameSite', () => {
+    expect(localeCookie.sameSite).toBe('lax');
+  });
+
+  test('re-exports locales from config', () => {
+    expect(locales).toEqual(['en', 'es']);
+  });
+
+  test('re-exports defaultLocale from config', () => {
+    expect(defaultLocale).toBe('en');
+  });
+});
+
+describe('middleware locale cookie persistence', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('cookie config is included in middleware routing', async () => {
+    // Verify the localeCookie object is shaped correctly for next-intl
+    expect(typeof localeCookie.name).toBe('string');
+    expect(typeof localeCookie.maxAge).toBe('number');
+    expect(typeof localeCookie.sameSite).toBe('string');
+  });
+});

--- a/FrontEnd/my-app/lib/i18n/index.ts
+++ b/FrontEnd/my-app/lib/i18n/index.ts
@@ -1,0 +1,15 @@
+export { locales, defaultLocale, localeNames } from './config';
+export type { Locale, Messages } from './config';
+
+/**
+ * Locale cookie configuration for next-intl middleware.
+ *
+ * The middleware writes a `NEXT_LOCALE` cookie so the user's language
+ * choice persists across visits.  Without this option the cookie is
+ * never set and the locale resets to the default on every request.
+ */
+export const localeCookie = {
+  name: 'NEXT_LOCALE',
+  maxAge: 31_536_000, // 1 year
+  sameSite: 'lax' as const,
+};

--- a/FrontEnd/my-app/middleware.ts
+++ b/FrontEnd/my-app/middleware.ts
@@ -1,5 +1,5 @@
 import createMiddleware from 'next-intl/middleware';
-import { locales, defaultLocale } from '@/lib/i18n/config';
+import { locales, defaultLocale, localeCookie } from '@/lib/i18n';
 import type { NextRequest } from 'next/server';
 
 // ---------------------------------------------------------------------------
@@ -70,6 +70,7 @@ const i18nMiddleware = createMiddleware({
   defaultLocale,
   localeDetection: true,
   localePrefix: 'always',
+  localeCookie,
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Linked Issue

Closes #2269

---

## Description

**What changed?**
Added locale cookie persistence to the `next-intl` middleware so the user's language preference survives across visits.

**Why was it changed?**
The chosen locale was not being persisted — users were reset to the default locale on every return visit because the middleware never wrote a cookie.

**How was it implemented?**
- Created `lib/i18n/index.ts` as a barrel export with an explicit `localeCookie` config (`NEXT_LOCALE`, 1-year `maxAge`, `sameSite: 'lax'`).
- Updated `middleware.ts` to import and pass `localeCookie` to `createMiddleware`.
- Root cause: `next-intl`'s `receiveRoutingConfig` resolves `localeCookie` to `false` when omitted, so `syncCookie` was never called.

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Security fix
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [x] Tests only
- [ ] Configuration / DevOps change

---

## Test Evidence

### Unit Tests

- [x] New unit tests added for changed logic
- [x] All existing unit tests pass (`npm run test`)
- [x] Coverage does not regress (`npm run test:cov`)

**Test output:**

```
 ✓ lib/i18n/__tests__/i18n-cookie.test.ts (6 tests) 7ms

 Test Files  91 passed (91)
      Tests  842 passed (842)
   Duration  100.32s
```

---

## Final Pre-Merge Checklist

- [x] Branch is up to date with `main`
- [x] Linting passes (`npm run lint`) — 0 errors
- [x] Formatting passes
- [x] No `console.log` / debug statements left in production code
- [x] No hardcoded secrets, API keys, or environment-specific values in source code
- [x] `.env.example` updated if new environment variables were introduced — N/A
- [x] Self-review completed

---

## Additional Notes for Reviewer

- The `package.json` and `package-lock.json` diff in the working tree are pre-existing changes from a prior branch, unrelated to this PR. They are **not** included in this commit.
- The fix is minimal and follows the existing project conventions for i18n configuration.