### PR TITLE
fix(quests): return conflict for duplicate IDs

### DIFF
--- a/BackEnd/src/modules/quests/CHANGELOG.md
+++ b/BackEnd/src/modules/quests/CHANGELOG.md
@@ -13,5 +13,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 - Unit tests for `QuestMapper` covering entity-to-DTO transformation
 
 ### Changed
+
+- Quest creation now translates PostgreSQL duplicate-key errors into a 409 conflict response (#2242).
 - Refactored `QuestsService` to use `QuestMapper` instead of `QuestResponseDto.fromEntity` for all response mappings (`create`, `findAll`, `findOne`, `update`)
 - Cache invalidation in `update` and `delete` now runs `deletePattern` and `delete` calls in parallel.

--- a/BackEnd/src/modules/quests/quests.controller.ts
+++ b/BackEnd/src/modules/quests/quests.controller.ts
@@ -53,6 +53,7 @@ export class QuestsController {
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden - Admin role required' })
+  @ApiResponse({ status: 409, description: 'Quest ID already exists' })
   async create(
     @Body() createQuestDto: CreateQuestDto,
     @CurrentUser() user: AuthUser,

--- a/BackEnd/src/modules/quests/quests.duplicate.spec.ts
+++ b/BackEnd/src/modules/quests/quests.duplicate.spec.ts
@@ -1,0 +1,106 @@
+import { QuestAlreadyExistsException } from '../../common/exceptions/app.exceptions';
+import { CacheService } from '../cache/cache.service';
+import { ModerationService } from '../moderation/moderation.service';
+import { QuotaService } from '../quota/quota.service';
+import { QuestsService } from './quests.service';
+
+const createService = () => {
+  const repository = {
+    create: jest.fn().mockReturnValue({
+      id: 'existing-quest-id',
+      title: 'Duplicate quest',
+      description: 'A quest with enough description text',
+      rewardAmount: 10,
+      createdBy: 'GABC',
+    }),
+    save: jest.fn(),
+  };
+  const cache = { deletePattern: jest.fn().mockResolvedValue(undefined) };
+  const eventEmitter = { emit: jest.fn() };
+  const moderation = {
+    scanText: jest.fn().mockResolvedValue({
+      shouldBlock: false,
+      keywordHits: [],
+    }),
+    saveQuestModerationItem: jest.fn().mockResolvedValue(undefined),
+  };
+  const quota = {
+    enforceQuestCreationQuota: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const service = new QuestsService(
+    repository as any,
+    cache as unknown as CacheService,
+    eventEmitter as any,
+    moderation as unknown as ModerationService,
+    quota as unknown as QuotaService,
+  );
+
+  return { service, repository };
+};
+
+describe('QuestsService duplicate quest handling', () => {
+  it('translates PostgreSQL duplicate-key errors into HTTP 409', async () => {
+    const { service, repository } = createService();
+    const duplicateError = Object.assign(new Error('duplicate key'), {
+      code: '23505',
+    });
+    repository.save.mockRejectedValue(duplicateError);
+
+    const promise = service.create(
+      {
+        title: 'Duplicate quest',
+        description: 'A quest with enough description text',
+        rewardAmount: 10,
+      } as any,
+      'GABC',
+    );
+
+    try {
+      await promise;
+      throw new Error('Expected quest creation to reject');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(QuestAlreadyExistsException);
+      const exception = error as QuestAlreadyExistsException;
+      expect(exception.getStatus()).toBe(409);
+      expect(exception.getResponse()).toBe(
+        "Quest 'existing-quest-id' already exists",
+      );
+    }
+  });
+
+  it('translates wrapped TypeORM PostgreSQL errors into HTTP 409', async () => {
+    const { service, repository } = createService();
+    repository.save.mockRejectedValue({
+      driverError: { code: '23505' },
+    });
+
+    await expect(
+      service.create(
+        {
+          title: 'Duplicate quest',
+          description: 'A quest with enough description text',
+          rewardAmount: 10,
+        } as any,
+        'GABC',
+      ),
+    ).rejects.toBeInstanceOf(QuestAlreadyExistsException);
+  });
+
+  it('preserves non-duplicate database errors', async () => {
+    const { service, repository } = createService();
+    const databaseError = new Error('database unavailable');
+    repository.save.mockRejectedValue(databaseError);
+
+    await expect(
+      service.create(
+        {
+          title: 'Quest',
+          description: 'A quest with enough description text',
+          rewardAmount: 10,
+        } as any,
+        'GABC',
+      ),
+    ).rejects.toBe(databaseError);
+  });
+});

--- a/BackEnd/src/modules/quests/quests.service.ts
+++ b/BackEnd/src/modules/quests/quests.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   ForbiddenException,
 } from '@nestjs/common';
+import { QuestAlreadyExistsException } from '../../common/exceptions/app.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Quest } from './entities/quest.entity';
@@ -86,7 +87,15 @@ export class QuestsService {
       });
     }
 
-    const savedQuest = await this.questRepository.save(quest);
+    let savedQuest: Quest;
+    try {
+      savedQuest = await this.questRepository.save(quest);
+    } catch (error: unknown) {
+      if (this.isUniqueViolation(error)) {
+        throw new QuestAlreadyExistsException(quest.id);
+      }
+      throw error;
+    }
 
     await this.moderationService.saveQuestModerationItem(
       savedQuest.id,
@@ -315,6 +324,22 @@ export class QuestsService {
       this.cacheService.deletePattern(CACHE_KEYS.QUESTS),
       this.cacheService.delete(`${CACHE_KEYS.QUEST_DETAIL}:${id}`),
     ]);
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) {
+      return false;
+    }
+
+    const databaseError = error as {
+      code?: unknown;
+      driverError?: { code?: unknown };
+    };
+
+    return (
+      databaseError.code === '23505' ||
+      databaseError.driverError?.code === '23505'
+    );
   }
 
   validateStatusTransition(currentStatus: string, newStatus: string): void {


### PR DESCRIPTION
## Summary

Closes #2242

Closes #2240 

Closes #2241 

Closes #2207 

Maps PostgreSQL duplicate-key failures from quest creation to the existing `QuestAlreadyExistsException`, producing a clean HTTP 409 response instead of an unhandled 500. The controller documents the conflict response, while non-duplicate database failures continue to propagate unchanged.

## Why

Quest creation previously passed repository save errors directly through the request pipeline, so a duplicate-key violation was treated as an internal server error. The fix checks PostgreSQL error code `23505` in both the direct and TypeORM-wrapped `driverError` shapes and reuses the existing conflict exception rather than adding a parallel error contract.

## What was built

- **`BackEnd/src/modules/quests/quests.service.ts`** — catches only PostgreSQL unique violations during quest persistence, translates them to `QuestAlreadyExistsException`, and preserves all other errors.
- **`BackEnd/src/modules/quests/quests.controller.ts`** — documents HTTP 409 for duplicate quest IDs in the create endpoint's OpenAPI responses.
- **`BackEnd/src/modules/quests/quests.duplicate.spec.ts`** — tests direct `23505` errors, TypeORM-wrapped `driverError.code` errors, and propagation of unrelated database errors.

## Integration changes outside the quests module

No existing files outside the quests module were modified.

## Acceptance criteria coverage

- [x] Implemented across the listed files (`BackEnd/src/modules/quests/quests.service.ts` and `BackEnd/src/modules/quests/quests.controller.ts`).
- [x] Unit/integration tests added or updated and passing (`quests.duplicate.spec.ts` — 3/3 passing).
- [x] No regression; follows project coding standards (Prettier, build-only TypeScript check, production build, and focused regression tests pass).

## Test plan

- [x] `npm test -- --runInBand src/modules/quests/quests.duplicate.spec.ts` — 3/3 passing (3 new tests)
- [x] `npx tsc --noEmit -p tsconfig.build.json` — passes
- [x] `npx prettier --check src/modules/quests/quests.service.ts src/modules/quests/quests.controller.ts src/modules/quests/quests.duplicate.spec.ts` — passes
- [x] `npm run build` — succeeds
- [x] `npx eslint ...` — no errors; 1 existing optional-chain warning remains in `QuestsService`
- [ ] Full backend Jest suite — not rerun for this PR; the repository baseline previously had 172 failing tests across 40 suites

## Env vars / Notes

No new environment variables or migrations. The create DTO currently generates quest UUIDs server-side; this handler also covers unique constraints such as the existing `contractTaskId` index.