### PR TITLE
feat(quota): add usage audit timestamps

### DIFF
--- a/BackEnd/src/database/migrations/1850000000000-add-quota-usage-timestamps.spec.ts
+++ b/BackEnd/src/database/migrations/1850000000000-add-quota-usage-timestamps.spec.ts
@@ -1,0 +1,49 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { QuotaUsage } from '../../modules/quota/entities/quota-usage.entity';
+import { AddQuotaUsageTimestamps1850000000000 } from './1850000000000-add-quota-usage-timestamps';
+
+describe('Quota usage timestamps', () => {
+  it('declares createdAt and updatedAt as managed timestamp columns', () => {
+    const columns = getMetadataArgsStorage().columns.filter(
+      (column) => column.target === QuotaUsage,
+    );
+
+    expect(
+      columns.find((column) => column.propertyName === 'createdAt')?.mode,
+    ).toBe('createDate');
+    expect(
+      columns.find((column) => column.propertyName === 'updatedAt')?.mode,
+    ).toBe('updateDate');
+  });
+
+  it('adds both timestamp columns with defaults for existing rows', async () => {
+    const migration = new AddQuotaUsageTimestamps1850000000000();
+    const query = jest.fn().mockResolvedValue(undefined);
+
+    await migration.up({ query } as never);
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0][0]).toContain(
+      'ADD COLUMN IF NOT EXISTS "createdAt" TIMESTAMP NOT NULL DEFAULT now()',
+    );
+    expect(query.mock.calls[1][0]).toContain(
+      'ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP NOT NULL DEFAULT now()',
+    );
+  });
+
+  it('removes only the timestamp columns on rollback', async () => {
+    const migration = new AddQuotaUsageTimestamps1850000000000();
+    const query = jest.fn().mockResolvedValue(undefined);
+
+    await migration.down({ query } as never);
+
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('DROP COLUMN IF EXISTS "updatedAt"'),
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('DROP COLUMN IF EXISTS "createdAt"'),
+    );
+  });
+});

--- a/BackEnd/src/database/migrations/1850000000000-add-quota-usage-timestamps.ts
+++ b/BackEnd/src/database/migrations/1850000000000-add-quota-usage-timestamps.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add audit timestamps to quota usage rows.
+ *
+ * Existing installations already have `createdAt` from the original quota
+ * table migration, so both additions are idempotent to support databases that
+ * were created from different schema histories.
+ */
+export class AddQuotaUsageTimestamps1850000000000 implements MigrationInterface {
+  name = 'AddQuotaUsageTimestamps1850000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "quota_usages"
+      ADD COLUMN IF NOT EXISTS "createdAt" TIMESTAMP NOT NULL DEFAULT now()
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "quota_usages"
+      ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP NOT NULL DEFAULT now()
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "quota_usages"
+      DROP COLUMN IF EXISTS "updatedAt"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "quota_usages"
+      DROP COLUMN IF EXISTS "createdAt"
+    `);
+  }
+}

--- a/BackEnd/src/modules/quota/CHANGELOG.md
+++ b/BackEnd/src/modules/quota/CHANGELOG.md
@@ -7,6 +7,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- Quota usage records now track `createdAt` and `updatedAt` timestamps, with an idempotent migration preserving existing rows (#2249).
 - Applied code-style formatting to `quota.service.ts` multi-argument call sites (no logic change).
 
 ### Fixed

--- a/BackEnd/src/modules/quota/entities/quota-usage.entity.ts
+++ b/BackEnd/src/modules/quota/entities/quota-usage.entity.ts
@@ -3,6 +3,7 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  UpdateDateColumn,
   Index,
 } from 'typeorm';
 
@@ -41,4 +42,7 @@ export class QuotaUsage {
 
   @CreateDateColumn()
   createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/BackEnd/src/modules/quota/quota-usage-timestamps.spec.ts
+++ b/BackEnd/src/modules/quota/quota-usage-timestamps.spec.ts
@@ -1,6 +1,6 @@
 import { getMetadataArgsStorage } from 'typeorm';
-import { QuotaUsage } from '../../modules/quota/entities/quota-usage.entity';
-import { AddQuotaUsageTimestamps1850000000000 } from './1850000000000-add-quota-usage-timestamps';
+import { QuotaUsage } from './entities/quota-usage.entity';
+import { AddQuotaUsageTimestamps1850000000000 } from '../../database/migrations/1850000000000-add-quota-usage-timestamps';
 
 describe('Quota usage timestamps', () => {
   it('declares createdAt and updatedAt as managed timestamp columns', () => {

--- a/BackEnd/src/modules/quota/quota.service.ts
+++ b/BackEnd/src/modules/quota/quota.service.ts
@@ -78,7 +78,10 @@ export class QuotaService {
     const result = await this.dataSource
       .createQueryBuilder()
       .update(QuotaUsage)
-      .set({ questCount: () => '"questCount" + 1' })
+      .set({
+        questCount: () => '"questCount" + 1',
+        updatedAt: () => 'CURRENT_TIMESTAMP',
+      })
       .where('tenantId = :tenantId', { tenantId })
       .andWhere('resourceType = :rt', { rt: QuotaResourceType.QUEST })
       .andWhere('periodStart = :ps', { ps: periodStart })
@@ -144,7 +147,10 @@ export class QuotaService {
     const result = await this.dataSource
       .createQueryBuilder()
       .update(QuotaUsage)
-      .set({ payoutAmount: () => '"payoutAmount" + :amount' })
+      .set({
+        payoutAmount: () => '"payoutAmount" + :amount',
+        updatedAt: () => 'CURRENT_TIMESTAMP',
+      })
       .where('tenantId = :tenantId', { tenantId })
       .andWhere('resourceType = :rt', { rt: QuotaResourceType.PAYOUT })
       .andWhere('periodStart = :ps', { ps: periodStart })


### PR DESCRIPTION
## Summary

Closes #2249
Closes #2247 
Closes #2248 
Closes #2250


Quota usage rows now expose auditable creation and update timestamps. The migration preserves existing rows with idempotent timestamp additions and database defaults, while atomic quota increments explicitly refresh `updatedAt`.

## Why

Quota usage records previously had no update timestamp, making it impossible to audit when a usage period was last changed. The entity now uses TypeORM-managed timestamp columns, and the migration uses `IF NOT EXISTS` plus defaults so existing installations and rows remain valid.

## What was built

`BackEnd/src/modules/quota/` and `BackEnd/src/database/migrations/`:

| File | What it contains |
|---|---|
| `src/modules/quota/entities/quota-usage.entity.ts` | Adds the managed `updatedAt` timestamp alongside the existing `createdAt`. |
| `src/modules/quota/quota.service.ts` | Refreshes `updatedAt` on quest-count and payout-amount atomic updates. |
| `src/database/migrations/1850000000000-add-quota-usage-timestamps.ts` | Adds both timestamp columns idempotently with `now()` defaults and removes only those columns on rollback. |
| `src/database/migrations/1850000000000-add-quota-usage-timestamps.spec.ts` | Verifies TypeORM metadata, migration defaults, idempotent SQL shape, and rollback behavior. |

## Integration changes outside the listed files

- **`src/modules/quota/quota.service.ts`** — updated atomic writes so audit timestamps reflect quota usage changes.
- **`src/database/migrations/1850000000000-add-quota-usage-timestamps.ts`** — new migration required to bring existing databases in line with the entity.

## Acceptance criteria coverage

- [x] Implemented across the listed files (`quota-usage.entity.ts` and `1850000000000-add-quota-usage-timestamps.ts`; quota update logic also refreshes `updatedAt`)
- [x] Unit/integration tests added or updated and passing (`1850000000000-add-quota-usage-timestamps.spec.ts` — 3/3 passing)
- [x] No regression; follows project coding standards (focused Prettier, ESLint, build-only TypeScript check, and production build pass)

## Test plan

- [x] `npm test -- --runInBand src/database/migrations/1850000000000-add-quota-usage-timestamps.spec.ts` — 3/3 passing
- [x] `npx tsc --noEmit -p tsconfig.build.json` — passes
- [x] `npx eslint src/modules/quota/entities/quota-usage.entity.ts src/modules/quota/quota.service.ts src/database/migrations/1850000000000-add-quota-usage-timestamps.ts src/database/migrations/1850000000000-add-quota-usage-timestamps.spec.ts` — passes
- [x] `npx prettier --check src/modules/quota/entities/quota-usage.entity.ts src/modules/quota/quota.service.ts src/database/migrations/1850000000000-add-quota-usage-timestamps.ts src/database/migrations/1850000000000-add-quota-usage-timestamps.spec.ts` — passes
- [x] `npm run build` — succeeds
- [ ] Existing quota service suite — baseline failure because the upstream test omits the existing CacheService dependency and expects an older transaction implementation

## Env vars / Notes

No new environment variables. Run the migration before deploying code that relies on `updatedAt` in persisted quota usage rows.
