### PR TITLE
fix(submissions): validate list query parameters

### DIFF
--- a/BackEnd/src/modules/submissions/CHANGELOG.md
+++ b/BackEnd/src/modules/submissions/CHANGELOG.md
@@ -12,6 +12,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Submission list query parameters now reject malformed UUID filters and invalid pagination, status, sort, and order values at the DTO boundary (#2252).
 - Converted `submissions/index.ts` from a corrupted UTF-16 encoding to UTF-8 and removed a duplicated export line.
 
 ### Changed

--- a/BackEnd/src/modules/submissions/dto/query-submissions.dto.spec.ts
+++ b/BackEnd/src/modules/submissions/dto/query-submissions.dto.spec.ts
@@ -1,0 +1,67 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+  QuerySubmissionsDto,
+  SortOrder,
+  SubmissionSortBy,
+  SubmissionStatus,
+} from './query-submissions.dto';
+
+describe('QuerySubmissionsDto', () => {
+  const getErrors = async (query: Record<string, unknown>) =>
+    validate(plainToInstance(QuerySubmissionsDto, query));
+
+  it('applies the documented defaults for limit, sort, and order', () => {
+    const query = plainToInstance(QuerySubmissionsDto, {});
+
+    expect(query.limit).toBe(10);
+    expect(query.sortBy).toBe(SubmissionSortBy.CREATED_AT);
+    expect(query.order).toBe(SortOrder.DESC);
+  });
+
+  it.each(['0', '-1', '101', '1.5', 'not-a-number'])(
+    'rejects an invalid limit: %s',
+    async (limit) => {
+      const errors = await getErrors({ limit });
+
+      expect(errors.some((error) => error.property === 'limit')).toBe(true);
+    },
+  );
+
+  it('accepts a numeric limit at both boundaries', async () => {
+    await expect(getErrors({ limit: '1' })).resolves.toHaveLength(0);
+    await expect(getErrors({ limit: '100' })).resolves.toHaveLength(0);
+  });
+
+  it('rejects unknown status and sort values', async () => {
+    const errors = await getErrors({ status: 'UNKNOWN', sortBy: 'title' });
+
+    expect(errors.map((error) => error.property)).toEqual(
+      expect.arrayContaining(['status', 'sortBy']),
+    );
+  });
+
+  it('accepts the supported status, sort, and order values', async () => {
+    const errors = await getErrors({
+      status: SubmissionStatus.APPROVED,
+      sortBy: SubmissionSortBy.UPDATED_AT,
+      order: SortOrder.ASC,
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a malformed user ID before it reaches the repository query', async () => {
+    const errors = await getErrors({ userId: 'user-1' });
+
+    expect(errors.some((error) => error.property === 'userId')).toBe(true);
+  });
+
+  it('accepts a UUID user ID', async () => {
+    const errors = await getErrors({
+      userId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/BackEnd/src/modules/submissions/dto/query-submissions.dto.ts
+++ b/BackEnd/src/modules/submissions/dto/query-submissions.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsEnum, IsString } from 'class-validator';
+import { IsOptional, IsEnum, IsUUID } from 'class-validator';
 import { CursorPaginationDto } from '../../../common/dto/pagination.dto';
 
 export enum SubmissionStatus {
@@ -37,7 +37,7 @@ export class QuerySubmissionsDto extends CursorPaginationDto {
     example: 'user-uuid-here',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID()
   userId?: string;
 
   @ApiPropertyOptional({


### PR DESCRIPTION
## Summary

Closes #2252
Closes #2251

Closes #2253 
Closes #2254 

The submissions list query now validates pagination, status, sort, order, and optional user IDs before repository access. The change keeps the existing DTO/controller flow and adds focused class-validator coverage for defaults, boundaries, accepted values, and rejected inputs.

## Why

The query DTO previously accepted arbitrary strings for `userId`, while invalid pagination and enum values were not covered by tests. Applying the existing validation decorators at the DTO boundary prevents malformed values from reaching the submissions repository query.

## What was built

`BackEnd/src/modules/submissions/dto/`:

| File | What it contains |
|---|---|
| `query-submissions.dto.ts` | UUID validation for the optional `userId` filter, alongside the existing pagination and enum constraints. |
| `query-submissions.dto.spec.ts` | Focused tests for documented defaults, limit boundaries, invalid values, supported values, and UUID validation. |

## Integration changes outside `BackEnd/src/modules/submissions/dto/`

No existing files outside the DTO module were modified.

## Acceptance criteria coverage

- [x] Implemented across the listed files (`query-submissions.dto.ts` and `query-submissions.dto.spec.ts`; the repository already applies the DTO to the submissions list controller)
- [x] Unit/integration tests added or updated and passing (`query-submissions.dto.spec.ts` — 11/11 passing)
- [x] No regression; follows project coding standards (Prettier, focused ESLint, build-only TypeScript check, and production build pass)

## Test plan

- [x] `npm test -- --runInBand src/modules/submissions/dto/query-submissions.dto.spec.ts` — 11/11 passing
- [x] `npx tsc --noEmit -p tsconfig.build.json` — passes
- [x] `npx eslint src/modules/submissions/dto/query-submissions.dto.ts src/modules/submissions/dto/query-submissions.dto.spec.ts` — passes
- [x] `npx prettier --check src/modules/submissions/dto/query-submissions.dto.ts src/modules/submissions/dto/query-submissions.dto.spec.ts` — passes
- [x] `npm run build` — succeeds
- [ ] Full suite — 1161 passed, 172 unrelated existing failures across 40 suites

## Env vars / Notes

No new environment variables or migrations.
