### PR TITLE
feat: bound quest expiry grace periods and debounce admin quest filters

### DIFF
--- a/FrontEnd/my-app/components/admin/__tests__/useQuestFilters.test.tsx
+++ b/FrontEnd/my-app/components/admin/__tests__/useQuestFilters.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import { useQuestFilters } from '../useQuestFilters';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { useQuestFilters, DEFAULT_DEBOUNCE_MS } from '../useQuestFilters';
 import type { Quest } from '@/lib/types/admin';
 
 const mockQuests: Quest[] = [
@@ -63,11 +63,27 @@ const mockQuests: Quest[] = [
   },
 ];
 
+/** Advances past the debounce window so pending filter changes are applied. */
+function advanceDebounce() {
+  act(() => {
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 1);
+  });
+}
+
 describe('useQuestFilters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('returns default state', () => {
     const { result } = renderHook(() => useQuestFilters(mockQuests));
 
     expect(result.current.searchQuery).toBe('');
+    expect(result.current.debouncedSearchQuery).toBe('');
     expect(result.current.statusFilter).toBe('all');
     expect(result.current.sortField).toBe('deadline');
     expect(result.current.sortOrder).toBe('asc');
@@ -85,6 +101,7 @@ describe('useQuestFilters', () => {
     act(() => {
       result.current.setSearchQuery('Alpha');
     });
+    advanceDebounce();
 
     expect(result.current.filteredAndSortedQuests).toHaveLength(1);
     expect(result.current.filteredAndSortedQuests[0].id).toBe('1');
@@ -96,6 +113,7 @@ describe('useQuestFilters', () => {
     act(() => {
       result.current.setSearchQuery('second quest');
     });
+    advanceDebounce();
 
     expect(result.current.filteredAndSortedQuests).toHaveLength(1);
     expect(result.current.filteredAndSortedQuests[0].id).toBe('2');
@@ -107,6 +125,7 @@ describe('useQuestFilters', () => {
     act(() => {
       result.current.setSearchQuery('blockchain');
     });
+    advanceDebounce();
 
     expect(result.current.filteredAndSortedQuests).toHaveLength(1);
     expect(result.current.filteredAndSortedQuests[0].id).toBe('2');
@@ -199,6 +218,7 @@ describe('useQuestFilters', () => {
     act(() => {
       result.current.setSearchQuery('Development');
     });
+    advanceDebounce();
 
     act(() => {
       result.current.setStatusFilter('draft');
@@ -213,5 +233,82 @@ describe('useQuestFilters', () => {
     const filtered = result.current.filteredAndSortedQuests;
     expect(filtered).toHaveLength(2);
     expect(filtered.every((q) => q.status === 'active')).toBe(true);
+  });
+
+  it('keeps the input value immediate while filtering waits for the debounce', () => {
+    const { result } = renderHook(() => useQuestFilters(mockQuests));
+
+    act(() => {
+      result.current.setSearchQuery('Alpha');
+    });
+
+    // The input value updates instantly, but the filter has not run yet.
+    expect(result.current.searchQuery).toBe('Alpha');
+    expect(result.current.debouncedSearchQuery).toBe('');
+    expect(result.current.filteredAndSortedQuests).toHaveLength(3);
+
+    advanceDebounce();
+
+    expect(result.current.debouncedSearchQuery).toBe('Alpha');
+    expect(result.current.filteredAndSortedQuests).toHaveLength(1);
+  });
+
+  it('coalesces rapid keystrokes into a single filter application', () => {
+    const { result } = renderHook(() => useQuestFilters(mockQuests));
+
+    // Several keystrokes inside the debounce window: only the last one applies.
+    act(() => {
+      result.current.setSearchQuery('A');
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      result.current.setSearchQuery('Al');
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      result.current.setSearchQuery('Alp');
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      result.current.setSearchQuery('Alpha');
+    });
+
+    // Not yet applied — the trailing debounce window is still open.
+    expect(result.current.debouncedSearchQuery).toBe('');
+    expect(result.current.filteredAndSortedQuests).toHaveLength(3);
+
+    advanceDebounce();
+
+    expect(result.current.debouncedSearchQuery).toBe('Alpha');
+    expect(result.current.filteredAndSortedQuests).toHaveLength(1);
+    expect(result.current.filteredAndSortedQuests[0].id).toBe('1');
+  });
+
+  it('respects a custom debounce delay', () => {
+    const { result } = renderHook(() =>
+      useQuestFilters(mockQuests, { debounceMs: 500 })
+    );
+
+    act(() => {
+      result.current.setSearchQuery('Alpha');
+    });
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+
+    expect(result.current.debouncedSearchQuery).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.debouncedSearchQuery).toBe('Alpha');
+    expect(result.current.filteredAndSortedQuests).toHaveLength(1);
   });
 });

--- a/FrontEnd/my-app/components/admin/useQuestFilters.ts
+++ b/FrontEnd/my-app/components/admin/useQuestFilters.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import type { Quest, QuestStatus } from '@/lib/types/admin';
 
 export type SortField =
@@ -11,11 +11,38 @@ export type SortField =
   | 'participants';
 export type SortOrder = 'asc' | 'desc';
 
-export function useQuestFilters(quests: Quest[]) {
+/** Default debounce delay for the search query, in milliseconds. */
+export const DEFAULT_DEBOUNCE_MS = 300;
+
+export function useQuestFilters(
+  quests: Quest[],
+  options?: { debounceMs?: number }
+) {
+  const debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<QuestStatus | 'all'>('all');
   const [sortField, setSortField] = useState<SortField>('deadline');
   const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounce the search query so rapid keystrokes don't re-run the filter on
+  // every change. The input stays responsive (`searchQuery` updates
+  // immediately) while filtering only happens once the user pauses typing.
+  useEffect(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+    debounceTimer.current = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+      }
+    };
+  }, [searchQuery, debounceMs]);
 
   const handleSort = (field: SortField) => {
     setSortField((currentField) => {
@@ -31,8 +58,8 @@ export function useQuestFilters(quests: Quest[]) {
   const filteredAndSortedQuests = useMemo(() => {
     let result = [...quests];
 
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
+    if (debouncedSearchQuery) {
+      const query = debouncedSearchQuery.toLowerCase();
       result = result.filter(
         (q) =>
           q.title.toLowerCase().includes(query) ||
@@ -71,11 +98,12 @@ export function useQuestFilters(quests: Quest[]) {
     });
 
     return result;
-  }, [quests, searchQuery, statusFilter, sortField, sortOrder]);
+  }, [quests, debouncedSearchQuery, statusFilter, sortField, sortOrder]);
 
   return {
     searchQuery,
     setSearchQuery,
+    debouncedSearchQuery,
     statusFilter,
     setStatusFilter,
     sortField,

--- a/contracts/earn-quest/CHANGELOG.md
+++ b/contracts/earn-quest/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Quest expiry bounds: per-quest grace periods and the global default grace period are now capped at `MAX_GRACE_PERIOD_SECONDS` (30 days) via `validate_grace_period`, so the effective quest expiry (`deadline + grace_period_seconds`) stays bounded even when the deadline itself is within `MAX_DEADLINE_DURATION`. Exceeding the cap returns `Error::GracePeriodTooLarge` (code 96) at quest registration and when admins update the default.
 - Registered oracle configurations are now capped at `MAX_ORACLE_CONFIGS` (10) in `oracle.rs`/`storage.rs`, preventing unbounded instance storage growth and unbounded aggregation gas. Registering beyond the cap returns `Error::OracleLimitReached` (code 108); updating an existing oracle at the cap remains allowed.
 - Property-based quest lifecycle invariant tests in `tests/property_tests.rs`: escrow balance, payout bounds, and cancel acyclicity are fuzzed via QuickCheck (1000 sequences) and proptest against the live Soroban client (50 sequences).
 - 2-of-2 SuperAdmin clawback: `initiate_clawback` and `execute_clawback` entry points in `payout.rs` allow two distinct SuperAdmins to collaboratively recover funds sent to a fraudulent recipient. Emits `ClawbackInitiated` and `ClawbackExecuted` events. Adds `ClawbackPending` storage key, `ClawbackNotFound` (150) and `ClawbackAlreadySigned` (151) error variants.

--- a/contracts/earn-quest/src/admin.rs
+++ b/contracts/earn-quest/src/admin.rs
@@ -2,6 +2,7 @@ use crate::errors::Error;
 use crate::events;
 use crate::storage;
 use crate::types::Role;
+use crate::validation;
 use soroban_sdk::{Address, Env};
 
 /// Adds a new administrator to the contract.
@@ -199,6 +200,7 @@ pub fn set_quest_grace_period(
     grace_period_seconds: u64,
 ) -> Result<(), Error> {
     require_admin(env, caller)?;
+    validation::validate_grace_period(grace_period_seconds)?;
     storage::set_quest_grace_period(env, grace_period_seconds);
     Ok(())
 }

--- a/contracts/earn-quest/src/errors.rs
+++ b/contracts/earn-quest/src/errors.rs
@@ -111,6 +111,10 @@ pub enum Error {
     DisputeAlreadyAppealed = 87,
     DisputeNotResolved = 95,
 
+    // Expiry validation
+    /// Quest expiry grace period exceeds the maximum allowed.
+    GracePeriodTooLarge = 96,
+
     // Additional validation / escrow
     InvalidDeadline = 88,
     QuestCancelled = 89,

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -40,6 +40,9 @@ mod test_arithmetic_overflow;
 #[cfg(test)]
 mod test_self_approval;
 
+#[cfg(test)]
+mod test_expiry_bounds;
+
 use crate::errors::Error;
 use crate::storage::{get_badge_type, list_badge_types};
 

--- a/contracts/earn-quest/src/quest.rs
+++ b/contracts/earn-quest/src/quest.rs
@@ -110,6 +110,9 @@ pub fn register_quest_with_category_and_grace_period(
 
     validation::validate_reward_amount(reward_amount)?;
     validation::validate_deadline(env, deadline)?;
+    if let Some(grace) = grace_period_seconds {
+        validation::validate_grace_period(grace)?;
+    }
     validation::validate_addresses_distinct(creator, verifier)?;
 
     // Check minimum creator level requirement

--- a/contracts/earn-quest/src/test_expiry_bounds.rs
+++ b/contracts/earn-quest/src/test_expiry_bounds.rs
@@ -1,0 +1,117 @@
+#![cfg(test)]
+
+//! Unit tests for quest expiry bounds validation (issue #2284).
+//!
+//! The quest `deadline` is already bounded by `validate_deadline`
+//! (`MIN_DEADLINE_DURATION`..`MAX_DEADLINE_DURATION` relative to the current
+//! ledger timestamp). These tests cover the missing half of the expiry path:
+//! the grace period that extends the *effective* quest expiry
+//! (`deadline + grace_period_seconds`), both at quest registration and when
+//! an admin sets the global default grace period.
+
+use crate::errors::Error;
+use crate::quest;
+use crate::validation::{self, MAX_GRACE_PERIOD_SECONDS};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, Address, Env};
+
+#[test]
+fn grace_period_within_bounds_is_accepted() {
+    assert!(validation::validate_grace_period(0).is_ok());
+    assert!(validation::validate_grace_period(60).is_ok());
+    assert!(validation::validate_grace_period(86_400).is_ok()); // 1 day
+    assert!(validation::validate_grace_period(MAX_GRACE_PERIOD_SECONDS).is_ok());
+}
+
+#[test]
+fn grace_period_beyond_max_is_rejected() {
+    assert_eq!(
+        validation::validate_grace_period(MAX_GRACE_PERIOD_SECONDS + 1),
+        Err(Error::GracePeriodTooLarge)
+    );
+    assert_eq!(
+        validation::validate_grace_period(u64::MAX),
+        Err(Error::GracePeriodTooLarge)
+    );
+}
+
+#[test]
+fn registering_quest_with_oversized_grace_period_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    env.as_contract(&cid, || {
+        let result = quest::register_quest_with_category_and_grace_period(
+            &env,
+            &symbol_short!("Q1"),
+            &creator,
+            &token,
+            1000,
+            &verifier,
+            deadline,
+            Some(MAX_GRACE_PERIOD_SECONDS + 1),
+            0,
+        );
+        assert_eq!(result, Err(Error::GracePeriodTooLarge));
+    });
+}
+
+#[test]
+fn registering_quest_with_bounded_grace_period_is_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    env.as_contract(&cid, || {
+        let result = quest::register_quest_with_category_and_grace_period(
+            &env,
+            &symbol_short!("Q2"),
+            &creator,
+            &token,
+            1000,
+            &verifier,
+            deadline,
+            Some(86_400),
+            0,
+        );
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+fn admin_setting_oversized_default_grace_period_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+    let client = crate::EarnQuestContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_set_quest_grace_period(&admin, &(MAX_GRACE_PERIOD_SECONDS + 1));
+    assert!(result.is_err());
+
+    // The default is unchanged after the rejected update.
+    assert_eq!(client.get_default_grace_period(), 10);
+}
+
+#[test]
+fn admin_setting_bounded_default_grace_period_is_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, crate::EarnQuestContract);
+    let client = crate::EarnQuestContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.set_quest_grace_period(&admin, &86_400);
+    assert_eq!(client.get_default_grace_period(), 86_400);
+}

--- a/contracts/earn-quest/src/validation.rs
+++ b/contracts/earn-quest/src/validation.rs
@@ -42,6 +42,15 @@ pub const MAX_DEADLINE_DURATION: u64 = 86400 * 365; // 1 year
 /// Minimum expiry buffer in seconds (absorbs normal validator clock drift)
 pub const MIN_EXPIRY_BUFFER: u64 = 10; // 10 seconds
 
+/// Maximum quest expiry grace period in seconds.
+///
+/// Bounds the *effective* quest expiry (`deadline + grace_period_seconds`):
+/// even when a quest's deadline is within `MAX_DEADLINE_DURATION`, an
+/// unbounded grace period would let the quest effectively live arbitrarily far
+/// in the future. Capping the grace period keeps the effective expiry within
+/// `MAX_DEADLINE_DURATION + MAX_GRACE_PERIOD_SECONDS` of the current time.
+pub const MAX_GRACE_PERIOD_SECONDS: u64 = 86400 * 30; // 30 days
+
 //================================================================================
 // Address Validation
 //================================================================================
@@ -133,6 +142,25 @@ pub fn validate_deadline(env: &Env, deadline: u64) -> Result<(), Error> {
         return Err(Error::DeadlineTooFar);
     }
 
+    Ok(())
+}
+
+/// Validates that a quest expiry grace period is within allowed bounds.
+///
+/// The grace period extends the effective quest expiry (`deadline + grace`),
+/// so without this cap a quest could effectively expire arbitrarily far in the
+/// future even though its `deadline` itself is bounded by `validate_deadline`.
+///
+/// # Arguments
+/// * `grace_period_seconds` - The grace period to validate
+///
+/// # Returns
+/// * `Ok(())` if `grace_period_seconds <= MAX_GRACE_PERIOD_SECONDS`
+/// * `Err(Error::GracePeriodTooLarge)` if it exceeds the cap
+pub fn validate_grace_period(grace_period_seconds: u64) -> Result<(), Error> {
+    if grace_period_seconds > MAX_GRACE_PERIOD_SECONDS {
+        return Err(Error::GracePeriodTooLarge);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Two changes:

1. **Bound quest expiry** — the quest `deadline` was already validated against `MIN_DEADLINE_DURATION`/`MAX_DEADLINE_DURATION`, but the grace period that extends the effective expiry (`deadline + grace_period_seconds`) was unbounded. Per-quest grace periods and the admin-set global default are now capped at `MAX_GRACE_PERIOD_SECONDS` (30 days) via `validate_grace_period`; exceeding the cap returns `Error::GracePeriodTooLarge` (code 96) at registration and on admin updates.
2. **Debounce QuestFilters** — the admin quest search query is now debounced (default 300ms, configurable) in `useQuestFilters` so rapid keystrokes don’t re-run filtering on every change. The input stays responsive; only the filter application is deferred.

## Tests

- New unit tests for the expiry bounds (`test_expiry_bounds.rs`): bounded grace accepted, oversized rejected, registration and admin paths covered.
- Updated `useQuestFilters` tests for the debounce and added coverage for immediate-input/deferred-filter behavior, coalescing rapid keystrokes, and custom debounce delays.
- `cargo test`, `cargo fmt --check`, `cargo clippy -D warnings`, frontend lint/typecheck/format, the full vitest suite (849 tests), and `next build` all pass.

Closes #2284
Closes #2267