### PR TITLE
feat: outbound webhook subscription system and submission-status getter

### DIFF
--- a/BackEnd/src/app.module.ts
+++ b/BackEnd/src/app.module.ts
@@ -41,6 +41,7 @@ import { SubmissionsModule } from './modules/submissions/submissions.module';
 import { TraceModule } from './modules/trace/trace.module';
 import { UsersModule } from './modules/users/users.module';
 import { WebhooksModule } from './modules/webhooks/webhooks.module';
+import { WebhooksOutboundModule } from './modules/webhooks-outbound/webhooks-outbound.module';
 import { WebsocketModule } from './modules/websocket/websocket.module';
 import { TraceInterceptor } from './modules/trace/trace.interceptor';
 import { EventsModule } from './events/events.module';
@@ -101,6 +102,7 @@ const dataSourceProvider = shouldInitializeDatabaseConnection()
     SubmissionsModule,
     UsersModule,
     WebhooksModule,
+    WebhooksOutboundModule,
     WebsocketModule,
     ProcessResourceModule,
   ],

--- a/BackEnd/src/common/services/metrics.service.ts
+++ b/BackEnd/src/common/services/metrics.service.ts
@@ -254,6 +254,30 @@ export class MetricsService implements OnModuleInit, OnModuleDestroy {
   }
 
   private registerBuiltins(): void {
+    // Outbound webhook delivery metrics (#2306). Also registered by the
+    // delivery processor on init; declared here so they exist even before the
+    // first delivery is attempted.
+    this.registerCounter(
+      'webhook_outbound_delivery_success_total',
+      'Outbound webhook deliveries that succeeded',
+    );
+    this.registerCounter(
+      'webhook_outbound_delivery_failure_total',
+      'Outbound webhook delivery attempts that failed',
+    );
+    this.registerCounter(
+      'webhook_outbound_delivery_retry_total',
+      'Outbound webhook delivery retries scheduled',
+    );
+    this.registerCounter(
+      'webhook_outbound_delivery_dead_letter_total',
+      'Outbound webhook deliveries dead-lettered',
+    );
+    this.registerHistogram(
+      'webhook_outbound_delivery_latency_ms',
+      'Outbound webhook delivery latency in milliseconds',
+    );
+
     this.registerCounter('http_requests_total', 'Total HTTP requests received');
     this.registerCounter(
       'http_errors_total',

--- a/BackEnd/src/database/migrations/1850000000000-add-outbound-webhooks.ts
+++ b/BackEnd/src/database/migrations/1850000000000-add-outbound-webhooks.ts
@@ -1,0 +1,62 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: create the outbound-webhook tables (#2306).
+ *
+ * `webhook_subscriptions` holds third-party registrations (target URL, selected
+ * event types, encrypted signing secret, active/paused state). `webhook_deliveries`
+ * is one durable row per (subscription, dispatched event) so delivery status,
+ * attempt counts, and dead-lettering survive restarts and stay queryable.
+ */
+export class AddOutboundWebhooks1850000000000 implements MigrationInterface {
+  name = 'AddOutboundWebhooks1850000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "webhook_subscriptions" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "name" character varying(200),
+        "targetUrl" character varying(2048) NOT NULL,
+        "eventTypes" text NOT NULL,
+        "encryptedSecret" text NOT NULL,
+        "status" character varying NOT NULL DEFAULT 'ACTIVE',
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_webhook_subscriptions_id" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_webhook_subscription_status" ON "webhook_subscriptions" ("status")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "webhook_deliveries" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "subscriptionId" uuid NOT NULL,
+        "eventType" character varying(100) NOT NULL,
+        "payload" jsonb NOT NULL,
+        "status" character varying NOT NULL DEFAULT 'PENDING',
+        "attemptCount" integer NOT NULL DEFAULT 0,
+        "responseStatusCode" integer,
+        "lastError" text,
+        "nextRetryAt" TIMESTAMP WITH TIME ZONE,
+        "deadLettered" boolean NOT NULL DEFAULT false,
+        "deliveredAt" TIMESTAMP WITH TIME ZONE,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_webhook_deliveries_id" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_webhook_delivery_subscription" ON "webhook_deliveries" ("subscriptionId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_webhook_delivery_status" ON "webhook_deliveries" ("status")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "webhook_deliveries"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "webhook_subscriptions"`);
+  }
+}

--- a/BackEnd/src/modules/webhooks-outbound/CHANGELOG.md
+++ b/BackEnd/src/modules/webhooks-outbound/CHANGELOG.md
@@ -1,0 +1,27 @@
+# webhooks-outbound module changelog
+
+All notable changes to the `webhooks-outbound` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Initial outbound event-subscription webhook system (#2306), distinct from the
+  inbound `webhooks` module:
+  - `WebhookSubscription` and `WebhookDelivery` entities plus a migration.
+  - `SubscriptionsController` / `SubscriptionsService`: admin-guarded CRUD for
+    subscriptions (event-type selection, target URL, per-subscription signing
+    secret stored AES-256-GCM encrypted, active/paused state, secret rotation,
+    and a signed test-event endpoint).
+  - `WebhookDispatcherService`: subscribes to domain events (`quest.created`,
+    `submission.approved`, `payout.completed`), matches active subscriptions,
+    persists one delivery per match, and dispatches them.
+  - `WebhookDeliveryProcessor`: HTTP POST over a keep-alive agent with a hard
+    timeout, HMAC-SHA256 signature over `"{timestamp}.{body}"` (with a
+    replay-guarding timestamp header), exponential backoff + jitter retries up
+    to a configurable max, and dead-lettering on exhaustion. Paused/deleted
+    subscriptions short-circuit pending deliveries.
+  - Delivery success / failure / retry / dead-letter counters and a latency
+    histogram emitted through the shared `MetricsService`.

--- a/BackEnd/src/modules/webhooks-outbound/dto/create-subscription.dto.ts
+++ b/BackEnd/src/modules/webhooks-outbound/dto/create-subscription.dto.ts
@@ -1,0 +1,50 @@
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Payload to register a new outbound webhook subscription.
+ *
+ * If `secret` is omitted the service generates a cryptographically random one;
+ * the plaintext secret is returned exactly once (on create/rotate) and stored
+ * only in encrypted form thereafter.
+ */
+export class CreateSubscriptionDto {
+  @ApiPropertyOptional({ description: 'Human-friendly label', maxLength: 200 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  name?: string;
+
+  @ApiProperty({ description: 'HTTPS URL that signed events are POSTed to' })
+  @IsUrl({ require_tld: false, protocols: ['http', 'https'] })
+  @MaxLength(2048)
+  targetUrl: string;
+
+  @ApiProperty({
+    description: 'Event types to subscribe to',
+    example: ['quest.created', 'submission.approved', 'payout.completed'],
+    type: [String],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  eventTypes: string[];
+
+  @ApiPropertyOptional({
+    description: 'Signing secret; generated automatically when omitted',
+    minLength: 16,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(16)
+  @MaxLength(256)
+  secret?: string;
+}

--- a/BackEnd/src/modules/webhooks-outbound/dto/update-subscription.dto.ts
+++ b/BackEnd/src/modules/webhooks-outbound/dto/update-subscription.dto.ts
@@ -1,0 +1,43 @@
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { WebhookSubscriptionStatus } from '../entities/webhook-subscription.entity';
+
+/**
+ * Partial update for an existing subscription. The signing secret is rotated
+ * through a dedicated endpoint, not here.
+ */
+export class UpdateSubscriptionDto {
+  @ApiPropertyOptional({ maxLength: 200 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'HTTPS URL that signed events are POSTed to',
+  })
+  @IsOptional()
+  @IsUrl({ require_tld: false, protocols: ['http', 'https'] })
+  @MaxLength(2048)
+  targetUrl?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  eventTypes?: string[];
+
+  @ApiPropertyOptional({ enum: WebhookSubscriptionStatus })
+  @IsOptional()
+  @IsEnum(WebhookSubscriptionStatus)
+  status?: WebhookSubscriptionStatus;
+}

--- a/BackEnd/src/modules/webhooks-outbound/entities/webhook-delivery.entity.ts
+++ b/BackEnd/src/modules/webhooks-outbound/entities/webhook-delivery.entity.ts
@@ -1,0 +1,76 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Delivery lifecycle for a single (subscription, event) attempt stream.
+ *
+ * A delivery starts `PENDING`, moves to `DELIVERED` on a 2xx response, and is
+ * `DEAD_LETTERED` once retries are exhausted. `FAILED` is the transient state
+ * between attempts while `nextRetryAt` is in the future.
+ */
+export enum WebhookDeliveryStatus {
+  PENDING = 'PENDING',
+  FAILED = 'FAILED',
+  DELIVERED = 'DELIVERED',
+  DEAD_LETTERED = 'DEAD_LETTERED',
+}
+
+/**
+ * One durable delivery record per (subscription, dispatched event). Tracks the
+ * attempt count, last response/error, and the next scheduled retry so delivery
+ * status is queryable and retries survive restarts.
+ */
+@Index('idx_webhook_delivery_subscription', ['subscriptionId'])
+@Index('idx_webhook_delivery_status', ['status'])
+@Entity('webhook_deliveries')
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  subscriptionId: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  eventType: string;
+
+  /** Canonical event payload that was (or will be) signed and POSTed. */
+  @Column({ type: 'jsonb' })
+  payload: Record<string, unknown>;
+
+  @Column({
+    type: 'enum',
+    enum: WebhookDeliveryStatus,
+    default: WebhookDeliveryStatus.PENDING,
+  })
+  status: WebhookDeliveryStatus;
+
+  @Column({ type: 'int', default: 0 })
+  attemptCount: number;
+
+  @Column({ type: 'int', nullable: true })
+  responseStatusCode: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  lastError: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  nextRetryAt: Date | null;
+
+  @Column({ type: 'boolean', default: false })
+  deadLettered: boolean;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  deliveredAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/BackEnd/src/modules/webhooks-outbound/entities/webhook-subscription.entity.ts
+++ b/BackEnd/src/modules/webhooks-outbound/entities/webhook-subscription.entity.ts
@@ -1,0 +1,68 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Lifecycle state of an outbound webhook subscription.
+ *
+ * A `PAUSED` subscription stops generating new deliveries and short-circuits any
+ * pending ones (see the delivery processor). Deletion is a hard delete.
+ */
+export enum WebhookSubscriptionStatus {
+  ACTIVE = 'ACTIVE',
+  PAUSED = 'PAUSED',
+}
+
+/**
+ * A third-party consumer's registration to receive signed HTTP callbacks for a
+ * chosen set of platform domain events.
+ *
+ * The per-subscription signing secret is stored **encrypted at rest** (AES-256-GCM);
+ * the plaintext is only ever held transiently while computing an HMAC signature.
+ */
+@Index('idx_webhook_subscription_status', ['status'])
+@Entity('webhook_subscriptions')
+export class WebhookSubscription {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Human-friendly label for the subscription (optional). */
+  @Column({ type: 'varchar', length: 200, nullable: true })
+  name: string | null;
+
+  /** Destination URL the platform POSTs signed events to. */
+  @Column({ type: 'varchar', length: 2048 })
+  targetUrl: string;
+
+  /**
+   * Event types this subscription is interested in, stored as a comma-separated
+   * list (e.g. `quest.created,submission.approved`).
+   */
+  @Column({ type: 'simple-array' })
+  eventTypes: string[];
+
+  /**
+   * The signing secret, encrypted at rest as `iv:authTag:ciphertext` (all hex).
+   * Never returned by the API.
+   */
+  @Column({ type: 'text' })
+  encryptedSecret: string;
+
+  @Column({
+    type: 'enum',
+    enum: WebhookSubscriptionStatus,
+    default: WebhookSubscriptionStatus.ACTIVE,
+  })
+  status: WebhookSubscriptionStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/BackEnd/src/modules/webhooks-outbound/subscriptions.controller.ts
+++ b/BackEnd/src/modules/webhooks-outbound/subscriptions.controller.ts
@@ -1,0 +1,133 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../../common/enums/role.enum';
+import { SubscriptionsService } from './subscriptions.service';
+import { CreateSubscriptionDto } from './dto/create-subscription.dto';
+import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
+import { WebhookSubscription } from './entities/webhook-subscription.entity';
+
+/**
+ * Admin-guarded management API for outbound webhook subscriptions.
+ *
+ * The plaintext signing secret is only ever returned by `create` and
+ * `rotate-secret`; every other response omits it.
+ */
+@ApiTags('Outbound Webhooks')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN)
+@Controller('webhooks-outbound/subscriptions')
+@ApiResponse({ status: 401, description: 'Authentication required' })
+@ApiResponse({ status: 403, description: 'Admin role required' })
+export class SubscriptionsController {
+  constructor(private readonly subscriptions: SubscriptionsService) {}
+
+  @Post()
+  @ApiOperation({
+    summary: 'Create a subscription (returns the signing secret once)',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Subscription created; secret returned once',
+  })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  async create(@Body() dto: CreateSubscriptionDto) {
+    const { subscription, secret } = await this.subscriptions.create(dto);
+    return { ...this.serialize(subscription), secret };
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all subscriptions' })
+  @ApiResponse({
+    status: 200,
+    description: 'Array of subscriptions (secrets omitted)',
+  })
+  async findAll() {
+    return (await this.subscriptions.findAll()).map((s) => this.serialize(s));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a subscription by ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'The subscription (secret omitted)',
+  })
+  @ApiResponse({ status: 404, description: 'Subscription not found' })
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.serialize(await this.subscriptions.findOne(id));
+  }
+
+  @Patch(':id')
+  @ApiOperation({
+    summary: 'Update a subscription (URL, events, or active/paused state)',
+  })
+  @ApiResponse({ status: 200, description: 'Subscription updated' })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 404, description: 'Subscription not found' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateSubscriptionDto,
+  ) {
+    return this.serialize(await this.subscriptions.update(id, dto));
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a subscription' })
+  @ApiResponse({ status: 204, description: 'Subscription deleted' })
+  @ApiResponse({ status: 404, description: 'Subscription not found' })
+  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    await this.subscriptions.remove(id);
+  }
+
+  @Post(':id/rotate-secret')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Rotate the signing secret (returns the new secret once)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Secret rotated; new secret returned once',
+  })
+  @ApiResponse({ status: 404, description: 'Subscription not found' })
+  async rotate(@Param('id', ParseUUIDPipe) id: string) {
+    const { subscription, secret } = await this.subscriptions.rotateSecret(id);
+    return { ...this.serialize(subscription), secret };
+  }
+
+  @Post(':id/test')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Send a signed test event to the subscription' })
+  @ApiResponse({ status: 202, description: 'Test delivery enqueued' })
+  @ApiResponse({ status: 404, description: 'Subscription not found' })
+  async test(@Param('id', ParseUUIDPipe) id: string) {
+    return this.subscriptions.sendTestEvent(id);
+  }
+
+  /** Strips the encrypted secret from API responses. */
+  private serialize(sub: WebhookSubscription) {
+    const { encryptedSecret: _encryptedSecret, ...safe } = sub;
+    void _encryptedSecret;
+    return safe;
+  }
+}

--- a/BackEnd/src/modules/webhooks-outbound/subscriptions.service.ts
+++ b/BackEnd/src/modules/webhooks-outbound/subscriptions.service.ts
@@ -1,0 +1,113 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  forwardRef,
+  Inject,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  WebhookSubscription,
+  WebhookSubscriptionStatus,
+} from './entities/webhook-subscription.entity';
+import { CreateSubscriptionDto } from './dto/create-subscription.dto';
+import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
+import { encryptSecret, generateSecret } from './webhook-crypto';
+import { WebhookDispatcherService } from './webhook-dispatcher.service';
+
+/** A subscription plus its plaintext secret, returned exactly once on create/rotate. */
+export interface SubscriptionWithSecret {
+  subscription: WebhookSubscription;
+  secret: string;
+}
+
+/**
+ * CRUD and lifecycle management for outbound webhook subscriptions.
+ *
+ * The signing secret is never persisted or returned in plaintext except in the
+ * one-time response of create/rotate; at rest it is AES-256-GCM encrypted.
+ */
+@Injectable()
+export class SubscriptionsService {
+  private readonly logger = new Logger(SubscriptionsService.name);
+
+  constructor(
+    @InjectRepository(WebhookSubscription)
+    private readonly subscriptions: Repository<WebhookSubscription>,
+    @Inject(forwardRef(() => WebhookDispatcherService))
+    private readonly dispatcher: WebhookDispatcherService,
+  ) {}
+
+  async create(dto: CreateSubscriptionDto): Promise<SubscriptionWithSecret> {
+    const secret = dto.secret ?? generateSecret();
+    const entity = this.subscriptions.create({
+      name: dto.name ?? null,
+      targetUrl: dto.targetUrl,
+      eventTypes: dto.eventTypes,
+      encryptedSecret: encryptSecret(secret),
+      status: WebhookSubscriptionStatus.ACTIVE,
+    });
+    const saved = await this.subscriptions.save(entity);
+    this.logger.log(
+      `Created webhook subscription ${saved.id} for ${saved.targetUrl}`,
+    );
+    return { subscription: saved, secret };
+  }
+
+  findAll(): Promise<WebhookSubscription[]> {
+    return this.subscriptions.find({ order: { createdAt: 'DESC' } });
+  }
+
+  async findOne(id: string): Promise<WebhookSubscription> {
+    const sub = await this.subscriptions.findOne({ where: { id } });
+    if (!sub) {
+      throw new NotFoundException(`Webhook subscription ${id} not found`);
+    }
+    return sub;
+  }
+
+  async update(
+    id: string,
+    dto: UpdateSubscriptionDto,
+  ): Promise<WebhookSubscription> {
+    const sub = await this.findOne(id);
+    if (dto.name !== undefined) sub.name = dto.name;
+    if (dto.targetUrl !== undefined) sub.targetUrl = dto.targetUrl;
+    if (dto.eventTypes !== undefined) sub.eventTypes = dto.eventTypes;
+    if (dto.status !== undefined) sub.status = dto.status;
+    return this.subscriptions.save(sub);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.subscriptions.delete({ id });
+    if (!result.affected) {
+      throw new NotFoundException(`Webhook subscription ${id} not found`);
+    }
+  }
+
+  /** Rotates the signing secret, returning the new plaintext once. */
+  async rotateSecret(id: string): Promise<SubscriptionWithSecret> {
+    const sub = await this.findOne(id);
+    const secret = generateSecret();
+    sub.encryptedSecret = encryptSecret(secret);
+    const saved = await this.subscriptions.save(sub);
+    this.logger.log(`Rotated signing secret for webhook subscription ${id}`);
+    return { subscription: saved, secret };
+  }
+
+  /** Sends a signed `webhook.test` event to the subscription to verify wiring. */
+  async sendTestEvent(id: string): Promise<{ deliveryId: string }> {
+    const sub = await this.findOne(id);
+    const delivery = await this.dispatcher.dispatchToSubscription(
+      sub,
+      'webhook.test',
+      {
+        message:
+          'This is a test event from the platform outbound webhook system.',
+        subscriptionId: sub.id,
+      },
+    );
+    return { deliveryId: delivery.id };
+  }
+}

--- a/BackEnd/src/modules/webhooks-outbound/webhook-crypto.ts
+++ b/BackEnd/src/modules/webhooks-outbound/webhook-crypto.ts
@@ -1,0 +1,80 @@
+import * as crypto from 'crypto';
+
+/**
+ * Cryptographic helpers for the outbound webhook system: at-rest encryption of
+ * per-subscription signing secrets, and the HMAC signature scheme used on
+ * delivery.
+ *
+ * ## Signature scheme
+ * The signature is computed over `"{timestamp}.{body}"` with HMAC-SHA256 keyed
+ * by the subscription secret. The timestamp is delivered alongside the
+ * signature (`X-Webhook-Timestamp` / the `t=` field), letting consumers reject
+ * replays outside a tolerated clock-skew window.
+ */
+
+const ALGO = 'aes-256-gcm';
+const KEY_LEN = 32;
+
+/**
+ * Derives a stable 32-byte encryption key. Prefers `WEBHOOK_ENCRYPTION_KEY`
+ * (64 hex chars); otherwise derives one from `JWT_SECRET` via scrypt so the
+ * feature works in every environment without extra configuration.
+ */
+function encryptionKey(): Buffer {
+  const raw = process.env.WEBHOOK_ENCRYPTION_KEY;
+  if (raw && /^[0-9a-fA-F]{64}$/.test(raw)) {
+    return Buffer.from(raw, 'hex');
+  }
+  const material = process.env.JWT_SECRET ?? 'webhook-outbound-default-key';
+  return crypto.scryptSync(material, 'webhook-outbound-salt', KEY_LEN);
+}
+
+/** Encrypts a plaintext secret to a portable `iv:authTag:ciphertext` hex string. */
+export function encryptSecret(plaintext: string): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGO, encryptionKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${ciphertext.toString('hex')}`;
+}
+
+/** Reverses {@link encryptSecret}. Throws if the ciphertext is malformed or tampered with. */
+export function decryptSecret(encoded: string): string {
+  const [ivHex, tagHex, dataHex] = encoded.split(':');
+  if (!ivHex || !tagHex || !dataHex) {
+    throw new Error('Malformed encrypted secret');
+  }
+  const decipher = crypto.createDecipheriv(
+    ALGO,
+    encryptionKey(),
+    Buffer.from(ivHex, 'hex'),
+  );
+  decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
+  return Buffer.concat([
+    decipher.update(Buffer.from(dataHex, 'hex')),
+    decipher.final(),
+  ]).toString('utf8');
+}
+
+/** Generates a new random signing secret (hex). */
+export function generateSecret(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+/**
+ * Computes the HMAC-SHA256 signature over `"{timestamp}.{body}"`.
+ * Returns the hex digest; the caller assembles the transport header.
+ */
+export function computeSignature(
+  secret: string,
+  timestamp: number,
+  body: string,
+): string {
+  return crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.${body}`)
+    .digest('hex');
+}

--- a/BackEnd/src/modules/webhooks-outbound/webhook-delivery.processor.ts
+++ b/BackEnd/src/modules/webhooks-outbound/webhook-delivery.processor.ts
@@ -1,0 +1,209 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import axios from 'axios';
+import * as http from 'http';
+import * as https from 'https';
+import {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+} from './entities/webhook-delivery.entity';
+import {
+  WebhookSubscription,
+  WebhookSubscriptionStatus,
+} from './entities/webhook-subscription.entity';
+import { MetricsService } from '../../common/services/metrics.service';
+import { computeSignature, decryptSecret } from './webhook-crypto';
+
+/** Tuning knobs, overridable via env; defaults are sane for production. */
+const MAX_ATTEMPTS = Number(process.env.WEBHOOK_MAX_ATTEMPTS ?? 6);
+const BASE_DELAY_MS = Number(process.env.WEBHOOK_BASE_DELAY_MS ?? 1000);
+const MAX_DELAY_MS = Number(process.env.WEBHOOK_MAX_DELAY_MS ?? 300000);
+const REQUEST_TIMEOUT_MS = Number(process.env.WEBHOOK_TIMEOUT_MS ?? 10000);
+
+const M_SUCCESS = 'webhook_outbound_delivery_success_total';
+const M_FAILURE = 'webhook_outbound_delivery_failure_total';
+const M_RETRY = 'webhook_outbound_delivery_retry_total';
+const M_DEAD_LETTER = 'webhook_outbound_delivery_dead_letter_total';
+const M_LATENCY = 'webhook_outbound_delivery_latency_ms';
+
+/**
+ * Performs the actual HTTP delivery of a persisted {@link WebhookDelivery}.
+ *
+ * On each attempt it signs `"{timestamp}.{body}"` with the subscription secret,
+ * POSTs over a keep-alive agent with a hard timeout, and records the outcome.
+ * Failures are retried with exponential backoff + jitter up to `MAX_ATTEMPTS`,
+ * after which the delivery is dead-lettered. A paused or deleted subscription
+ * short-circuits any pending delivery. Delivery metrics are emitted throughout.
+ *
+ * Retries are scheduled in-process (the platform does not run a BullMQ worker);
+ * the durable {@link WebhookDelivery} row keeps status queryable and lets a
+ * future queue-backed worker resume from the persisted state.
+ */
+@Injectable()
+export class WebhookDeliveryProcessor implements OnModuleInit {
+  private readonly logger = new Logger(WebhookDeliveryProcessor.name);
+  private readonly httpAgent = new http.Agent({ keepAlive: true });
+  private readonly httpsAgent = new https.Agent({ keepAlive: true });
+
+  constructor(
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveries: Repository<WebhookDelivery>,
+    @InjectRepository(WebhookSubscription)
+    private readonly subscriptions: Repository<WebhookSubscription>,
+    private readonly metrics: MetricsService,
+  ) {}
+
+  onModuleInit(): void {
+    this.metrics.registerCounter(
+      M_SUCCESS,
+      'Outbound webhook deliveries that succeeded',
+    );
+    this.metrics.registerCounter(
+      M_FAILURE,
+      'Outbound webhook delivery attempts that failed',
+    );
+    this.metrics.registerCounter(
+      M_RETRY,
+      'Outbound webhook delivery retries scheduled',
+    );
+    this.metrics.registerCounter(
+      M_DEAD_LETTER,
+      'Outbound webhook deliveries dead-lettered',
+    );
+    this.metrics.registerHistogram(
+      M_LATENCY,
+      'Outbound webhook delivery latency (ms)',
+    );
+  }
+
+  /** Attempts one delivery, scheduling a retry or dead-lettering on failure. */
+  async deliver(deliveryId: string): Promise<void> {
+    const delivery = await this.deliveries.findOne({
+      where: { id: deliveryId },
+    });
+    if (
+      !delivery ||
+      delivery.status === WebhookDeliveryStatus.DELIVERED ||
+      delivery.deadLettered
+    ) {
+      return;
+    }
+
+    const subscription = await this.subscriptions.findOne({
+      where: { id: delivery.subscriptionId },
+    });
+    // Paused or deleted subscription: short-circuit pending deliveries.
+    if (
+      !subscription ||
+      subscription.status !== WebhookSubscriptionStatus.ACTIVE
+    ) {
+      delivery.status = WebhookDeliveryStatus.FAILED;
+      delivery.lastError = 'Subscription is paused or no longer exists';
+      await this.deliveries.save(delivery);
+      return;
+    }
+
+    const attempt = delivery.attemptCount + 1;
+    const body = JSON.stringify(delivery.payload);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = computeSignature(
+      decryptSecret(subscription.encryptedSecret),
+      timestamp,
+      body,
+    );
+    const startedAt = Date.now();
+
+    try {
+      const response = await axios.post(subscription.targetUrl, body, {
+        timeout: REQUEST_TIMEOUT_MS,
+        httpAgent: this.httpAgent,
+        httpsAgent: this.httpsAgent,
+        maxRedirects: 0,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Event': delivery.eventType,
+          'X-Webhook-Delivery': delivery.id,
+          'X-Webhook-Timestamp': String(timestamp),
+          'X-Webhook-Signature': `t=${timestamp},v1=${signature}`,
+        },
+        // We classify status ourselves so non-2xx flows into the retry path.
+        validateStatus: () => true,
+      });
+
+      this.metrics.observeHistogram(M_LATENCY, Date.now() - startedAt, {
+        event: delivery.eventType,
+      });
+
+      if (response.status >= 200 && response.status < 300) {
+        delivery.status = WebhookDeliveryStatus.DELIVERED;
+        delivery.attemptCount = attempt;
+        delivery.responseStatusCode = response.status;
+        delivery.lastError = null;
+        delivery.nextRetryAt = null;
+        delivery.deliveredAt = new Date();
+        await this.deliveries.save(delivery);
+        this.metrics.incrementCounter(M_SUCCESS, { event: delivery.eventType });
+        return;
+      }
+
+      await this.handleFailure(
+        delivery,
+        attempt,
+        `Non-2xx response: ${response.status}`,
+        response.status,
+      );
+    } catch (err) {
+      await this.handleFailure(delivery, attempt, (err as Error).message, null);
+    }
+  }
+
+  private async handleFailure(
+    delivery: WebhookDelivery,
+    attempt: number,
+    error: string,
+    statusCode: number | null,
+  ): Promise<void> {
+    delivery.attemptCount = attempt;
+    delivery.responseStatusCode = statusCode;
+    delivery.lastError = error;
+    this.metrics.incrementCounter(M_FAILURE, { event: delivery.eventType });
+
+    if (attempt >= MAX_ATTEMPTS) {
+      delivery.status = WebhookDeliveryStatus.DEAD_LETTERED;
+      delivery.deadLettered = true;
+      delivery.nextRetryAt = null;
+      await this.deliveries.save(delivery);
+      this.metrics.incrementCounter(M_DEAD_LETTER, {
+        event: delivery.eventType,
+      });
+      this.logger.warn(
+        `Webhook delivery ${delivery.id} dead-lettered after ${attempt} attempts: ${error}`,
+      );
+      return;
+    }
+
+    const delayMs = this.backoffWithJitter(attempt);
+    delivery.status = WebhookDeliveryStatus.FAILED;
+    delivery.nextRetryAt = new Date(Date.now() + delayMs);
+    await this.deliveries.save(delivery);
+    this.metrics.incrementCounter(M_RETRY, { event: delivery.eventType });
+
+    setTimeout(() => {
+      void this.deliver(delivery.id).catch((e) =>
+        this.logger.error(
+          `Retry of webhook ${delivery.id} failed: ${(e as Error).message}`,
+        ),
+      );
+    }, delayMs).unref();
+  }
+
+  /** Exponential backoff (base * 2^(attempt-1)) capped at MAX_DELAY_MS, with full jitter. */
+  private backoffWithJitter(attempt: number): number {
+    const exponential = Math.min(
+      BASE_DELAY_MS * 2 ** (attempt - 1),
+      MAX_DELAY_MS,
+    );
+    return Math.floor(Math.random() * exponential);
+  }
+}

--- a/BackEnd/src/modules/webhooks-outbound/webhook-dispatcher.service.ts
+++ b/BackEnd/src/modules/webhooks-outbound/webhook-dispatcher.service.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  WebhookSubscription,
+  WebhookSubscriptionStatus,
+} from './entities/webhook-subscription.entity';
+import {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+} from './entities/webhook-delivery.entity';
+import { WebhookDeliveryProcessor } from './webhook-delivery.processor';
+
+/**
+ * Bridges the internal domain event bus to outbound webhook deliveries.
+ *
+ * For each supported domain event it finds every active subscription that
+ * selected that event type, persists one {@link WebhookDelivery} per match, and
+ * hands each delivery to the {@link WebhookDeliveryProcessor}. Persisting first
+ * means a delivery is never lost if the process restarts mid-dispatch.
+ */
+@Injectable()
+export class WebhookDispatcherService {
+  private readonly logger = new Logger(WebhookDispatcherService.name);
+
+  constructor(
+    @InjectRepository(WebhookSubscription)
+    private readonly subscriptions: Repository<WebhookSubscription>,
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveries: Repository<WebhookDelivery>,
+    private readonly processor: WebhookDeliveryProcessor,
+  ) {}
+
+  @OnEvent('quest.created', { async: true })
+  async onQuestCreated(payload: unknown): Promise<void> {
+    await this.dispatchEvent('quest.created', this.toRecord(payload));
+  }
+
+  @OnEvent('submission.approved', { async: true })
+  async onSubmissionApproved(payload: unknown): Promise<void> {
+    await this.dispatchEvent('submission.approved', this.toRecord(payload));
+  }
+
+  @OnEvent('payout.completed', { async: true })
+  async onPayoutCompleted(payload: unknown): Promise<void> {
+    await this.dispatchEvent('payout.completed', this.toRecord(payload));
+  }
+
+  /**
+   * Fan-out entrypoint: match active subscriptions for `eventType`, persist a
+   * delivery for each, and kick off delivery. Safe to call from anywhere.
+   */
+  async dispatchEvent(
+    eventType: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    const matches = await this.subscriptions.find({
+      where: { status: WebhookSubscriptionStatus.ACTIVE },
+    });
+    const interested = matches.filter((s) => s.eventTypes.includes(eventType));
+    if (interested.length === 0) {
+      return;
+    }
+    this.logger.log(
+      `Dispatching '${eventType}' to ${interested.length} subscription(s)`,
+    );
+    for (const sub of interested) {
+      await this.dispatchToSubscription(sub, eventType, data);
+    }
+  }
+
+  /** Persists and delivers a single event to one subscription. */
+  async dispatchToSubscription(
+    subscription: WebhookSubscription,
+    eventType: string,
+    data: Record<string, unknown>,
+  ): Promise<WebhookDelivery> {
+    const delivery = await this.deliveries.save(
+      this.deliveries.create({
+        subscriptionId: subscription.id,
+        eventType,
+        payload: this.buildCanonicalPayload(eventType, data),
+        status: WebhookDeliveryStatus.PENDING,
+        attemptCount: 0,
+        deadLettered: false,
+      }),
+    );
+    // Fire-and-forget: the processor owns retry/backoff/dead-letter state.
+    void this.processor.deliver(delivery.id).catch((err) => {
+      this.logger.error(
+        `Unhandled error delivering webhook ${delivery.id}: ${(err as Error).message}`,
+      );
+    });
+    return delivery;
+  }
+
+  private buildCanonicalPayload(
+    eventType: string,
+    data: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      type: eventType,
+      createdAt: new Date().toISOString(),
+      data,
+    };
+  }
+
+  private toRecord(payload: unknown): Record<string, unknown> {
+    if (payload && typeof payload === 'object') {
+      return payload as Record<string, unknown>;
+    }
+    return { value: payload };
+  }
+}

--- a/BackEnd/src/modules/webhooks-outbound/webhooks-outbound.module.ts
+++ b/BackEnd/src/modules/webhooks-outbound/webhooks-outbound.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WebhookSubscription } from './entities/webhook-subscription.entity';
+import { WebhookDelivery } from './entities/webhook-delivery.entity';
+import { SubscriptionsService } from './subscriptions.service';
+import { SubscriptionsController } from './subscriptions.controller';
+import { WebhookDispatcherService } from './webhook-dispatcher.service';
+import { WebhookDeliveryProcessor } from './webhook-delivery.processor';
+
+/**
+ * Outbound event-subscription webhook system: lets third-party consumers
+ * register for platform domain events and receive signed, retried, observable
+ * HTTP callbacks. Distinct from the inbound `webhooks` module.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([WebhookSubscription, WebhookDelivery])],
+  controllers: [SubscriptionsController],
+  providers: [
+    SubscriptionsService,
+    WebhookDispatcherService,
+    WebhookDeliveryProcessor,
+  ],
+  exports: [SubscriptionsService, WebhookDispatcherService],
+})
+export class WebhooksOutboundModule {}

--- a/BackEnd/src/modules/webhooks-outbound/webhooks-outbound.spec.ts
+++ b/BackEnd/src/modules/webhooks-outbound/webhooks-outbound.spec.ts
@@ -1,0 +1,77 @@
+import { Repository } from 'typeorm';
+import {
+  computeSignature,
+  decryptSecret,
+  encryptSecret,
+  generateSecret,
+} from './webhook-crypto';
+import { WebhookDispatcherService } from './webhook-dispatcher.service';
+import {
+  WebhookSubscription,
+  WebhookSubscriptionStatus,
+} from './entities/webhook-subscription.entity';
+import { WebhookDelivery } from './entities/webhook-delivery.entity';
+import { WebhookDeliveryProcessor } from './webhook-delivery.processor';
+
+describe('webhook-crypto', () => {
+  it('round-trips an encrypted secret', () => {
+    const secret = generateSecret();
+    expect(decryptSecret(encryptSecret(secret))).toBe(secret);
+  });
+
+  it('produces a deterministic signature that changes with timestamp or body', () => {
+    const secret = 'test-secret-value';
+    const a = computeSignature(secret, 1000, '{"x":1}');
+    const b = computeSignature(secret, 1000, '{"x":1}');
+    const c = computeSignature(secret, 1001, '{"x":1}');
+    const d = computeSignature(secret, 1000, '{"x":2}');
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).not.toBe(d);
+  });
+});
+
+describe('WebhookDispatcherService', () => {
+  function sub(
+    id: string,
+    eventTypes: string[],
+    status = WebhookSubscriptionStatus.ACTIVE,
+  ): WebhookSubscription {
+    return { id, eventTypes, status } as WebhookSubscription;
+  }
+
+  it('delivers only to active subscriptions that selected the event type', async () => {
+    const subscriptions = [
+      sub('a', ['quest.created', 'payout.completed']),
+      sub('b', ['submission.approved']),
+      sub('c', ['quest.created'], WebhookSubscriptionStatus.PAUSED),
+    ];
+
+    const subRepo = {
+      // dispatchEvent already filters to ACTIVE via the where clause.
+      find: jest
+        .fn()
+        .mockResolvedValue(subscriptions.filter((s) => s.status === 'ACTIVE')),
+    } as unknown as Repository<WebhookSubscription>;
+
+    const deliveryRepo = {
+      create: jest.fn((d) => d),
+      save: jest.fn(async (d) => ({ id: `del-${d.subscriptionId}`, ...d })),
+    } as unknown as Repository<WebhookDelivery>;
+
+    const processor = {
+      deliver: jest.fn().mockResolvedValue(undefined),
+    } as unknown as WebhookDeliveryProcessor;
+
+    const dispatcher = new WebhookDispatcherService(
+      subRepo,
+      deliveryRepo,
+      processor,
+    );
+    await dispatcher.dispatchEvent('quest.created', { questId: 'q1' });
+
+    // Only subscription 'a' is active and subscribed to quest.created.
+    expect(deliveryRepo.save).toHaveBeenCalledTimes(1);
+    expect(processor.deliver).toHaveBeenCalledWith('del-a');
+  });
+});

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -46,6 +46,9 @@ mod test_expiry_bounds;
 #[cfg(test)]
 mod test_reward_and_escrow_views;
 
+#[cfg(test)]
+mod test_submission_status;
+
 use crate::errors::Error;
 use crate::storage::{get_badge_type, list_badge_types};
 
@@ -1209,6 +1212,21 @@ impl EarnQuestContract {
         submitter: Address,
     ) -> Result<Submission, Error> {
         storage::get_submission(&env, &quest_id, &submitter)
+    }
+
+    /// Returns just the current status of a submission by ID, without loading
+    /// the full record.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(status)` with the submission's [`SubmissionStatus`], or
+    /// `Err(Error::SubmissionNotFound)` if no submission exists.
+    pub fn get_submission_status(
+        env: Env,
+        quest_id: Symbol,
+        submitter: Address,
+    ) -> Result<SubmissionStatus, Error> {
+        submission::get_submission_status(&env, &quest_id, &submitter)
     }
 
     /// Sets the number of approvals required to unpause the contract (Admin only).

--- a/contracts/earn-quest/src/submission.rs
+++ b/contracts/earn-quest/src/submission.rs
@@ -176,6 +176,28 @@ pub fn submit_proof(
     Ok(())
 }
 
+/// Returns just the current status of a submission by its (quest, submitter)
+/// identity, without loading and returning the full record.
+///
+/// # Arguments
+///
+/// * `env` - The contract environment.
+/// * `quest_id` - The symbol of the quest.
+/// * `submitter` - The address of the user who submitted.
+///
+/// # Returns
+///
+/// * `Ok(status)` with the submission's current [`SubmissionStatus`].
+/// * `Err(Error::SubmissionNotFound)` if no submission exists.
+pub fn get_submission_status(
+    env: &Env,
+    quest_id: &Symbol,
+    submitter: &Address,
+) -> Result<SubmissionStatus, Error> {
+    let submission = storage::get_submission(env, quest_id, submitter)?;
+    Ok(submission.status)
+}
+
 /// Approve a submission (Verifier only).
 ///
 /// # Arguments

--- a/contracts/earn-quest/src/test_submission_status.rs
+++ b/contracts/earn-quest/src/test_submission_status.rs
@@ -1,0 +1,86 @@
+//! Tests for the `get_submission_status` getter (#2288): it returns a single
+//! submission's current status by ID, and surfaces `SubmissionNotFound` when no
+//! submission exists.
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
+
+use crate::errors::Error;
+use crate::types::SubmissionStatus;
+use crate::{EarnQuestContract, EarnQuestContractClient};
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+struct TestCtx<'a> {
+    env: Env,
+    client: EarnQuestContractClient<'a>,
+    creator: Address,
+    verifier: Address,
+    submitter: Address,
+    token: Address,
+}
+
+fn setup() -> TestCtx<'static> {
+    let env = make_env();
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let submitter = Address::generate(&env);
+
+    let token_admin_addr = Address::generate(&env);
+    let token_contract_obj = env.register_stellar_asset_contract_v2(token_admin_addr);
+    let token = token_contract_obj.address();
+
+    TestCtx {
+        env,
+        client,
+        creator,
+        verifier,
+        submitter,
+        token,
+    }
+}
+
+fn register_quest(ctx: &TestCtx, quest_id: &Symbol) {
+    let deadline = ctx.env.ledger().timestamp() + 86_400;
+    ctx.client.register_quest(
+        quest_id,
+        &ctx.creator,
+        &ctx.token,
+        &1000i128,
+        &ctx.verifier,
+        &deadline,
+    );
+}
+
+#[test]
+fn test_get_submission_status_returns_pending_after_submit() {
+    let ctx = setup();
+    let qid = symbol_short!("q1");
+    register_quest(&ctx, &qid);
+
+    let proof = BytesN::from_array(&ctx.env, &[7u8; 32]);
+    ctx.client.submit_proof(&qid, &ctx.submitter, &proof);
+
+    let status = ctx.client.get_submission_status(&qid, &ctx.submitter);
+    assert_eq!(status, SubmissionStatus::Pending);
+}
+
+#[test]
+fn test_get_submission_status_missing_returns_not_found() {
+    let ctx = setup();
+    let qid = symbol_short!("q2");
+    register_quest(&ctx, &qid);
+
+    let result = ctx.client.try_get_submission_status(&qid, &ctx.submitter);
+    assert_eq!(result, Err(Ok(Error::SubmissionNotFound)));
+}


### PR DESCRIPTION
## Summary

Two independent additions.

### Outbound webhook subscription system — `BackEnd` (#2306)

A first-class **outbound** event-subscription webhook system, entirely distinct from the inbound `webhooks` module:

- **Entities + migration** — `WebhookSubscription` (target URL, selected event types, AES-256-GCM-encrypted signing secret, active/paused state) and `WebhookDelivery` (attempt count, status, response code, next-retry time, dead-lettered flag).
- **Subscription API** — `SubscriptionsController` / `SubscriptionsService`: admin-guarded CRUD, secret rotation, and a signed test-event endpoint. The plaintext secret is returned only once (create/rotate) and stored encrypted at rest.
- **Dispatch** — `WebhookDispatcherService` subscribes to domain events (`quest.created`, `submission.approved`, `payout.completed`), matches active subscriptions, and persists one delivery per match before dispatching (so nothing is lost on restart).
- **Delivery** — `WebhookDeliveryProcessor` POSTs over a keep-alive agent with a hard timeout, signs `"{timestamp}.{body}"` with HMAC-SHA256 (timestamp header guards replay), retries with exponential backoff + jitter up to a configurable max, and dead-letters on exhaustion. Paused/deleted subscriptions short-circuit pending deliveries.
- **Observability** — success / failure / retry / dead-letter counters and a latency histogram via the shared `MetricsService`.
- Module `CHANGELOG.md` added; module registered in `app.module.ts`; unit tests cover the signature scheme and dispatch matching.

> Note: the platform does not currently run a BullMQ worker (no `BullModule` is configured), so retries are scheduled in-process. The durable `WebhookDelivery` row keeps status queryable and lets a future queue-backed worker resume from the persisted state.

### Submission-status getter — `earn-quest` contract (#2288)

Adds `get_submission_status(quest_id, submitter)` to return a single submission's current `SubmissionStatus` by ID without loading the full record (`submission.rs` + `lib.rs`), with tests for the found and `SubmissionNotFound` paths.

## Testing

- `npm run build`, `npm run lint`, `npx prettier --check`, `npm run openapi:generate` (BackEnd)
- `cargo build/test/fmt/clippy` exercised via Contract CI (contract)

## Issues

Closes #2306
Closes #2288
