### PR TITLE
feat(earn-quest): typed error on zero claim and total batch-approval bound

### DIFF
--- a/contracts/earn-quest/src/errors.rs
+++ b/contracts/earn-quest/src/errors.rs
@@ -148,6 +148,7 @@ pub enum Error {
     BadgeTypeNotFound = 142,
 
     // Payout Errors
+    /// Reward-claim amount is zero or negative.
     InvalidClaimAmount = 143,
 
     // Verifier Stake Errors

--- a/contracts/earn-quest/src/lib.rs
+++ b/contracts/earn-quest/src/lib.rs
@@ -49,6 +49,9 @@ mod test_reward_and_escrow_views;
 #[cfg(test)]
 mod test_submission_status;
 
+#[cfg(test)]
+mod test_claim_and_batch_bounds;
+
 use crate::errors::Error;
 use crate::storage::{get_badge_type, list_badge_types};
 
@@ -615,6 +618,19 @@ impl EarnQuestContract {
 
         security::require_not_paused(&env)?;
         verifier.require_auth();
+
+        // Bound the total fan-out across all inputs' inner submission vectors,
+        // not just the number of inputs, to prevent gas exhaustion from an
+        // arbitrarily long single input.
+        let mut total: u32 = 0;
+        for i in 0u32..submissions.len() {
+            let input = submissions.get(i).ok_or(Error::IndexOutOfBounds)?;
+            total = total
+                .checked_add(input.submissions.len())
+                .ok_or(Error::ArithmeticOverflow)?;
+        }
+        validation::validate_batch_approval_total(total)?;
+
         submission::approve_submissions_batch(&env, &verifier, &submissions)
     }
 
@@ -631,6 +647,10 @@ impl EarnQuestContract {
         gas_budget::reset_call_budget(&env);
         gas_budget::enforce_budget(&env, &soroban_sdk::symbol_short!("clm_rwd"))?;
         submitter.require_auth();
+
+        // Reject a zero/negative claim up front with a clear, typed error
+        // instead of silently proceeding.
+        payout::validate_claim_positive(amount)?;
 
         // Single read of quest and submission for all subsequent operations
         let quest = storage::get_quest(&env, &quest_id)?;

--- a/contracts/earn-quest/src/payout.rs
+++ b/contracts/earn-quest/src/payout.rs
@@ -3,6 +3,18 @@ use crate::escrow;
 use crate::storage;
 use soroban_sdk::{token, Address, Env, Symbol};
 
+/// Validates that a reward-claim amount is strictly positive.
+///
+/// Claiming a zero (or negative) amount is a no-op that previously proceeded
+/// silently; this surfaces the clear, typed `Error::InvalidClaimAmount` instead
+/// so callers get an unambiguous error rather than a silent success.
+pub fn validate_claim_positive(amount: i128) -> Result<(), Error> {
+    if amount <= 0 {
+        return Err(Error::InvalidClaimAmount);
+    }
+    Ok(())
+}
+
 /// Transfer rewards from the contract escrow to the user (gas-optimized).
 ///
 /// This function handles the low-level token transfer and ensures

--- a/contracts/earn-quest/src/test_claim_and_batch_bounds.rs
+++ b/contracts/earn-quest/src/test_claim_and_batch_bounds.rs
@@ -1,0 +1,99 @@
+//! Tests for:
+//!   * Claiming a zero amount now returns the typed `Error::InvalidClaimAmount`
+//!     instead of proceeding silently (#2280).
+//!   * Batch approval bounds the *total* number of approvals across all inputs'
+//!     inner vectors, rejecting an oversized call with `Error::ArrayTooLong`
+//!     (#2279).
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
+
+use crate::errors::Error;
+use crate::types::BatchApprovalInput;
+use crate::validation::MAX_BATCH_APPROVAL_TOTAL;
+use crate::{EarnQuestContract, EarnQuestContractClient};
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+struct TestCtx<'a> {
+    env: Env,
+    client: EarnQuestContractClient<'a>,
+    creator: Address,
+    verifier: Address,
+    submitter: Address,
+    token: Address,
+}
+
+fn setup() -> TestCtx<'static> {
+    let env = make_env();
+    let contract_id = env.register_contract(None, EarnQuestContract);
+    let client = EarnQuestContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let creator = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let submitter = Address::generate(&env);
+
+    let token_admin_addr = Address::generate(&env);
+    let token_contract_obj = env.register_stellar_asset_contract_v2(token_admin_addr);
+    let token = token_contract_obj.address();
+
+    TestCtx {
+        env,
+        client,
+        creator,
+        verifier,
+        submitter,
+        token,
+    }
+}
+
+fn register_quest(ctx: &TestCtx, quest_id: &Symbol) {
+    let deadline = ctx.env.ledger().timestamp() + 86_400;
+    ctx.client.register_quest(
+        quest_id,
+        &ctx.creator,
+        &ctx.token,
+        &1000i128,
+        &ctx.verifier,
+        &deadline,
+    );
+}
+
+#[test]
+fn test_claim_zero_returns_typed_error() {
+    let ctx = setup();
+    let qid = symbol_short!("q1");
+    register_quest(&ctx, &qid);
+
+    let result = ctx.client.try_claim_reward(&qid, &ctx.submitter, &0i128);
+    assert_eq!(result, Err(Ok(Error::InvalidClaimAmount)));
+}
+
+#[test]
+fn test_batch_approval_rejects_oversized_total() {
+    let ctx = setup();
+
+    // A single input whose inner submissions vector exceeds the total cap.
+    let mut submitters: Vec<Address> = Vec::new(&ctx.env);
+    for _ in 0..(MAX_BATCH_APPROVAL_TOTAL + 1) {
+        submitters.push_back(Address::generate(&ctx.env));
+    }
+
+    let mut batch: Vec<BatchApprovalInput> = Vec::new(&ctx.env);
+    batch.push_back(BatchApprovalInput {
+        quest_id: symbol_short!("q1"),
+        submissions: submitters,
+    });
+
+    let result = ctx
+        .client
+        .try_approve_submissions_batch(&ctx.verifier, &batch);
+    assert_eq!(result, Err(Ok(Error::ArrayTooLong)));
+}

--- a/contracts/earn-quest/src/validation.rs
+++ b/contracts/earn-quest/src/validation.rs
@@ -27,6 +27,11 @@ pub const MAX_BATCH_QUEST_REGISTRATION: u32 = 50;
 /// Maximum number of submissions that can be approved in a single batch call
 pub const MAX_BATCH_APPROVALS: u32 = 50;
 
+/// Maximum total number of individual submission approvals across all inputs in
+/// a single batch-approval call. Bounds the inner-vector fan-out that
+/// `MAX_BATCH_APPROVALS` (which only counts inputs) does not.
+pub const MAX_BATCH_APPROVAL_TOTAL: u32 = 200;
+
 /// Maximum total number of quests allowed in the system (prevents global index bloat)
 pub const MAX_QUEST_IDS_TOTAL: u32 = 5000;
 
@@ -434,6 +439,21 @@ pub fn validate_batch_approval_size(length: u32) -> Result<(), Error> {
         return Err(Error::ArrayTooLong);
     }
     if length > MAX_BATCH_APPROVALS {
+        return Err(Error::ArrayTooLong);
+    }
+    Ok(())
+}
+
+/// Validates the *total* number of individual submission approvals across every
+/// input in a single batch-approval call.
+///
+/// `validate_batch_approval_size` only bounds the number of `BatchApprovalInput`
+/// entries; each entry carries its own inner vector of submitter addresses, so
+/// without this check a single input with an arbitrarily long inner vector could
+/// still exhaust gas. Bounding the total fan-out keeps a batch call's work
+/// predictable.
+pub fn validate_batch_approval_total(total: u32) -> Result<(), Error> {
+    if total > MAX_BATCH_APPROVAL_TOTAL {
         return Err(Error::ArrayTooLong);
     }
     Ok(())


### PR DESCRIPTION
## Summary

Two hardening fixes to the `earn-quest` contract.

- **Typed error when claiming a zero amount (#2280)** — `claim_reward` now rejects a zero (or negative) amount up front via the new `payout::validate_claim_positive`, returning the typed `Error::InvalidClaimAmount` instead of proceeding silently. `errors.rs` documents the variant.
- **Bounds check on batch-approval input length (#2279)** — `validate_batch_approval_size` only capped the number of `BatchApprovalInput` entries; each entry carries its own inner vector of submitter addresses, so a single input with an arbitrarily long inner vector could still exhaust gas. The `approve_submissions_batch` entrypoint now sums the total approvals across all inputs and rejects an oversized call with `Error::ArrayTooLong` via the new `validation::validate_batch_approval_total` (`MAX_BATCH_APPROVAL_TOTAL = 200`).

## Tests

- Claiming `0` returns `InvalidClaimAmount`.
- A batch whose total inner submissions exceed the cap is rejected with `ArrayTooLong`.

(Exercised through Contract CI: `cargo build` / `cargo test` / `cargo fmt --check` / `cargo clippy -D warnings`.)

## Issues

Closes #2280
Closes #2279
