### PR TITLE
feat(health): monitor BullMQ queue connectivity

### DIFF
--- a/BackEnd/src/modules/health/CHANGELOG.md
+++ b/BackEnd/src/modules/health/CHANGELOG.md
@@ -7,6 +7,8 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+
+- Deep health diagnostics now include bounded BullMQ/Redis queue connectivity checks (#2257).
 - `ExternalHealthService` now uses `PooledHttpClientService` (keep-alive connection pool, 3 s `short` timeout budget) instead of ad-hoc `axios` calls for Stellar Horizon and SendGrid health checks. `HttpClientModule` added to `HealthModule` imports.
 - Added `HealthCacheService` with configurable TTL to cache readiness probe results and avoid redundant dependency checks.
 - Readiness endpoint (`/health/ready`) now returns cached results within the TTL window.

--- a/BackEnd/src/modules/health/health.controller.spec.ts
+++ b/BackEnd/src/modules/health/health.controller.spec.ts
@@ -1,0 +1,70 @@
+import { HealthController } from './health.controller';
+import { HealthCheckResult } from './types/health.types';
+
+describe('HealthController queue health', () => {
+  const okResult: HealthCheckResult = { status: 'ok', latency: 10 };
+  const dependencies = {
+    dbHealth: { check: jest.fn().mockResolvedValue(okResult) },
+    cacheHealth: { check: jest.fn().mockResolvedValue(okResult) },
+    externalHealth: {
+      check: jest.fn().mockResolvedValue(okResult),
+      checkStellar: jest.fn(),
+    },
+    metricsService: { getPrometheusOutput: jest.fn() },
+    healthCache: { get: jest.fn().mockReturnValue(null), set: jest.fn() },
+    jobsService: { checkHealth: jest.fn().mockResolvedValue(okResult) },
+  };
+
+  const createController = () =>
+    new HealthController(
+      dependencies.dbHealth as any,
+      dependencies.cacheHealth as any,
+      dependencies.externalHealth as any,
+      dependencies.metricsService as any,
+      dependencies.healthCache as any,
+      dependencies.jobsService as any,
+    );
+
+  const response = () => ({ status: jest.fn() }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dependencies.dbHealth.check.mockResolvedValue(okResult);
+    dependencies.cacheHealth.check.mockResolvedValue(okResult);
+    dependencies.externalHealth.check.mockResolvedValue(okResult);
+    dependencies.jobsService.checkHealth.mockResolvedValue(okResult);
+  });
+
+  it('includes BullMQ health in the deep response', async () => {
+    const res = response();
+    const result = await createController().deep(res);
+
+    expect(result.services.jobs).toEqual(okResult);
+    expect(dependencies.jobsService.checkHealth).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 503 when BullMQ health is down', async () => {
+    const res = response();
+    const downResult: HealthCheckResult = {
+      status: 'down',
+      latency: 3000,
+      error: 'Redis connection refused',
+    };
+    dependencies.jobsService.checkHealth.mockResolvedValue(downResult);
+
+    const result = await createController().deep(res);
+
+    expect(result.status).toBe('down');
+    expect(result.services.jobs).toEqual(downResult);
+    expect(res.status).toHaveBeenCalledWith(503);
+  });
+
+  it('includes BullMQ health in the legacy response', async () => {
+    const res = response();
+    const result = await createController().root(res);
+
+    expect(result.services.jobs).toEqual(okResult);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/BackEnd/src/modules/health/health.controller.ts
+++ b/BackEnd/src/modules/health/health.controller.ts
@@ -7,6 +7,7 @@ import { CacheHealthService } from './services/cache-health.service';
 import { ExternalHealthService } from './services/external-health.service';
 import { MetricsService } from '../../common/services/metrics.service';
 import { HealthCacheService } from '../../common/services/health-cache.service';
+import { JobsService } from '../jobs/jobs.service';
 import {
   LiveHealthResponse,
   ReadyHealthResponse,
@@ -27,6 +28,7 @@ export class HealthController {
     private readonly externalHealth: ExternalHealthService,
     private readonly metricsService: MetricsService,
     private readonly healthCache: HealthCacheService,
+    private readonly jobsService: JobsService,
   ) {}
 
   @Get('live')
@@ -57,22 +59,26 @@ export class HealthController {
   ): Promise<DeepHealthResponse> {
     this.logger.debug('Legacy health check (/) - collecting dependency status');
 
-    const [dbResult, cacheResult, externalResult] = await Promise.all([
-      this.dbHealth.check(),
-      this.cacheHealth.check(),
-      this.externalHealth.check(),
-    ]);
+    const [dbResult, cacheResult, externalResult, jobsResult] =
+      await Promise.all([
+        this.dbHealth.check(),
+        this.cacheHealth.check(),
+        this.externalHealth.check(),
+        this.jobsService.checkHealth(),
+      ]);
 
     const services = {
       database: this.mapServiceHealth(dbResult),
       cache: this.mapServiceHealth(cacheResult),
       external: this.mapServiceHealth(externalResult),
+      jobs: this.mapServiceHealth(jobsResult),
     };
 
     const overallStatus = this.calculateLegacyOverallStatus([
       dbResult,
       cacheResult,
       externalResult,
+      jobsResult,
     ]);
 
     res.status(overallStatus === 'down' ? 503 : 200);
@@ -218,22 +224,26 @@ export class HealthController {
     this.logger.debug('Deep health check starting');
 
     // Run all checks in parallel
-    const [dbResult, cacheResult, externalResult] = await Promise.all([
-      this.dbHealth.check(),
-      this.cacheHealth.check(),
-      this.externalHealth.check(),
-    ]);
+    const [dbResult, cacheResult, externalResult, jobsResult] =
+      await Promise.all([
+        this.dbHealth.check(),
+        this.cacheHealth.check(),
+        this.externalHealth.check(),
+        this.jobsService.checkHealth(),
+      ]);
 
     const services = {
       database: this.mapServiceHealth(dbResult),
       cache: this.mapServiceHealth(cacheResult),
       external: this.mapServiceHealth(externalResult),
+      jobs: this.mapServiceHealth(jobsResult),
     };
 
     const overallStatus = this.calculateOverallStatus([
       dbResult,
       cacheResult,
       externalResult,
+      jobsResult,
     ]);
 
     // Set HTTP status code based on overall status
@@ -243,6 +253,7 @@ export class HealthController {
       dbLatency: dbResult.latency,
       cacheLatency: cacheResult.latency,
       externalLatency: externalResult.latency,
+      jobsLatency: jobsResult.latency,
     });
 
     return {
@@ -299,9 +310,13 @@ export class HealthController {
   private calculateLegacyOverallStatus(
     results: HealthCheckResult[],
   ): ServiceStatus {
-    const [databaseResult, cacheResult, externalResult] = results;
+    const [databaseResult, cacheResult, externalResult, jobsResult] = results;
 
-    if (databaseResult?.status === 'down' || cacheResult?.status === 'down') {
+    if (
+      databaseResult?.status === 'down' ||
+      cacheResult?.status === 'down' ||
+      jobsResult?.status === 'down'
+    ) {
       return 'down';
     }
 

--- a/BackEnd/src/modules/health/health.module.ts
+++ b/BackEnd/src/modules/health/health.module.ts
@@ -9,9 +9,16 @@ import { CacheHealthService } from './services/cache-health.service';
 import { ExternalHealthService } from './services/external-health.service';
 import { DatabasePoolMonitorService } from './services/database-pool-monitor.service';
 import { MetricsService } from '../../common/services/metrics.service';
+import { JobsModule } from '../jobs/jobs.module';
 
 @Module({
-  imports: [TypeOrmModule, ConfigModule, CacheModule, HttpClientModule],
+  imports: [
+    TypeOrmModule,
+    ConfigModule,
+    CacheModule,
+    HttpClientModule,
+    JobsModule,
+  ],
   controllers: [HealthController],
   providers: [
     DatabaseHealthService,

--- a/BackEnd/src/modules/health/types/health.types.ts
+++ b/BackEnd/src/modules/health/types/health.types.ts
@@ -28,6 +28,7 @@ export interface DeepHealthResponse {
     database: ServiceHealth;
     cache: ServiceHealth;
     external: ServiceHealth;
+    jobs: ServiceHealth;
   };
 }
 

--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -12,6 +12,8 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 - Stuck-outbox recovery in `PayoutReconciliationProcessor.recoverStuckPayoutOutbox()` — resets outbox rows left in PROCESSING beyond the crash threshold back to PENDING so the idempotent relay can safely replay them (#2158).
 
 ### Changed
+
+- `JobsService` now exposes bounded Redis/BullMQ queue health checks for system diagnostics (#2257).
 - Applied code-style formatting to `jobs.constants.ts` import block (no logic change).
 
 ### Added

--- a/BackEnd/src/modules/jobs/jobs.health.spec.ts
+++ b/BackEnd/src/modules/jobs/jobs.health.spec.ts
@@ -1,0 +1,53 @@
+import { JobsService } from './jobs.service';
+
+describe('JobsService queue health', () => {
+  let service: JobsService;
+
+  beforeEach(() => {
+    service = new JobsService({} as any, {} as any);
+  });
+
+  it('returns ok after Redis ping succeeds for every initialized queue', async () => {
+    const ping = jest.fn().mockResolvedValue('PONG');
+    const queues = {
+      notifications: {
+        waitUntilReady: jest.fn().mockResolvedValue({ ping }),
+      },
+      payouts: {
+        waitUntilReady: jest.fn().mockResolvedValue({ ping }),
+      },
+    };
+    (service as any).queues = queues;
+
+    const result = await service.checkHealth();
+
+    expect(result.status).toBe('ok');
+    expect(result.error).toBeUndefined();
+    expect(queues.notifications.waitUntilReady).toHaveBeenCalledTimes(1);
+    expect(queues.payouts.waitUntilReady).toHaveBeenCalledTimes(1);
+    expect(ping).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns down when a queue cannot connect to Redis', async () => {
+    const queues = {
+      notifications: {
+        waitUntilReady: jest
+          .fn()
+          .mockRejectedValue(new Error('Redis connection refused')),
+      },
+    };
+    (service as any).queues = queues;
+
+    const result = await service.checkHealth();
+
+    expect(result.status).toBe('down');
+    expect(result.error).toBe('Redis connection refused');
+  });
+
+  it('returns down when no queues have been initialized', async () => {
+    const result = await service.checkHealth();
+
+    expect(result.status).toBe('down');
+    expect(result.error).toBe('No BullMQ queues are initialized');
+  });
+});

--- a/BackEnd/src/modules/jobs/jobs.service.ts
+++ b/BackEnd/src/modules/jobs/jobs.service.ts
@@ -23,6 +23,7 @@ import {
   resolveWorkerLimiter,
 } from './utils/worker-concurrency.util';
 import { PayloadStorageService } from './services/payload-storage.service';
+import type { HealthCheckResult } from '../health/types/health.types';
 
 export interface QueueMetrics {
   queue: string;
@@ -36,6 +37,8 @@ export interface QueueMetrics {
 interface TraceableJobData {
   __trace?: TraceContext;
 }
+
+const QUEUE_HEALTH_TIMEOUT_MS = 3000;
 
 const redisConnection = () => {
   const url = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
@@ -321,6 +324,55 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     return job.data as T;
   }
 
+  /**
+   * Checks Redis connectivity and readiness of every initialized BullMQ queue.
+   *
+   * Health checks must not wait indefinitely for a reconnecting Redis client,
+   * so the complete check is bounded by QUEUE_HEALTH_TIMEOUT_MS.
+   */
+  async checkHealth(): Promise<HealthCheckResult> {
+    const startTime = Date.now();
+    const queueEntries = Object.entries(this.queues);
+
+    if (queueEntries.length === 0) {
+      return {
+        status: 'down',
+        latency: Date.now() - startTime,
+        error: 'No BullMQ queues are initialized',
+      };
+    }
+
+    try {
+      await this.withTimeout(
+        Promise.all(
+          queueEntries.map(async ([name, queue]) => {
+            const client = await queue.waitUntilReady();
+            if (typeof client.ping !== 'function') {
+              throw new Error(`Redis client for queue ${name} cannot ping`);
+            }
+            await client.ping();
+          }),
+        ),
+        QUEUE_HEALTH_TIMEOUT_MS,
+      );
+
+      return {
+        status: 'ok',
+        latency: Date.now() - startTime,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown queue health error';
+      this.logger.error(`BullMQ health check failed: ${errorMessage}`);
+
+      return {
+        status: 'down',
+        latency: Date.now() - startTime,
+        error: errorMessage,
+      };
+    }
+  }
+
   /** Returns active, delayed, failed, and completed counts for every queue. */
   async getQueueMetrics(): Promise<QueueMetrics[]> {
     return Promise.all(
@@ -351,6 +403,30 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
       queue.getWaitingCount(),
     ]);
     return { queue: name, active, delayed, failed, completed, waiting };
+  }
+
+  private async withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+  ): Promise<T> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<T>((_, reject) => {
+          timeout = setTimeout(
+            () =>
+              reject(
+                new Error(`Queue health check timed out after ${timeoutMs}ms`),
+              ),
+            timeoutMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
   }
 
   /**

--- a/BackEnd/test/health/health.e2e-spec.ts
+++ b/BackEnd/test/health/health.e2e-spec.ts
@@ -13,6 +13,8 @@ import { CacheHealthService } from '#src/modules/health/services/cache-health.se
 import { ExternalHealthService } from '#src/modules/health/services/external-health.service';
 import { HealthCheckResult } from '#src/modules/health/types/health.types';
 import { MetricsService } from '#src/common/services/metrics.service';
+import { JobsService } from '#src/modules/jobs/jobs.service';
+import { HealthCacheService } from '#src/common/services/health-cache.service';
 
 const mockDatabaseHealth = {
   check: jest.fn(),
@@ -31,6 +33,15 @@ const mockMetricsService = {
   getPrometheusOutput: jest.fn().mockReturnValue(''),
 };
 
+const mockJobsHealth = {
+  checkHealth: jest.fn().mockResolvedValue({ status: 'ok', latency: 10 }),
+};
+
+const mockHealthCache = {
+  get: jest.fn().mockReturnValue(null),
+  set: jest.fn(),
+};
+
 describe('Health (e2e)', () => {
   let app: INestApplication<App>;
 
@@ -43,6 +54,8 @@ describe('Health (e2e)', () => {
         { provide: CacheHealthService, useValue: mockCacheHealth },
         { provide: ExternalHealthService, useValue: mockExternalHealth },
         { provide: MetricsService, useValue: mockMetricsService },
+        { provide: JobsService, useValue: mockJobsHealth },
+        { provide: HealthCacheService, useValue: mockHealthCache },
       ],
     }).compile();
 
@@ -63,6 +76,7 @@ describe('Health (e2e)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockJobsHealth.checkHealth.mockResolvedValue({ status: 'ok', latency: 10 });
   });
 
   describe('GET /health/live', () => {
@@ -266,6 +280,29 @@ describe('Health (e2e)', () => {
       expect(res.body.services.database.status).toBe('ok');
       expect(res.body.services.cache.status).toBe('ok');
       expect(res.body.services.external.status).toBe('ok');
+      expect(res.body.services.jobs.status).toBe('ok');
+      expect(mockJobsHealth.checkHealth).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 503 when the BullMQ queue health check is down', async () => {
+      const okResult: HealthCheckResult = { status: 'ok', latency: 50 };
+      const downResult: HealthCheckResult = {
+        status: 'down',
+        latency: 3000,
+        error: 'Redis connection refused',
+      };
+      mockDatabaseHealth.check.mockResolvedValue(okResult);
+      mockCacheHealth.check.mockResolvedValue(okResult);
+      mockExternalHealth.check.mockResolvedValue(okResult);
+      mockJobsHealth.checkHealth.mockResolvedValue(downResult);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/health/deep')
+        .expect(503);
+
+      expect(res.body.status).toBe('down');
+      expect(res.body.services.jobs.status).toBe('down');
+      expect(res.body.services.jobs.error).toBe('Redis connection refused');
     });
 
     it('returns 200 with status degraded when external service is degraded', async () => {


### PR DESCRIPTION
## Summary

Closes #2257
Closes #2236
Closes #2258 
Closes #2196 

Adds bounded BullMQ/Redis connectivity checks to the existing health diagnostics. The implementation keeps queue ownership in `JobsService`, uses BullMQ's supported `waitUntilReady()` API followed by Redis `PING`, and exposes the result through the existing deep and legacy health responses.

## Why

The health system previously checked the database, cache, and external services but could not detect a queue infrastructure outage before jobs accumulated. The new check reports an uninitialized queue set, Redis connection failure, missing ping capability, and timeout as `down`, while bounding the probe so a reconnecting Redis client cannot hang the health endpoint.

## What was built

- **`BackEnd/src/modules/jobs/jobs.service.ts`** — added `checkHealth()`, which checks every initialized BullMQ queue in parallel, verifies Redis readiness and `PING`, and returns the repository's existing `HealthCheckResult` contract with a 3-second timeout.
- **`BackEnd/src/modules/health/health.controller.ts`** — includes queue health in `/health/deep` and the backwards-compatible `/health` endpoint, making queue failure contribute to HTTP 503 responses.
- **`BackEnd/src/modules/health/health.module.ts`** — wires `JobsModule` so the controller reuses the existing `JobsService`.
- **`BackEnd/src/modules/health/types/health.types.ts`** — adds the `jobs` service entry to `DeepHealthResponse`.
- **`BackEnd/src/modules/jobs/jobs.health.spec.ts`** — tests healthy Redis, connection failure, and uninitialized queues.
- **`BackEnd/src/modules/health/health.controller.spec.ts`** — tests healthy and failing queue results in deep health and the legacy endpoint.
- **`BackEnd/test/health/health.e2e-spec.ts`** — updates the fixture and verifies the public deep endpoint reports queue status and 503 on queue failure.

## Integration changes outside the health/jobs modules

- **`BackEnd/test/health/health.e2e-spec.ts`** — updated the existing health fixture for the new `JobsService` and `HealthCacheService` dependencies, and added queue failure coverage.

## Acceptance criteria coverage

- [x] Implemented across the listed files (`BackEnd/src/modules/health/health.controller.ts` and `BackEnd/src/modules/jobs/jobs.service.ts`, with module/type wiring required for dependency injection).
- [x] Unit/integration tests added or updated and passing (`jobs.health.spec.ts`, `health.controller.spec.ts`, and `test:e2e` health suite).
- [x] No regression; follows project coding standards (Prettier, build-only TypeScript check, production build, focused unit tests, and configured health e2e suite pass).

## Test plan

- [x] `npm test -- --runInBand src/modules/jobs/jobs.health.spec.ts src/modules/health/health.controller.spec.ts` — 6/6 passing (6 new focused tests)
- [x] `npm run test:e2e -- --runInBand test/health/health.e2e-spec.ts` — 20/20 passing (1 new queue-failure test plus updated queue assertions)
- [x] `npx tsc --noEmit -p tsconfig.build.json` — passes
- [x] `npx prettier --check ...` — passes
- [x] `npm run build` — succeeds
- [x] `npx eslint ...` — no errors; 52 warnings remain in existing touched-file code, primarily pre-existing `JobsService` unsafe-any and controller optional-chain warnings
- [ ] Full backend Jest suite — not rerun for this PR; the repository baseline previously had 172 failing tests across 40 suites

## Env vars / Notes

No new environment variables. The queue health probe uses the existing `REDIS_URL` configuration through the queues already owned by `JobsService` and times out after 3 seconds.