### PR TITLE
feat(ui): respect prefers-reduced-motion in animations (#2270)

### DIFF
--- a/FrontEnd/my-app/app/globals.css
+++ b/FrontEnd/my-app/app/globals.css
@@ -4,6 +4,7 @@
 @source "../lib";
 @import '../styles/themes.css';
 @import '../styles/homepage.css';
+@import '../styles/animations.css';
 
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -146,3 +147,17 @@ body {
 /* Ensure sufficient color contrast for text */
 /* Primary color #089ec3 (cyan) has good contrast on white (#ffffff) - ratio ~4.5:1 (AA) */
 /* On dark backgrounds, ensure text colors meet contrast requirements */
+
+/* Respect the user's reduced-motion preference (WCAG 2.1 criterion 2.3.3).
+   Suppresses CSS animations and transitions so users who opt into reduced
+   motion are not exposed to motion that could cause discomfort. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/FrontEnd/my-app/components/ui/LevelUpModal.tsx
+++ b/FrontEnd/my-app/components/ui/LevelUpModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { LevelBadge } from '@/components/reputation/LevelBadge';
 import { FocusTrap } from '@/components/a11y/FocusTrap';
+import { usePrefersReducedMotion } from '@/lib/animations';
 
 /**
  * Props for the level-up celebration modal.
@@ -51,6 +52,7 @@ function ConfettiParticle({
 export function LevelUpModal({ isOpen, newLevel, onClose }: LevelUpModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
   const [confettiParticles] = useState(() => {
     return Array.from({ length: 50 }, (_, i) => ({
       id: i,
@@ -102,23 +104,27 @@ export function LevelUpModal({ isOpen, newLevel, onClose }: LevelUpModalProps) {
 
   if (!isOpen) return null;
 
-  const handleBackdropClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const entranceClass = prefersReducedMotion ? '' : ' animate-modal-entrance';
+
+  const handleBackdropClick = (_e: React.MouseEvent<HTMLButtonElement>) => {
     onClose();
   };
 
   return (
     <>
       {/* Confetti Container */}
-      <div className="fixed inset-0 pointer-events-none z-50 overflow-hidden">
-        {confettiParticles.map((particle) => (
-          <ConfettiParticle
-            key={particle.id}
-            delay={particle.delay}
-            duration={particle.duration}
-            left={particle.left}
-          />
-        ))}
-      </div>
+      {!prefersReducedMotion && (
+        <div className="fixed inset-0 pointer-events-none z-50 overflow-hidden">
+          {confettiParticles.map((particle) => (
+            <ConfettiParticle
+              key={particle.id}
+              delay={particle.delay}
+              duration={particle.duration}
+              left={particle.left}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Modal Overlay */}
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -135,7 +141,7 @@ export function LevelUpModal({ isOpen, newLevel, onClose }: LevelUpModalProps) {
             role="dialog"
             aria-modal="true"
             aria-labelledby="level-up-title"
-            className="relative w-full max-w-md rounded-lg bg-white shadow-xl dark:bg-zinc-900 animate-modal-entrance"
+            className={`relative w-full max-w-md rounded-lg bg-white shadow-xl dark:bg-zinc-900${entranceClass}`}
             tabIndex={-1}
           >
             {/* Close Button */}
@@ -162,7 +168,11 @@ export function LevelUpModal({ isOpen, newLevel, onClose }: LevelUpModalProps) {
             {/* Content */}
             <div className="px-8 py-12 text-center">
               {/* Level Up Text */}
-              <div className="mb-6 animate-bounce">
+              <div
+                className={
+                  prefersReducedMotion ? 'mb-6' : 'mb-6 animate-bounce'
+                }
+              >
                 <h2
                   id="level-up-title"
                   className="text-4xl font-bold text-zinc-900 dark:text-zinc-50 mb-2"

--- a/FrontEnd/my-app/lib/animations.test.ts
+++ b/FrontEnd/my-app/lib/animations.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import {
+  prefersReducedMotion,
+  onPrefersReducedMotionChange,
+  usePrefersReducedMotion,
+} from './animations';
+
+type MediaQueryListener = (e: MediaQueryListEvent) => void;
+
+interface MockMql {
+  matches: boolean;
+  media: string;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  addListener: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  dispatchEvent: ReturnType<typeof vi.fn>;
+  onchange: null;
+  _fireChange: (next: boolean) => void;
+}
+
+function createMqlMock(matches: boolean): MockMql {
+  let listener: MediaQueryListener | null = null;
+  return {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-reduced-motion: reduce)',
+    addEventListener: vi.fn((_type: string, cb: MediaQueryListener) => {
+      listener = cb;
+    }),
+    removeEventListener: vi.fn(() => {
+      listener = null;
+    }),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+    _fireChange: vi.fn((next: boolean) => {
+      listener?.({ matches: next } as MediaQueryListEvent);
+    }),
+  };
+}
+
+function fireMqlChange(mql: MockMql, next: boolean) {
+  mql._fireChange(next);
+}
+
+describe('prefersReducedMotion', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('returns true when the reduced-motion query matches', () => {
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue(
+        createMqlMock(true)
+      ) as unknown as typeof window.matchMedia;
+    expect(prefersReducedMotion()).toBe(true);
+  });
+
+  it('returns false when the reduced-motion query does not match', () => {
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue(
+        createMqlMock(false)
+      ) as unknown as typeof window.matchMedia;
+    expect(prefersReducedMotion()).toBe(false);
+  });
+
+  it('returns false when matchMedia is unavailable', () => {
+    window.matchMedia = undefined as unknown as typeof window.matchMedia;
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});
+
+describe('onPrefersReducedMotionChange', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('invokes the callback with the current value on change', () => {
+    const mql = createMqlMock(false);
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue(mql) as unknown as typeof window.matchMedia;
+
+    const callback = vi.fn();
+    onPrefersReducedMotionChange(callback);
+    fireMqlChange(mql, true);
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('returned unsubscribe stops future callbacks', () => {
+    const mql = createMqlMock(false);
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue(mql) as unknown as typeof window.matchMedia;
+
+    const callback = vi.fn();
+    const unsubscribe = onPrefersReducedMotionChange(callback);
+    unsubscribe();
+    fireMqlChange(mql, true);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('is a safe no-op outside a browser', () => {
+    const matchMedia = window.matchMedia;
+    window.matchMedia = undefined as unknown as typeof window.matchMedia;
+
+    let result: () => void = () => {};
+    expect(() => {
+      result = onPrefersReducedMotionChange(() => {});
+    }).not.toThrow();
+    expect(result).toEqual(expect.any(Function));
+
+    window.matchMedia = matchMedia;
+  });
+});
+
+describe('usePrefersReducedMotion', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('returns the initial reduced-motion value', () => {
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue(
+        createMqlMock(true)
+      ) as unknown as typeof window.matchMedia;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when the preference changes', () => {
+    const mql = createMqlMock(false);
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue(mql) as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      fireMqlChange(mql, true);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('defaults to false when matchMedia is unavailable', () => {
+    window.matchMedia = undefined as unknown as typeof window.matchMedia;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+});

--- a/FrontEnd/my-app/lib/animations.ts
+++ b/FrontEnd/my-app/lib/animations.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+function getMediaQueryList(): MediaQueryList | null {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return null;
+  }
+  return window.matchMedia(REDUCED_MOTION_QUERY);
+}
+
+/**
+ * Check whether the user prefers reduced motion.
+ * Safe to call during server-side rendering (returns false).
+ */
+export function prefersReducedMotion(): boolean {
+  const mql = getMediaQueryList();
+  return mql ? mql.matches : false;
+}
+
+/**
+ * Subscribe to changes in the user's reduced-motion preference.
+ * Returns an unsubscribe function. No-op in non-browser environments.
+ */
+export function onPrefersReducedMotionChange(
+  callback: (reduced: boolean) => void
+): () => void {
+  const mql = getMediaQueryList();
+  if (!mql) {
+    return () => {};
+  }
+
+  const listener = (e: MediaQueryListEvent) => callback(e.matches);
+
+  if (typeof mql.addEventListener === 'function') {
+    mql.addEventListener('change', listener);
+    return () => mql.removeEventListener('change', listener);
+  }
+
+  // Fallback for older browsers that only support addListener.
+  mql.addListener(listener);
+  return () => mql.removeListener(listener);
+}
+
+/**
+ * React hook that returns whether the user prefers reduced motion,
+ * re-rendering the component when the preference changes.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(prefersReducedMotion);
+
+  useEffect(() => {
+    return onPrefersReducedMotionChange(setReduced);
+  }, []);
+
+  return reduced;
+}


### PR DESCRIPTION
## Linked Issue

Closes #2270

## Description

**What changed?**

* Implemented a global `prefers-reduced-motion: reduce` CSS override.
* Added `lib/animations.ts` containing the `usePrefersReducedMotion` hook and related helper functions.
* Updated `LevelUpModal` to disable particle confetti and motion animations when the reduced motion preference is active.
* Explicitly imported the existing `styles/animations.css` into `app/globals.css`.
* Added unit tests covering preference detection, subscriptions, and hook behavior.

**Why was it changed?**
To improve accessibility and prevent user discomfort by respecting OS-level reduced motion preferences. Previously, animations ran regardless of user settings.

**How was it implemented?**

* **CSS Layer:** A global media query suppresses standard CSS animations and transitions.
* **JavaScript Layer:** A reusable client-side React hook enables JS-driven animations to read and dynamically react to the user's preference.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Security fix
* [ ] Refactor
* [ ] Documentation update
* [ ] Tests only
* [ ] Configuration / DevOps change

## Contract Changelog Discipline

* [x] No contract implementation changes - not applicable

## Test Evidence

### Unit Tests

* [x] New unit tests added for changed logic
* [x] All relevant tests pass
* [x] Coverage does not regress

### Test Output

```text
npx vitest run lib/animations.test.ts — 9/9 passed
npx vitest run components/ui — 21/21 passed
npm run typecheck — Passed
npx prettier --check & ESLint — Passed (0 problems)

```

### Additional Verifications

* [x] Manually verified against the local environment
* [x] No API or database changes required
* [x] No breaking type/model changes
* [x] Linting and formatting pass for changed files
* [x] No debug statements or hardcoded secrets left behind
* [x] Self-review completed

## Additional Notes for Reviewer

* **Styles Location:** The active global stylesheet in this repository is `app/globals.css` (rather than `styles/globals.css` referenced in the issue). Implementation follows the actual repository structure.
* **Stylesheet Import:** The existing `styles/animations.css` was previously unimported and is now explicitly loaded.
* **Dependencies:** No `framer-motion` usage was found in the application, so this targets purely CSS animations and the JS-driven `LevelUpModal`. No dependencies were added, leaving `package-lock.json` untouched.