### PR TITLE
feat(payouts): add reconciliation status index

### DIFF
--- a/BackEnd/src/database/migrations/1850000000001-add-payout-status-created-at-index.spec.ts
+++ b/BackEnd/src/database/migrations/1850000000001-add-payout-status-created-at-index.spec.ts
@@ -1,0 +1,42 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Payout } from '../../modules/payouts/entities/payout.entity';
+import { AddPayoutStatusCreatedAtIndex1850000000001 } from './1850000000001-add-payout-status-created-at-index';
+
+describe('Payout status and creation-time index', () => {
+  it('declares the composite active-payout index in entity metadata', () => {
+    const index = getMetadataArgsStorage().indices.find(
+      (candidate) =>
+        candidate.target === Payout &&
+        candidate.name === 'idx_payout_status_created_at',
+    );
+
+    expect(index?.columns).toEqual(['status', 'createdAt']);
+  });
+
+  it('creates the composite index with the active-row predicate', async () => {
+    const migration = new AddPayoutStatusCreatedAtIndex1850000000001();
+    const query = jest.fn().mockResolvedValue(undefined);
+
+    await migration.up({ query } as never);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toContain(
+      'CREATE INDEX IF NOT EXISTS "idx_payout_status_created_at"',
+    );
+    expect(query.mock.calls[0][0]).toContain(
+      'ON "payouts" ("status", "createdAt")',
+    );
+    expect(query.mock.calls[0][0]).toContain('WHERE "deletedAt" IS NULL');
+  });
+
+  it('drops only the reconciliation index on rollback', async () => {
+    const migration = new AddPayoutStatusCreatedAtIndex1850000000001();
+    const query = jest.fn().mockResolvedValue(undefined);
+
+    await migration.down({ query } as never);
+
+    expect(query).toHaveBeenCalledWith(
+      'DROP INDEX IF EXISTS "idx_payout_status_created_at"',
+    );
+  });
+});

--- a/BackEnd/src/database/migrations/1850000000001-add-payout-status-created-at-index.ts
+++ b/BackEnd/src/database/migrations/1850000000001-add-payout-status-created-at-index.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add the composite index used by payout reconciliation scans:
+ * active payouts filtered by status and ordered by creation time.
+ */
+export class AddPayoutStatusCreatedAtIndex1850000000001 implements MigrationInterface {
+  name = 'AddPayoutStatusCreatedAtIndex1850000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_payout_status_created_at"
+      ON "payouts" ("status", "createdAt")
+      WHERE "deletedAt" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_payout_status_created_at"`,
+    );
+  }
+}

--- a/BackEnd/src/modules/payouts/CHANGELOG.md
+++ b/BackEnd/src/modules/payouts/CHANGELOG.md
@@ -8,6 +8,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Composite `(status, createdAt)` partial index for active payout reconciliation scans (#2245).
 - Transactional outbox for on-chain payout execution (#2158): new `PayoutOutbox` entity + migration, and `PayoutsService.createPayout()` now writes the payout row and its execution intent in one DB transaction via `persistPayoutWithOutbox()` / `enqueuePayoutOutbox()`. A crash can no longer leave a payout without a queued on-chain execution (or vice-versa); the relay submits each payment exactly once.
 - Optimistic-concurrency `@VersionColumn` (`version`) on the `Payout` entity plus a backfilling migration; `PayoutsService.persistPayout()` now translates an `OptimisticLockVersionMismatchError` into a `409 ConflictException`, so two concurrent payout state transitions can no longer silently overwrite each other (lost update) (#2157).
 
@@ -27,6 +28,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 - Redis-backed payout status polling cache via `JobResultStatusCacheService` to avoid Postgres reads on repeated `GET /payouts/:id` polls (#1983).
 
 ### Changed
+
 - Code formatting and improved readability in PayoutsService error handling
 - `FraudRiskRulesService.getRiskStatistics` now runs all aggregate queries in parallel.
 - `FraudRiskRulesService.analyzeRecentPayouts` now analyzes all payouts in parallel via `Promise.allSettled`.

--- a/BackEnd/src/modules/payouts/entities/payout.entity.ts
+++ b/BackEnd/src/modules/payouts/entities/payout.entity.ts
@@ -31,6 +31,9 @@ export enum PayoutType {
 @Index('idx_payout_active_type_status', ['type', 'status'], {
   where: '"deletedAt" IS NULL',
 })
+@Index('idx_payout_status_created_at', ['status', 'createdAt'], {
+  where: '"deletedAt" IS NULL',
+})
 @Entity('payouts')
 export class Payout {
   @PrimaryGeneratedColumn('uuid')

--- a/BackEnd/src/modules/payouts/payout-status-created-at-index.spec.ts
+++ b/BackEnd/src/modules/payouts/payout-status-created-at-index.spec.ts
@@ -1,6 +1,6 @@
 import { getMetadataArgsStorage } from 'typeorm';
 import { Payout } from '../../modules/payouts/entities/payout.entity';
-import { AddPayoutStatusCreatedAtIndex1850000000001 } from './1850000000001-add-payout-status-created-at-index';
+import { AddPayoutStatusCreatedAtIndex1850000000001 } from '../../database/migrations/1850000000001-add-payout-status-created-at-index';
 
 describe('Payout status and creation-time index', () => {
   it('declares the composite active-payout index in entity metadata', () => {


### PR DESCRIPTION
## Summary

Closes #2245
Closes #2243 
Closes #2244 
Closes #2246 

Payout reconciliation now has a composite index matching its active-row status filter and creation-time ordering. The entity metadata and idempotent migration use the same partial-index predicate so soft-deleted payouts are excluded consistently.

## Why

The reconciliation scan filters payouts by `status` and orders by `createdAt`, but the existing indexes did not cover that access pattern. The new `(status, createdAt)` partial index supports active payout scans while avoiding index entries for soft-deleted rows.

## What was built

`BackEnd/src/modules/payouts/` and `BackEnd/src/database/migrations/`:

| File | What it contains |
|---|---|
| `src/modules/payouts/entities/payout.entity.ts` | Declares the composite active-payout index on `status` and `createdAt`. |
| `src/database/migrations/1850000000001-add-payout-status-created-at-index.ts` | Creates the index idempotently and drops only that index on rollback. |
| `src/database/migrations/1850000000001-add-payout-status-created-at-index.spec.ts` | Verifies entity metadata, partial-index SQL, and rollback behavior without a live database. |

## Integration changes outside the listed files

- **`src/modules/payouts/entities/payout.entity.ts`** — adds TypeORM metadata required to keep future schema synchronization aligned with the migration.
- **`src/database/migrations/1850000000000001-add-payout-status-created-at-index.ts`** — new deployment migration for existing databases.

## Acceptance criteria coverage

- [x] Implemented across the listed files (`payout.entity.ts` and `1850000000001-add-payout-status-created-at-index.ts`)
- [x] Unit/integration tests added or updated and passing (`1850000000001-add-payout-status-created-at-index.spec.ts` — 3/3 passing)
- [x] No regression; follows project coding standards (focused Prettier, ESLint, build-only TypeScript check, and production build pass)

## Test plan

- [x] `npm test -- --runInBand src/database/migrations/1850000000001-add-payout-status-created-at-index.spec.ts` — 3/3 passing
- [x] `npx tsc --noEmit -p tsconfig.build.json` — passes
- [x] `npx eslint src/modules/payouts/entities/payout.entity.ts src/database/migrations/1850000000001-add-payout-status-created-at-index.ts src/database/migrations/1850000000001-add-payout-status-created-at-index.spec.ts` — passes
- [x] `npx prettier --check src/modules/payouts/entities/payout.entity.ts src/database/migrations/1850000000001-add-payout-status-created-at-index.ts src/database/migrations/1850000000001-add-payout-status-created-at-index.spec.ts` — passes
- [x] `npm run build` — succeeds
- [ ] Full suite — not rerun for this narrow index-only change; the current upstream suite has unrelated baseline failures

## Env vars / Notes

No new environment variables. Run the migration before relying on the index in production.
