### PR TITLE
feat(earn-quest): total-escrow view and explicit max-reward validation

### DIFF
--- a/contracts/earn-quest/src/escrow.rs
+++ b/contracts/earn-quest/src/escrow.rs
@@ -402,6 +402,18 @@ pub fn get_info(env: &Env, quest_id: &Symbol) -> Result<EscrowInfo, Error> {
     storage::get_escrow(env, quest_id)
 }
 
+/// Get the total amount ever deposited into a quest's escrow (read-only view).
+///
+/// Unlike [`get_balance`], which returns the *remaining* spendable balance
+/// (deposits minus payouts and refunds), this returns the cumulative
+/// `total_deposited` counter — the full escrow size funded for the quest. It
+/// lets integrators query a quest's total escrow without inspecting raw
+/// storage.
+pub fn get_total_deposited(env: &Env, quest_id: &Symbol) -> Result<i128, Error> {
+    let b = storage::get_escrow_balances(env, quest_id)?;
+    Ok(b.total_deposited)
+}
+
 // ═══════════════════════════════════════════════════════════════
 // VERIFIER STAKE: Deposit stake before verifying; return if no dispute
 // ═══════════════════════════════════════════════════════════════

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -43,6 +43,9 @@ mod test_self_approval;
 #[cfg(test)]
 mod test_expiry_bounds;
 
+#[cfg(test)]
+mod test_reward_and_escrow_views;
+
 use crate::errors::Error;
 use crate::storage::{get_badge_type, list_badge_types};
 
@@ -1164,6 +1167,15 @@ impl EarnQuestContract {
     /// Returns detailed escrow information for a quest.
     pub fn get_escrow_info(env: Env, quest_id: Symbol) -> Result<EscrowInfo, Error> {
         escrow::get_info(&env, &quest_id)
+    }
+
+    /// Returns the total amount ever deposited into a quest's escrow.
+    ///
+    /// Read-only view over the cumulative `total_deposited` counter, letting
+    /// integrators query a quest's full escrow size without inspecting raw
+    /// storage. See [`Self::get_escrow_balance`] for the *remaining* balance.
+    pub fn get_escrow_total_deposited(env: Env, quest_id: Symbol) -> Result<i128, Error> {
+        escrow::get_total_deposited(&env, &quest_id)
     }
 
     /// Returns the details of a quest by its symbol ID.

--- a/contracts/earn-quest/src/test_reward_and_escrow_views.rs
+++ b/contracts/earn-quest/src/test_reward_and_escrow_views.rs
@@ -1,0 +1,164 @@
+//! Tests for:
+//!   * Maximum reward-amount validation on quest registration (implausibly
+//!     large rewards are rejected with `Error::AmountTooLarge`, the boundary
+//!     value is accepted, and a zero reward is rejected).
+//!   * The read-only escrow views: `get_escrow_balance` (remaining) and the new
+//!     `get_escrow_total_deposited` (cumulative deposits), including that a
+//!     payout reduces the remaining balance while leaving total-deposited
+//!     unchanged.
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, token, Address, Env, Symbol};
+
+use crate::errors::Error;
+use crate::storage;
+use crate::types::EscrowBalances;
+use crate::validation::MAX_REWARD_AMOUNT;
+use crate::{EarnQuestContract, EarnQuestContractClient};
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+struct TestCtx<'a> {
+    env: Env,
+    client: EarnQuestContractClient<'a>,
+    contract_id: Address,
+    creator: Address,
+    verifier: Address,
+    token: Address,
+    token_admin: token::StellarAssetClient<'a>,
+}
+
+fn setup() -> TestCtx<'static> {
+    let env = make_env();
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+
+    let token_admin_addr = Address::generate(&env);
+    let token_contract_obj = env.register_stellar_asset_contract_v2(token_admin_addr);
+    let token = token_contract_obj.address();
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+
+    TestCtx {
+        env,
+        client,
+        contract_id,
+        creator,
+        verifier,
+        token,
+        token_admin,
+    }
+}
+
+fn register_with_reward(ctx: &TestCtx, quest_id: &Symbol, reward: i128) {
+    let deadline = ctx.env.ledger().timestamp() + 86_400;
+    ctx.client.register_quest(
+        quest_id,
+        &ctx.creator,
+        &ctx.token,
+        &reward,
+        &ctx.verifier,
+        &deadline,
+    );
+}
+
+fn as_contract<T>(ctx: &TestCtx, f: impl FnOnce() -> T) -> T {
+    ctx.env.as_contract(&ctx.contract_id, f)
+}
+
+// ── Maximum reward validation on registration ─────────────────────────────
+
+#[test]
+fn test_register_quest_rejects_reward_above_max() {
+    let ctx = setup();
+    let qid = symbol_short!("q_over");
+    let deadline = ctx.env.ledger().timestamp() + 86_400;
+
+    let result = ctx.client.try_register_quest(
+        &qid,
+        &ctx.creator,
+        &ctx.token,
+        &(MAX_REWARD_AMOUNT + 1),
+        &ctx.verifier,
+        &deadline,
+    );
+    assert_eq!(result, Err(Ok(Error::AmountTooLarge)));
+}
+
+#[test]
+fn test_register_quest_accepts_reward_at_max_boundary() {
+    let ctx = setup();
+    let qid = symbol_short!("q_max");
+    register_with_reward(&ctx, &qid, MAX_REWARD_AMOUNT);
+
+    let quest = ctx.client.get_quest(&qid);
+    assert_eq!(quest.reward_amount, MAX_REWARD_AMOUNT);
+}
+
+#[test]
+fn test_register_quest_rejects_zero_reward() {
+    let ctx = setup();
+    let qid = symbol_short!("q_zero");
+    let deadline = ctx.env.ledger().timestamp() + 86_400;
+
+    let result = ctx.client.try_register_quest(
+        &qid,
+        &ctx.creator,
+        &ctx.token,
+        &0i128,
+        &ctx.verifier,
+        &deadline,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidRewardAmount)));
+}
+
+// ── Escrow views: remaining vs total deposited ────────────────────────────
+
+#[test]
+fn test_escrow_total_deposited_matches_deposit() {
+    let ctx = setup();
+    let qid = symbol_short!("q_esc");
+    register_with_reward(&ctx, &qid, 1_000i128);
+
+    ctx.token_admin.mint(&ctx.creator, &5_000i128);
+    ctx.client
+        .deposit_escrow(&qid, &ctx.creator, &ctx.token, &5_000i128);
+
+    assert_eq!(ctx.client.get_escrow_balance(&qid), 5_000i128);
+    assert_eq!(ctx.client.get_escrow_total_deposited(&qid), 5_000i128);
+}
+
+#[test]
+fn test_total_deposited_unchanged_by_payout() {
+    let ctx = setup();
+    let qid = symbol_short!("q_pay");
+    register_with_reward(&ctx, &qid, 1_000i128);
+
+    // Seed escrow accounting so that some funds have already been paid out:
+    // remaining = 1_000 - 300 = 700, but total_deposited stays 1_000.
+    as_contract(&ctx, || {
+        storage::set_escrow_balances(
+            &ctx.env,
+            &qid,
+            &EscrowBalances {
+                total_deposited: 1_000,
+                total_paid_out: 300,
+                total_refunded: 0,
+                is_active: true,
+                deposit_count: 1,
+            },
+        );
+    });
+
+    assert_eq!(ctx.client.get_escrow_balance(&qid), 700i128);
+    assert_eq!(ctx.client.get_escrow_total_deposited(&qid), 1_000i128);
+}

--- a/contracts/earn-quest/src/validation.rs
+++ b/contracts/earn-quest/src/validation.rs
@@ -94,6 +94,24 @@ pub fn validate_reward_amount(amount: i128) -> Result<(), Error> {
     if amount <= 0 {
         return Err(Error::InvalidRewardAmount);
     }
+    validate_max_reward_amount(amount)?;
+    Ok(())
+}
+
+/// Validates that a reward amount does not exceed the maximum allowed bound.
+///
+/// Split out from [`validate_reward_amount`] so the upper-bound check has a
+/// single, explicitly named home. Quest registration relies on this to reject
+/// implausibly large rewards that would otherwise overflow downstream math
+/// (e.g. cumulative platform-reward accounting or reward × claims arithmetic).
+///
+/// # Arguments
+/// * `amount` - The reward amount to validate
+///
+/// # Returns
+/// * `Ok(())` if `amount <= MAX_REWARD_AMOUNT`
+/// * `Err(Error::AmountTooLarge)` if `amount > MAX_REWARD_AMOUNT`
+pub fn validate_max_reward_amount(amount: i128) -> Result<(), Error> {
     if amount > MAX_REWARD_AMOUNT {
         return Err(Error::AmountTooLarge);
     }


### PR DESCRIPTION
## Summary

Two related read/validation improvements to the `earn-quest` contract.

- **Maximum reward validation on quest registration (#2282)** — extracts the upper-bound reward check into a dedicated, documented `validate_max_reward_amount` in `validation.rs`. `validate_reward_amount` (already invoked on every registration path) now delegates to it, so an implausibly large reward can never be stored and overflow downstream math. Behaviour is unchanged for existing callers.
- **Total escrow balance view per quest (#2278)** — adds `escrow::get_total_deposited` and exposes it through a new `get_escrow_total_deposited` contract entrypoint. Unlike `get_escrow_balance` (remaining/spendable), this returns the cumulative amount deposited, letting integrators query a quest's full escrow size without inspecting raw storage.

## Tests

`test_reward_and_escrow_views.rs` adds coverage for:
- registration rejecting a reward above `MAX_REWARD_AMOUNT` (`AmountTooLarge`), accepting the exact boundary, and rejecting a zero reward (`InvalidRewardAmount`);
- `get_escrow_balance` and `get_escrow_total_deposited` agreeing after a deposit, and total-deposited staying constant while the remaining balance drops after a payout.

## Issues

Closes #2282
Closes #2278
