### PR TITLE
feat: add right-to-erasure pipeline with cross-module PII anonymization

### DIFF
--- a/BackEnd/src/app.module.ts
+++ b/BackEnd/src/app.module.ts
@@ -32,6 +32,7 @@ import { ModerationModule } from './modules/moderation/moderation.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
 import { PayoutsModule } from './modules/payouts/payouts.module';
 import { PostmortemsModule } from './modules/postmortems/postmortems.module';
+import { PrivacyModule } from './modules/privacy/privacy.module';
 import { QueryMonitoringModule } from './modules/query-monitoring/query-monitoring.module';
 import { QuestsModule } from './modules/quests/quests.module';
 import { QuotaModule } from './modules/quota/quota.module';
@@ -93,6 +94,7 @@ const dataSourceProvider = shouldInitializeDatabaseConnection()
     JobsModule,
     ModerationModule,
     MultiSigModule,
+    PrivacyModule,
     NotificationsModule,
     PayoutsModule,
     ...(process.env.NODE_ENV !== 'production' ? [PostmortemsModule] : []),

--- a/BackEnd/src/database/migrations/1860000000000-add-erasure-requests.ts
+++ b/BackEnd/src/database/migrations/1860000000000-add-erasure-requests.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddErasureRequests1860000000000 implements MigrationInterface {
+  name = 'AddErasureRequests1860000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."erasure_requests_status_enum" AS ENUM('REQUESTED','PROCESSING','COMPLETED','CANCELLED','FAILED')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "erasure_requests" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "subjectId" character varying NOT NULL, "requestedBy" character varying, "status" "public"."erasure_requests_status_enum" NOT NULL DEFAULT 'REQUESTED', "requestedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "scheduledFor" TIMESTAMP WITH TIME ZONE NOT NULL, "executedAt" TIMESTAMP WITH TIME ZONE, "cancelledAt" TIMESTAMP WITH TIME ZONE, "scope" jsonb, "reason" text, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_erasure_requests_id" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_erasure_subject_status" ON "erasure_requests" ("subjectId", "status")`,
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_erasure_subject_status"`);
+    await queryRunner.query(`DROP TABLE "erasure_requests"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."erasure_requests_status_enum"`,
+    );
+  }
+}

--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Account-erasure pipeline: new `ERASURE` BullMQ queue, `JobType.ACCOUNT_ERASURE` (with retry policy), `AccountErasureProcessor` and `AccountErasureListener`. The listener schedules the erasure job for the end of the grace period; the processor runs the idempotent, transactional anonymization via `ErasureService` (#2337).
 - Payout transactional-outbox relay in `PayoutProcessor.relayPayoutOutbox()` — an every-minute job that atomically claims PENDING `payout_outbox` rows (`PENDING → PROCESSING`), submits each via `StellarPaymentService` exactly once, and marks them DONE (or retries/parks on failure) (#2158).
 - Stuck-outbox recovery in `PayoutReconciliationProcessor.recoverStuckPayoutOutbox()` — resets outbox rows left in PROCESSING beyond the crash threshold back to PENDING so the idempotent relay can safely replay them (#2158).
 

--- a/BackEnd/src/modules/jobs/job-retry-policy.ts
+++ b/BackEnd/src/modules/jobs/job-retry-policy.ts
@@ -223,6 +223,20 @@ export const JOB_RETRY_POLICIES: Readonly<
     removeOnComplete: 10,
     removeOnFail: 20,
   },
+
+  // ── Privacy / Right to Erasure ────────────────────────────────────────────
+  // High-value, irreversible operation; generous retries with slow backoff.
+  // Completed/cancelled requests are no-ops, so replays are always safe.
+  [JobType.ACCOUNT_ERASURE]: {
+    attempts: 5,
+    backoff: { type: 'exponential', delay: 30_000 },
+    nonRetryableErrors: [
+      'Erasure request .* not found',
+      'is already .* processing',
+    ],
+    removeOnComplete: 25,
+    removeOnFail: 50,
+  },
 };
 
 // ─── Utility Functions ────────────────────────────────────────────────────────

--- a/BackEnd/src/modules/jobs/job.types.ts
+++ b/BackEnd/src/modules/jobs/job.types.ts
@@ -36,6 +36,9 @@ export enum JobType {
 
   // Dependency Management
   DEPENDENCY_FRESHNESS_CHECK = 'dependency:freshness-check',
+
+  // Privacy / Right to Erasure
+  ACCOUNT_ERASURE = 'privacy:account-erasure',
 }
 
 export enum JobPriority {

--- a/BackEnd/src/modules/jobs/jobs.constants.ts
+++ b/BackEnd/src/modules/jobs/jobs.constants.ts
@@ -16,6 +16,7 @@ export const QUEUES = {
   MAINTENANCE: 'maintenance',
   WEBHOOKS: 'webhooks',
   QUESTS: 'quests',
+  ERASURE: 'erasure',
 };
 
 /**
@@ -78,5 +79,10 @@ export const JOB_QUEUE_CONFIG = {
     concurrency: 20,
     priority: 'MEDIUM',
     timeout: 30000,
+  },
+  [QUEUES.ERASURE]: {
+    concurrency: 1,
+    priority: 'LOW',
+    timeout: 120000, // 2 minutes — bounded by the erasure transaction
   },
 };

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -30,6 +30,8 @@ import {
 import { JobLogArchive } from './entities/job-log-archive.entity';
 import { DataExport } from '../users/entities/data-export.entity';
 import { DataExportListener } from './listeners/data-export.listener';
+import { AccountErasureListener } from './listeners/account-erasure.listener';
+import { AccountErasureProcessor } from './processors/account-erasure.processor';
 import { Payout } from '../payouts/entities/payout.entity';
 import { PayoutOutbox } from '../payouts/entities/payout-outbox.entity';
 import { Quest } from '../quests/entities/quest.entity';
@@ -70,6 +72,17 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     AnalyticsModule,
     forwardRef(() => EmailModule),
     CacheModule,
+    // Lazy reference to PrivacyModule: the module graph has a cycle
+    // (JobsModule → PrivacyModule → UsersModule → EmailModule → JobsModule)
+    // that Nest resolves via forwardRef, but the static `import` would leave
+    // module classes undefined during CommonJS evaluation. Requiring inside
+    // the forwardRef closure defers resolution until scan time, when every
+    // module has finished loading.
+    forwardRef(
+      () =>
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../privacy/privacy.module').PrivacyModule,
+    ),
   ],
   providers: [
     JobsService,
@@ -94,6 +107,8 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     QuestStateReconciliationProcessor,
     DependencyProcessor,
     DataExportListener,
+    AccountErasureListener,
+    AccountErasureProcessor,
     DependencyFreshnessService,
   ],
   controllers: [JobsController],
@@ -116,6 +131,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     QuestProcessor,
     QuestStateReconciliationProcessor,
     DependencyProcessor,
+    AccountErasureProcessor,
     DependencyFreshnessService,
   ],
 })

--- a/BackEnd/src/modules/jobs/jobs.service.ts
+++ b/BackEnd/src/modules/jobs/jobs.service.ts
@@ -14,6 +14,7 @@ import {
 import { JobType } from './job.types';
 import { DataExportProcessor } from './processors/export.processor';
 import { PayoutProcessor } from './processors/payout.processor';
+import { AccountErasureProcessor } from './processors/account-erasure.processor';
 import {
   TracingService,
   TraceContext,
@@ -59,6 +60,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     private readonly payloadStorage: PayloadStorageService,
     private readonly dataExportProcessor?: DataExportProcessor,
     private readonly payoutProcessor?: PayoutProcessor,
+    private readonly accountErasureProcessor?: AccountErasureProcessor,
   ) {}
 
   registerEmailProcessor(
@@ -90,6 +92,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     // ── Payouts queue — registered here so PAYOUT_PROCESS / PAYOUT_SETTLE
     //    jobs can be enqueued via JobsService.addJob(QUEUES.PAYOUTS, ...).
     this.queues[QUEUES.PAYOUTS] = new Queue(QUEUES.PAYOUTS, redisConnection());
+    this.queues[QUEUES.ERASURE] = new Queue(QUEUES.ERASURE, redisConnection());
 
     this.createWorker(QUEUES.NOTIFICATIONS, this.handleNotification.bind(this));
     this.createWorker(QUEUES.ANALYTICS, this.handleAnalytics.bind(this));
@@ -117,6 +120,17 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
       this.createWorker(
         QUEUES.PAYOUTS,
         this.payoutProcessor.process.bind(this.payoutProcessor),
+      );
+    }
+
+    // ── Wire the AccountErasureProcessor to the ERASURE queue ────────────
+    if (
+      this.accountErasureProcessor &&
+      typeof this.accountErasureProcessor.process === 'function'
+    ) {
+      this.createWorker(
+        QUEUES.ERASURE,
+        this.accountErasureProcessor.process.bind(this.accountErasureProcessor),
       );
     }
   }

--- a/BackEnd/src/modules/jobs/listeners/account-erasure.listener.ts
+++ b/BackEnd/src/modules/jobs/listeners/account-erasure.listener.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { JobsService } from '../jobs.service';
+import { QUEUES } from '../jobs.constants';
+import { JobType } from '../job.types';
+
+export interface ErasureRequestedEvent {
+  requestId: string;
+  subjectId: string;
+  /** ISO timestamp at which the grace period ends and erasure may run. */
+  scheduledFor: string;
+}
+
+/**
+ * Account Erasure Listener
+ *
+ * Listens for `privacy.erasure.requested` events and enqueues the
+ * account-erasure job on the ERASURE queue, delayed until the end of the
+ * grace period. The worker re-checks the request status before executing, so
+ * a cancellation inside the grace window makes the job a no-op.
+ */
+@Injectable()
+export class AccountErasureListener {
+  private readonly logger = new Logger(AccountErasureListener.name);
+
+  constructor(private readonly jobsService: JobsService) {}
+
+  @OnEvent('privacy.erasure.requested', { async: true })
+  async handleErasureRequested(event: ErasureRequestedEvent) {
+    this.logger.log(
+      `[JobsModule] Erasure requested for user ${event.subjectId}, requestId: ${event.requestId}`,
+    );
+
+    try {
+      const scheduledFor = new Date(event.scheduledFor).getTime();
+      const delay = Math.max(0, scheduledFor - Date.now());
+
+      await this.jobsService.addJob(
+        QUEUES.ERASURE,
+        {
+          requestId: event.requestId,
+          subjectId: event.subjectId,
+        },
+        { delay, jobId: `erasure-${event.requestId}` },
+        JobType.ACCOUNT_ERASURE,
+      );
+
+      this.logger.log(
+        `Successfully queued account erasure job for requestId: ${event.requestId} (delay ${delay}ms)`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to queue account erasure job for requestId ${event.requestId}: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+}

--- a/BackEnd/src/modules/jobs/processors/account-erasure.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/account-erasure.processor.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { JobResult } from '../job.types';
+import { ErasureService } from '../../privacy/erasure.service';
+
+export interface AccountErasurePayload {
+  requestId: string;
+  subjectId: string;
+}
+
+/**
+ * Account Erasure Processor
+ *
+ * Executes a right-to-erasure request once its grace period has elapsed.
+ * Delegates to {@link ErasureService.executeErasure}, which performs the
+ * cross-module anonymization inside a single transaction and is idempotent
+ * (safe to re-run, no-ops on completed/cancelled requests).
+ */
+@Injectable()
+export class AccountErasureProcessor {
+  private readonly logger = new Logger(AccountErasureProcessor.name);
+
+  constructor(private readonly erasureService: ErasureService) {}
+
+  async process(job: Job<AccountErasurePayload>): Promise<JobResult> {
+    const { requestId, subjectId } = job.data;
+
+    this.logger.log(
+      `Processing account erasure job ${job.id}: request=${requestId}, subject=${subjectId}`,
+    );
+
+    try {
+      const result = await this.erasureService.executeErasure(requestId);
+      return {
+        success: true,
+        data: {
+          requestId,
+          subjectId,
+          status: result.status,
+          skipped: result.skipped ?? false,
+          alreadyExecuted: result.alreadyExecuted ?? false,
+        },
+        duration: Date.now() - job.timestamp,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error processing account erasure for request ${requestId}: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+}

--- a/BackEnd/src/modules/jobs/services/job-scheduler.service.ts
+++ b/BackEnd/src/modules/jobs/services/job-scheduler.service.ts
@@ -477,6 +477,7 @@ export class JobSchedulerService implements OnModuleInit, OnModuleDestroy {
       [JobType.QUEST_COMPLETION_VERIFY]: 'quests',
       [JobType.DEPENDENCY_FRESHNESS_CHECK]: 'maintenance',
       [JobType.QUEST_STATE_RECONCILE]: 'quests',
+      [JobType.ACCOUNT_ERASURE]: 'erasure',
     };
     return queueMap[jobType] || 'default';
   }

--- a/BackEnd/src/modules/privacy/CHANGELOG.md
+++ b/BackEnd/src/modules/privacy/CHANGELOG.md
@@ -1,0 +1,18 @@
+# privacy module changelog
+
+All notable changes to the `privacy` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Right-to-erasure pipeline (`ErasureService`) with a full request lifecycle: submit → cancellable grace period → execute → completed, plus idempotent, transactional cross-module PII anonymization (#2337).
+- `ErasureController` endpoints — request erasure, cancel within the grace window, check status (auth-guarded to the requesting user), and admin-initiated erasure (`POST /privacy/erasure/admin/requests`) (#2337).
+- `ErasureRequest` entity (`erasure_requests` table) persisting subject id, status, requested/scheduled/executed timestamps and scope, with a TypeORM migration (#2337).
+- `erasure.service.spec.ts` unit tests covering the request lifecycle, grace-window cancellation, and cross-module anonymization (#2337).
+
+### Changed
+
+- On erasure execution, PII across users/submissions/notifications/payouts/moderation is anonymized or deleted inside a single transaction; legally-required payout and audit records are retained but de-identified with a per-subject tombstone (#2337).

--- a/BackEnd/src/modules/privacy/README.md
+++ b/BackEnd/src/modules/privacy/README.md
@@ -1,0 +1,54 @@
+# Privacy Module — Account Erasure (Right to Erasure)
+
+Implements the right-to-erasure ("right to be forgotten") pipeline: a user (or
+an admin on a user's behalf) can request account erasure, cancel it within a
+grace window, and track its status. Once the grace period elapses, a BullMQ
+job anonymizes the user's PII across modules **inside a single transaction**.
+
+## API
+
+All endpoints require a valid JWT (`Authorization: Bearer <token>`).
+
+| Method | Path                              | Access              | Description                                          |
+| ------ | --------------------------------- | ------------------- | ---------------------------------------------------- |
+| POST   | `/privacy/erasure/requests`       | authenticated user  | Request erasure of the caller's account              |
+| POST   | `/privacy/erasure/requests/:id/cancel` | subject or admin | Cancel within the grace window                       |
+| GET    | `/privacy/erasure/requests/:id`   | subject or admin    | Check request status                                 |
+| POST   | `/privacy/erasure/admin/requests` | admin               | Initiate erasure on behalf of a user                 |
+
+### Request body
+
+```json
+{ "reason": "Optional legal/operator reason" }
+```
+
+`POST /privacy/erasure/admin/requests` additionally requires `"userId"`.
+
+### Lifecycle
+
+```
+REQUESTED ──(grace period elapses)──▶ PROCESSING ──▶ COMPLETED
+    │                                      │
+    └──(cancelled in grace window)──▶ CANCELLED
+```
+
+- The default grace period is **7 days**, configurable via
+  `ERASURE_GRACE_PERIOD_MS`.
+- A request is idempotent: completing twice is a no-op, and a cancelled
+  request is never executed. A failed transaction rolls back the claim, so the
+  job retries cleanly.
+
+## Per-module erasure policy (single transaction)
+
+| Module        | Action                                                                 |
+| ------------- | ---------------------------------------------------------------------- |
+| users         | `email` / `stellarAddress` / profile PII replaced with per-user tombstone values; the row is retained so FKs and aggregate stats stay valid. |
+| submissions   | Submitter PII and proof references detached (`proof` → `{ erased: true }`, notes nulled); quest integrity and reviewer decisions preserved. |
+| notifications | Rows for the subject are deleted.                                      |
+| payouts       | Retained for compliance but de-identified — the actor identifier is replaced with the tombstone (`erased:<subjectId>`). |
+| moderation    | Submitter PII (snapshots, image URLs, notes) detached; review records retained. |
+| audit         | An `privacy.erasure.executed` record is written to the event store inside the same transaction. |
+
+Retention rationale: financial payout history and audit records are legally
+required to be retained, but are de-identified so they can no longer be linked
+to a natural person.

--- a/BackEnd/src/modules/privacy/dto/erasure.dto.ts
+++ b/BackEnd/src/modules/privacy/dto/erasure.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+
+export class RequestErasureDto {
+  @ApiPropertyOptional({
+    description: 'Optional reason for the erasure request',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  reason?: string;
+}
+
+export class AdminInitiateErasureDto {
+  @ApiProperty({ description: 'Id of the user whose account is erased' })
+  @IsUUID()
+  @IsNotEmpty()
+  userId: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional operator/legal reason for the request',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  reason?: string;
+}

--- a/BackEnd/src/modules/privacy/entities/erasure-request.entity.ts
+++ b/BackEnd/src/modules/privacy/entities/erasure-request.entity.ts
@@ -1,0 +1,89 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Lifecycle of an account-erasure (right-to-erasure) request:
+ *
+ *   REQUESTED  → user/admin submits; grace period starts (cancellable)
+ *   PROCESSING → the BullMQ account-erasure worker claimed the request and is
+ *                anonymizing PII inside a single transaction
+ *   COMPLETED  → anonymization finished; the request is irreversible
+ *   CANCELLED  → cancelled by the subject or an admin within the grace window
+ *   FAILED     → execution errored and the job exhausted its retries
+ */
+export enum ErasureStatus {
+  REQUESTED = 'REQUESTED',
+  PROCESSING = 'PROCESSING',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+  FAILED = 'FAILED',
+}
+
+/**
+ * Tombstone marker used to de-identify retained rows (payouts, audit
+ * references) while keeping referential integrity intact. Unique per subject.
+ */
+export function erasureTombstone(subjectId: string): string {
+  return `erased:${subjectId}`;
+}
+
+@Entity('erasure_requests')
+@Index('idx_erasure_subject_status', ['subjectId', 'status'])
+export class ErasureRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The user whose data is being erased. The user row itself is retained. */
+  @Column({ type: 'varchar' })
+  subjectId: string;
+
+  /** Who initiated the request — the subject, or an admin on their behalf. */
+  @Column({ type: 'varchar', nullable: true })
+  requestedBy: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: ErasureStatus,
+    default: ErasureStatus.REQUESTED,
+  })
+  status: ErasureStatus;
+
+  /** When the request was submitted (start of the grace period). */
+  @Column({ type: 'timestamptz' })
+  requestedAt: Date;
+
+  /**
+   * End of the grace period. Before this instant the request can be
+   * cancelled; the erasure job is scheduled for this moment.
+   */
+  @Column({ type: 'timestamptz' })
+  scheduledFor: Date;
+
+  /** When anonymization actually ran (COMPLETED). */
+  @Column({ type: 'timestamptz', nullable: true })
+  executedAt: Date | null;
+
+  /** When the request was cancelled within the grace window. */
+  @Column({ type: 'timestamptz', nullable: true })
+  cancelledAt: Date | null;
+
+  /** Modules included in the erasure (defaults to the full scope). */
+  @Column({ type: 'jsonb', nullable: true })
+  scope: string[] | null;
+
+  /** Optional operator/legal reason for the request. */
+  @Column({ type: 'text', nullable: true })
+  reason: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/BackEnd/src/modules/privacy/erasure.controller.ts
+++ b/BackEnd/src/modules/privacy/erasure.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ErasureService } from './erasure.service';
+import { RequestErasureDto, AdminInitiateErasureDto } from './dto/erasure.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../../common/enums/role.enum';
+
+@ApiTags('privacy')
+@Controller('privacy/erasure')
+export class ErasureController {
+  constructor(private readonly erasureService: ErasureService) {}
+
+  @Post('requests')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Request erasure of the authenticated user’s account (enters a cancellable grace period)',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Erasure request created and scheduled',
+  })
+  async requestErasure(@Request() req: any, @Body() dto: RequestErasureDto) {
+    const request = await this.erasureService.requestErasure(req.user.id, {
+      requestedBy: req.user.id,
+      reason: dto.reason,
+    });
+    return { success: true, data: request };
+  }
+
+  @Post('requests/:id/cancel')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Cancel an erasure request within the grace window',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Erasure request cancelled',
+  })
+  async cancelErasure(@Param('id') id: string, @Request() req: any) {
+    const request = await this.erasureService.cancelErasure(id, {
+      id: req.user.id,
+      role: req.user.role,
+    });
+    return { success: true, data: request };
+  }
+
+  @Get('requests/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check the status of an erasure request' })
+  @ApiResponse({ status: 200, description: 'Erasure request status' })
+  async getStatus(@Param('id') id: string, @Request() req: any) {
+    const request = await this.erasureService.getStatus(id, {
+      id: req.user.id,
+      role: req.user.role,
+    });
+    return { success: true, data: request };
+  }
+
+  @Post('admin/requests')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Admin-initiated erasure on behalf of a user',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Erasure request created on behalf of the user',
+  })
+  async adminInitiate(
+    @Request() req: any,
+    @Body() dto: AdminInitiateErasureDto,
+  ) {
+    const request = await this.erasureService.requestErasure(dto.userId, {
+      requestedBy: req.user.id,
+      reason: dto.reason,
+    });
+    return { success: true, data: request };
+  }
+}

--- a/BackEnd/src/modules/privacy/erasure.service.spec.ts
+++ b/BackEnd/src/modules/privacy/erasure.service.spec.ts
@@ -1,0 +1,364 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DataSource } from 'typeorm';
+import { ErasureService } from './erasure.service';
+import {
+  ErasureRequest,
+  ErasureStatus,
+} from './entities/erasure-request.entity';
+import { User } from '../users/entities/user.entity';
+import { Submission } from '../submissions/entities/submission.entity';
+import { Payout } from '../payouts/entities/payout.entity';
+import { Notification } from '../notifications/entities/notification.entity';
+import { ModerationItem } from '../moderation/entities/moderation-item.entity';
+import { EventStore } from '../../events/entities/event-store.entity';
+import { UsersService } from '../users/users.service';
+import { SubmissionsService } from '../submissions/submissions.service';
+
+describe('ErasureService', () => {
+  let service: ErasureService;
+  let erasureRepo: any;
+  let userRepo: any;
+  let dataSource: any;
+  let usersService: any;
+  let submissionsService: any;
+  let eventEmitter: any;
+
+  const subjectId = '11111111-1111-4111-8111-111111111111';
+  const requestId = '22222222-2222-4222-8222-222222222222';
+
+  const baseRequest = () =>
+    ({
+      id: requestId,
+      subjectId,
+      requestedBy: subjectId,
+      status: ErasureStatus.REQUESTED,
+      requestedAt: new Date(),
+      scheduledFor: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      executedAt: null,
+      cancelledAt: null,
+      scope: ['users', 'submissions', 'notifications', 'payouts', 'moderation'],
+      reason: null,
+    }) as ErasureRequest;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    erasureRepo = {
+      findOne: jest.fn(),
+      create: jest.fn((x) => x),
+      save: jest.fn((x) => Promise.resolve(x)),
+    };
+    userRepo = { findOne: jest.fn() };
+
+    const managerFns: Record<string, jest.Mock> = {};
+    dataSource = {
+      transaction: jest.fn(async (cb: any) => cb(createManager(managerFns))),
+    };
+
+    usersService = { anonymizeForErasure: jest.fn() };
+    submissionsService = { anonymizeForErasure: jest.fn() };
+    eventEmitter = { emit: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ErasureService,
+        { provide: getRepositoryToken(ErasureRequest), useValue: erasureRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Submission), useValue: {} },
+        { provide: getRepositoryToken(Payout), useValue: {} },
+        { provide: getRepositoryToken(Notification), useValue: {} },
+        { provide: getRepositoryToken(ModerationItem), useValue: {} },
+        { provide: getRepositoryToken(EventStore), useValue: {} },
+        { provide: DataSource, useValue: dataSource },
+        { provide: UsersService, useValue: usersService },
+        { provide: SubmissionsService, useValue: submissionsService },
+        { provide: EventEmitter2, useValue: eventEmitter },
+      ],
+    }).compile();
+
+    service = module.get<ErasureService>(ErasureService);
+
+    function createManager(fns: Record<string, jest.Mock>) {
+      const manager = {
+        update: jest.fn((entity: any, criteria: any, _patch: any) => {
+          if (entity === ErasureRequest && criteria.id === requestId) {
+            return Promise.resolve({ affected: 1 });
+          }
+          return Promise.resolve({ affected: 1 });
+        }),
+        getRepository: jest.fn((entity: any) => {
+          const key = entity.name || String(entity);
+          if (!fns[key]) {
+            fns[key] = {
+              findOne: jest.fn(),
+              update: jest.fn(),
+              delete: jest.fn(),
+              create: jest.fn((x: any) => x),
+              save: jest.fn((x: any) => Promise.resolve(x)),
+            };
+          }
+          return fns[key];
+        }),
+      };
+      return manager;
+    }
+  });
+
+  describe('requestErasure', () => {
+    it('creates a request with a grace period and emits the scheduling event', async () => {
+      userRepo.findOne.mockResolvedValue({ id: subjectId });
+      erasureRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.requestErasure(subjectId, {
+        requestedBy: subjectId,
+      });
+
+      expect(erasureRepo.create).toHaveBeenCalled();
+      expect(erasureRepo.save).toHaveBeenCalled();
+      expect(result.status).toBe(ErasureStatus.REQUESTED);
+      expect(result.scheduledFor.getTime()).toBeGreaterThan(Date.now());
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'privacy.erasure.requested',
+        expect.objectContaining({ requestId: result.id, subjectId }),
+      );
+    });
+
+    it('throws NotFoundException when the subject does not exist', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.requestErasure(subjectId)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(erasureRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when an active request already exists', async () => {
+      userRepo.findOne.mockResolvedValue({ id: subjectId });
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+
+      await expect(service.requestErasure(subjectId)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(erasureRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelErasure', () => {
+    it('cancels a request within the grace window', async () => {
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+
+      const result = await service.cancelErasure(requestId, {
+        id: subjectId,
+        role: 'USER',
+      });
+
+      expect(result.status).toBe(ErasureStatus.CANCELLED);
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'privacy.erasure.cancelled',
+        expect.objectContaining({ requestId, subjectId }),
+      );
+    });
+
+    it('allows an admin to cancel on behalf of the subject', async () => {
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+
+      const result = await service.cancelErasure(requestId, {
+        id: 'admin-id',
+        role: 'ADMIN',
+      });
+      expect(result.status).toBe(ErasureStatus.CANCELLED);
+    });
+
+    it('rejects a third party that is neither subject nor admin', async () => {
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+
+      await expect(
+        service.cancelErasure(requestId, { id: 'other-id', role: 'USER' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects cancellation after the grace period has elapsed', async () => {
+      const request = baseRequest();
+      request.scheduledFor = new Date(Date.now() - 1000);
+      erasureRepo.findOne.mockResolvedValue(request);
+
+      await expect(
+        service.cancelErasure(requestId, { id: subjectId, role: 'USER' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects cancellation of an already-completed request', async () => {
+      const request = baseRequest();
+      request.status = ErasureStatus.COMPLETED;
+      erasureRepo.findOne.mockResolvedValue(request);
+
+      await expect(
+        service.cancelErasure(requestId, { id: subjectId, role: 'USER' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns the request for the subject', async () => {
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+      const result = await service.getStatus(requestId, {
+        id: subjectId,
+        role: 'USER',
+      });
+      expect(result.id).toBe(requestId);
+    });
+
+    it('returns the request for an admin', async () => {
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+      const result = await service.getStatus(requestId, {
+        id: 'admin-id',
+        role: 'ADMIN',
+      });
+      expect(result.id).toBe(requestId);
+    });
+
+    it('rejects a third party', async () => {
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+      await expect(
+        service.getStatus(requestId, { id: 'other-id', role: 'USER' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws NotFoundException for an unknown request', async () => {
+      erasureRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.getStatus(requestId, { id: subjectId, role: 'USER' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('executeErasure', () => {
+    it('is a no-op for an already-completed request', async () => {
+      const request = baseRequest();
+      request.status = ErasureStatus.COMPLETED;
+      erasureRepo.findOne.mockResolvedValue(request);
+
+      const result = await service.executeErasure(requestId);
+      expect(result).toEqual({
+        requestId,
+        status: ErasureStatus.COMPLETED,
+        alreadyExecuted: true,
+      });
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('skips cancelled requests', async () => {
+      const request = baseRequest();
+      request.status = ErasureStatus.CANCELLED;
+      erasureRepo.findOne.mockResolvedValue(request);
+
+      const result = await service.executeErasure(requestId);
+      expect(result).toEqual({
+        requestId,
+        status: ErasureStatus.CANCELLED,
+        skipped: true,
+      });
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('refuses to run before the grace period has elapsed', async () => {
+      erasureRepo.findOne.mockResolvedValue(baseRequest());
+
+      await expect(service.executeErasure(requestId)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('anonymizes all modules in a single transaction and completes the request', async () => {
+      const request = baseRequest();
+      request.scheduledFor = new Date(Date.now() - 1000);
+      erasureRepo.findOne.mockResolvedValue(request);
+
+      const managerUserRepo = {
+        findOne: jest.fn().mockResolvedValue({
+          id: subjectId,
+          stellarAddress: 'GOLDEN-STELLAR-ADDRESS',
+        }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+        delete: jest.fn().mockResolvedValue({ affected: 0 }),
+        create: jest.fn((x: any) => x),
+        save: jest.fn((x: any) => Promise.resolve(x)),
+      };
+      dataSource.transaction.mockImplementation(async (cb: any) => {
+        const manager: any = {
+          update: jest
+            .fn()
+            .mockResolvedValueOnce({ affected: 1 }) // claim
+            .mockResolvedValueOnce({ affected: 1 }) // payout update
+            .mockResolvedValueOnce({ affected: 1 }) // moderation update
+            .mockResolvedValueOnce({ affected: 1 }), // mark completed
+          getRepository: jest.fn().mockImplementation((entity: any) => {
+            if (entity === User) return managerUserRepo;
+            if (entity === Notification)
+              return { delete: jest.fn().mockResolvedValue({ affected: 3 }) };
+            if (entity === Payout)
+              return { update: jest.fn().mockResolvedValue({ affected: 2 }) };
+            if (entity === ModerationItem)
+              return {
+                update: jest.fn().mockResolvedValue({ affected: 1 }),
+              };
+            if (entity === EventStore)
+              return {
+                create: jest.fn((x: any) => x),
+                save: jest.fn((x: any) => Promise.resolve(x)),
+              };
+            return {};
+          }),
+        };
+        return cb(manager);
+      });
+
+      usersService.anonymizeForErasure.mockResolvedValue({
+        stellarAddress: 'GOLDEN-STELLAR-ADDRESS',
+        email: 'user@example.com',
+      });
+      submissionsService.anonymizeForErasure.mockResolvedValue(2);
+
+      const result = await service.executeErasure(requestId);
+
+      expect(result.status).toBe(ErasureStatus.COMPLETED);
+      expect(usersService.anonymizeForErasure).toHaveBeenCalledWith(
+        subjectId,
+        expect.anything(),
+      );
+      expect(submissionsService.anonymizeForErasure).toHaveBeenCalledWith(
+        subjectId,
+        expect.anything(),
+      );
+      expect(managerUserRepo.findOne).toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the subject row is gone', async () => {
+      const request = baseRequest();
+      request.scheduledFor = new Date(Date.now() - 1000);
+      erasureRepo.findOne.mockResolvedValue(request);
+
+      dataSource.transaction.mockImplementation(async (cb: any) => {
+        const manager: any = {
+          update: jest.fn().mockResolvedValue({ affected: 1 }),
+          getRepository: jest.fn().mockReturnValue({
+            findOne: jest.fn().mockResolvedValue(null),
+          }),
+        };
+        return cb(manager);
+      });
+
+      await expect(service.executeErasure(requestId)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/BackEnd/src/modules/privacy/erasure.service.ts
+++ b/BackEnd/src/modules/privacy/erasure.service.ts
@@ -1,0 +1,360 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  ErasureRequest,
+  ErasureStatus,
+} from './entities/erasure-request.entity';
+import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
+import { SubmissionsService } from '../submissions/submissions.service';
+import { Submission } from '../submissions/entities/submission.entity';
+import { Payout } from '../payouts/entities/payout.entity';
+import { Notification } from '../notifications/entities/notification.entity';
+import { ModerationItem } from '../moderation/entities/moderation-item.entity';
+import { EventStore } from '../../events/entities/event-store.entity';
+import { erasureTombstone } from './entities/erasure-request.entity';
+
+export interface RequestErasureOptions {
+  /** Id of the actor creating the request (subject or admin). */
+  requestedBy?: string;
+  /** Modules to include; defaults to the full scope. */
+  scope?: string[];
+  /** Operator/legal reason. */
+  reason?: string;
+}
+
+export const DEFAULT_ERASURE_SCOPE = [
+  'users',
+  'submissions',
+  'notifications',
+  'payouts',
+  'moderation',
+];
+
+/**
+ * Grace period before an erasure executes (ms). Reversible/cancellable within
+ * this window. Overridable via ERASURE_GRACE_PERIOD_MS (default: 7 days).
+ */
+export function erasureGracePeriodMs(): number {
+  const parsed = parseInt(process.env.ERASURE_GRACE_PERIOD_MS || '', 10);
+  return Number.isFinite(parsed) && parsed >= 0
+    ? parsed
+    : 7 * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Right-to-erasure pipeline.
+ *
+ * Models the request lifecycle (request → cancellable grace period → execute →
+ * completed), performs the cross-module PII anonymization inside a single
+ * transaction, and is safe to re-run (idempotent).
+ */
+@Injectable()
+export class ErasureService {
+  private readonly logger = new Logger(ErasureService.name);
+
+  constructor(
+    @InjectRepository(ErasureRequest)
+    private readonly erasureRepo: Repository<ErasureRequest>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(Submission)
+    private readonly submissionRepo: Repository<Submission>,
+    @InjectRepository(Payout)
+    private readonly payoutRepo: Repository<Payout>,
+    @InjectRepository(Notification)
+    private readonly notificationRepo: Repository<Notification>,
+    @InjectRepository(ModerationItem)
+    private readonly moderationRepo: Repository<ModerationItem>,
+    @InjectRepository(EventStore)
+    private readonly eventStoreRepo: Repository<EventStore>,
+    private readonly dataSource: DataSource,
+    private readonly usersService: UsersService,
+    private readonly submissionsService: SubmissionsService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /**
+   * Submit an erasure request. The request enters the grace period and a
+   * delayed BullMQ job (scheduled for `scheduledFor`) is enqueued via the
+   * `privacy.erasure.requested` event.
+   */
+  async requestErasure(
+    subjectId: string,
+    options: RequestErasureOptions = {},
+  ): Promise<ErasureRequest> {
+    const user = await this.userRepo.findOne({ where: { id: subjectId } });
+    if (!user) {
+      throw new NotFoundException(`User ${subjectId} not found`);
+    }
+
+    const active = await this.erasureRepo.findOne({
+      where: {
+        subjectId,
+        status: In([ErasureStatus.REQUESTED, ErasureStatus.PROCESSING]),
+      },
+    });
+    if (active) {
+      throw new ConflictException(
+        `An erasure request for user ${subjectId} is already ${active.status.toLowerCase()}`,
+      );
+    }
+
+    const now = new Date();
+    const scheduledFor = new Date(now.getTime() + erasureGracePeriodMs());
+    const request = this.erasureRepo.create({
+      subjectId,
+      requestedBy: options.requestedBy ?? null,
+      status: ErasureStatus.REQUESTED,
+      requestedAt: now,
+      scheduledFor,
+      scope: options.scope ?? DEFAULT_ERASURE_SCOPE,
+      reason: options.reason ?? null,
+    });
+    const saved = await this.erasureRepo.save(request);
+
+    this.eventEmitter.emit('privacy.erasure.requested', {
+      requestId: saved.id,
+      subjectId,
+      scheduledFor: scheduledFor.toISOString(),
+    });
+
+    this.logger.log(
+      `Erasure request ${saved.id} created for user ${subjectId}, scheduled for ${scheduledFor.toISOString()}`,
+    );
+    return saved;
+  }
+
+  /**
+   * Cancel an erasure request within the grace window. Only the subject or an
+   * admin may cancel. Once the grace period has elapsed the request can no
+   * longer be cancelled (the worker will execute it).
+   */
+  async cancelErasure(
+    requestId: string,
+    actor: { id: string; role?: string },
+  ): Promise<ErasureRequest> {
+    const request = await this.erasureRepo.findOne({
+      where: { id: requestId },
+    });
+    if (!request) {
+      throw new NotFoundException(`Erasure request ${requestId} not found`);
+    }
+
+    const isSubject = request.subjectId === actor.id;
+    const isAdmin = actor.role === 'ADMIN';
+    if (!isSubject && !isAdmin) {
+      throw new BadRequestException(
+        'Only the requesting user or an admin can cancel an erasure request',
+      );
+    }
+
+    if (request.status !== ErasureStatus.REQUESTED) {
+      throw new BadRequestException(
+        `Erasure request ${requestId} is ${request.status.toLowerCase()} and cannot be cancelled`,
+      );
+    }
+
+    if (new Date() >= request.scheduledFor) {
+      throw new BadRequestException(
+        'The grace period has elapsed; the erasure can no longer be cancelled',
+      );
+    }
+
+    request.status = ErasureStatus.CANCELLED;
+    request.cancelledAt = new Date();
+    const saved = await this.erasureRepo.save(request);
+
+    this.eventEmitter.emit('privacy.erasure.cancelled', {
+      requestId,
+      subjectId: request.subjectId,
+    });
+    this.logger.log(
+      `Erasure request ${requestId} cancelled within grace window`,
+    );
+    return saved;
+  }
+
+  /**
+   * Read the status of an erasure request. The subject and admins may read any
+   * request; other actors are limited to their own requests.
+   */
+  async getStatus(
+    requestId: string,
+    actor: { id: string; role?: string },
+  ): Promise<ErasureRequest> {
+    const request = await this.erasureRepo.findOne({
+      where: { id: requestId },
+    });
+    if (!request) {
+      throw new NotFoundException(`Erasure request ${requestId} not found`);
+    }
+    const isSubject = request.subjectId === actor.id;
+    const isAdmin = actor.role === 'ADMIN';
+    if (!isSubject && !isAdmin) {
+      throw new BadRequestException(
+        'You are not authorized to view this erasure request',
+      );
+    }
+    return request;
+  }
+
+  /**
+   * Execute an erasure. Called by the account-erasure BullMQ processor after
+   * the grace period has elapsed.
+   *
+   * Idempotency / safe re-run:
+   *  - COMPLETED requests are a no-op.
+   *  - CANCELLED / FAILED requests are skipped.
+   *  - A conditional claim (REQUESTED|PROCESSING → PROCESSING) runs inside the
+   *    transaction, so a concurrent or repeated run cannot double-execute and a
+   *    failed transaction rolls the claim back for a clean retry.
+   *
+   * All per-module anonymization happens inside a single transaction:
+   *  - users        : email / stellarAddress / profile PII → tombstone values,
+   *                   the row is retained so FKs and aggregate stats stay valid.
+   *  - submissions  : submitter PII and proof references detached; quest
+   *                   integrity and reviewer decisions preserved.
+   *  - notifications: rows deleted.
+   *  - payouts      : retained for compliance but de-identified — the actor
+   *                   identifier is replaced with the tombstone.
+   *  - moderation   : submitter PII detached from moderation notes.
+   *  - audit        : an erasure audit record is written to the event store.
+   */
+  async executeErasure(requestId: string): Promise<{
+    requestId: string;
+    status: ErasureStatus;
+    skipped?: boolean;
+    alreadyExecuted?: boolean;
+  }> {
+    const request = await this.erasureRepo.findOne({
+      where: { id: requestId },
+    });
+    if (!request) {
+      throw new NotFoundException(`Erasure request ${requestId} not found`);
+    }
+
+    if (request.status === ErasureStatus.COMPLETED) {
+      return {
+        requestId,
+        status: ErasureStatus.COMPLETED,
+        alreadyExecuted: true,
+      };
+    }
+    if (
+      request.status === ErasureStatus.CANCELLED ||
+      request.status === ErasureStatus.FAILED
+    ) {
+      return { requestId, status: request.status, skipped: true };
+    }
+    if (
+      request.status === ErasureStatus.REQUESTED &&
+      new Date() < request.scheduledFor
+    ) {
+      throw new BadRequestException(
+        `Erasure request ${requestId} is still within its grace period`,
+      );
+    }
+
+    try {
+      await this.dataSource.transaction(async (manager) => {
+        // ── Claim the request (idempotent under concurrency) ──────────────
+        const claim = await manager.update(
+          ErasureRequest,
+          {
+            id: requestId,
+            status: In([ErasureStatus.REQUESTED, ErasureStatus.PROCESSING]),
+          },
+          { status: ErasureStatus.PROCESSING },
+        );
+        if (!claim.affected) {
+          return; // claimed/executed by a concurrent run — nothing to do
+        }
+
+        // Capture the pre-anonymization user so retained financial records can
+        // be re-pointed at the tombstone.
+        const user = await manager.getRepository(User).findOne({
+          where: { id: request.subjectId },
+        });
+        if (!user) {
+          throw new NotFoundException(`User ${request.subjectId} not found`);
+        }
+        const { stellarAddress } = user;
+
+        // ── Per-module anonymization policies (same transaction) ──────────
+        await this.usersService.anonymizeForErasure(request.subjectId, manager);
+        await this.submissionsService.anonymizeForErasure(
+          request.subjectId,
+          manager,
+        );
+
+        await manager.getRepository(Notification).delete({
+          userId: request.subjectId,
+        });
+
+        if (stellarAddress) {
+          await manager
+            .getRepository(Payout)
+            .update(
+              { stellarAddress },
+              { stellarAddress: erasureTombstone(request.subjectId) },
+            );
+        }
+
+        await manager.getRepository(ModerationItem).update(
+          { userId: request.subjectId },
+          {
+            textSnapshot: null,
+            imageUrls: null,
+            keywordHits: null,
+            imageFlags: null,
+            notes: null,
+          },
+        );
+
+        // ── Audit record of the erasure itself ─────────────────────────────
+        const audit = manager.getRepository(EventStore).create({
+          eventName: 'privacy.erasure.executed',
+          source: 'application',
+          sourceId: requestId,
+          payload: {
+            requestId,
+            subjectId: request.subjectId,
+            requestedBy: request.requestedBy,
+            scope: request.scope,
+          },
+          metadata: { erasure: true },
+          timestamp: new Date(),
+        });
+        await manager.getRepository(EventStore).save(audit);
+
+        // ── Mark completed ─────────────────────────────────────────────────
+        await manager.update(
+          ErasureRequest,
+          { id: requestId },
+          { status: ErasureStatus.COMPLETED, executedAt: new Date() },
+        );
+      });
+
+      this.logger.log(
+        `Erasure request ${requestId} executed for user ${request.subjectId}`,
+      );
+      return { requestId, status: ErasureStatus.COMPLETED };
+    } catch (error) {
+      // A failed transaction rolled back the claim, so the job can safely retry.
+      this.logger.error(
+        `Erasure request ${requestId} failed: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+}

--- a/BackEnd/src/modules/privacy/privacy.module.ts
+++ b/BackEnd/src/modules/privacy/privacy.module.ts
@@ -1,0 +1,39 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ErasureRequest } from './entities/erasure-request.entity';
+import { ErasureService } from './erasure.service';
+import { ErasureController } from './erasure.controller';
+import { User } from '../users/entities/user.entity';
+import { Submission } from '../submissions/entities/submission.entity';
+import { Payout } from '../payouts/entities/payout.entity';
+import { Notification } from '../notifications/entities/notification.entity';
+import { ModerationItem } from '../moderation/entities/moderation-item.entity';
+import { EventStore } from '../../events/entities/event-store.entity';
+import { UsersModule } from '../users/users.module';
+import { SubmissionsModule } from '../submissions/submissions.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      ErasureRequest,
+      User,
+      Submission,
+      Payout,
+      Notification,
+      ModerationItem,
+      EventStore,
+    ]),
+    EventEmitterModule,
+    // forwardRef breaks the JS import cycle PrivacyModule → UsersModule →
+    // EmailModule → JobsModule → (forwardRef) PrivacyModule; SubmissionsModule
+    // is wrapped for the same reason (it is imported from the same module file
+    // during circular evaluation).
+    forwardRef(() => UsersModule),
+    forwardRef(() => SubmissionsModule),
+  ],
+  controllers: [ErasureController],
+  providers: [ErasureService],
+  exports: [ErasureService],
+})
+export class PrivacyModule {}

--- a/BackEnd/src/modules/submissions/CHANGELOG.md
+++ b/BackEnd/src/modules/submissions/CHANGELOG.md
@@ -12,6 +12,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `anonymizeForErasure(userId, manager?)` — detaches submitter PII and proof references from a user's submissions while preserving quest integrity and reviewer decisions, used by the right-to-erasure pipeline; runs inside the caller's transaction when a manager is supplied (#2337).
+
+### Added
+
 - Optimistic-concurrency `@VersionColumn` (`version`) on the `Submission` entity plus a backfilling migration, so concurrent submission writes (e.g. a status transition racing with an edit) are rejected on stale-version saves instead of causing a lost update (#2157).
 
 ### Fixed

--- a/BackEnd/src/modules/submissions/submissions.service.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.ts
@@ -8,7 +8,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Brackets, Repository } from 'typeorm';
+import { Brackets, EntityManager, Repository } from 'typeorm';
 
 /**
  * Sentinel error thrown inside the capacity-gate transaction when the
@@ -78,6 +78,39 @@ export class SubmissionsService {
     private metricsService: MetricsService,
     private verificationDedup: VerificationDedupService,
   ) {}
+
+  /**
+   * Anonymize a user's submissions (right-to-erasure).
+   *
+   * Submitter PII and proof references are detached (`proof` is replaced with
+   * an erased marker, notes are nulled) while quest integrity and reviewer
+   * decisions (status, approvedBy/rejectedBy timestamps, transactionHash) are
+   * preserved so payout/audit trails stay consistent. Returns the number of
+   * submissions anonymized.
+   *
+   * Runs on the provided transaction manager when called from the erasure
+   * pipeline (so the whole erasure is atomic); otherwise uses its own
+   * repository manager.
+   */
+  async anonymizeForErasure(
+    userId: string,
+    manager?: EntityManager,
+  ): Promise<number> {
+    const em = manager ?? this.submissionsRepository.manager;
+    const repo = em.getRepository(Submission);
+    const submissions = await repo.find({ where: { userId } });
+    if (submissions.length === 0) {
+      return 0;
+    }
+
+    for (const submission of submissions) {
+      submission.proof = { erased: true };
+      submission.verifierNotes = null;
+      submission.rejectionReason = null;
+    }
+    await repo.save(submissions);
+    return submissions.length;
+  }
 
   /**
    * Create a new submission for a quest.

--- a/BackEnd/src/modules/users/CHANGELOG.md
+++ b/BackEnd/src/modules/users/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `anonymizeForErasure(userId, manager?)` — replaces a user's PII (email, stellarAddress, profile fields) with per-user tombstone values while retaining the row, used by the right-to-erasure pipeline; runs inside the caller's transaction when a manager is supplied (#2337).
+
 ### Changed
 
 - `findById()` now reads through the unified cache-aside layer (`CacheService.getOrSet`) tagged per user, and `update()` calls `invalidateTag(CacheTags.user(id))` so a write drops the user's cached reads (#2159).

--- a/BackEnd/src/modules/users/users.service.ts
+++ b/BackEnd/src/modules/users/users.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
-import { User } from './entities/user.entity';
+import { User, PrivacyLevel } from './entities/user.entity';
 import { CacheService } from '../cache/cache.service';
 import { CacheKeys, CacheTags, CacheTtl } from '../cache/cache-tags';
 
@@ -32,6 +32,53 @@ export class UsersService {
     private readonly usersRepository: Repository<User>,
     private readonly cacheService: CacheService,
   ) {}
+
+  /**
+   * Anonymize a user's PII in place (right-to-erasure).
+   *
+   * Email / stellarAddress / profile fields are replaced with per-user
+   * tombstone values, but the row itself is retained so aggregate stats and
+   * foreign keys (submissions, payouts, …) remain valid. Returns the
+   * pre-anonymization identifiers so the caller can re-point retained
+   * financial/audit records at the tombstone.
+   *
+   * Runs on the provided transaction manager when called from the erasure
+   * pipeline (so the whole erasure is atomic); otherwise uses its own
+   * repository manager.
+   */
+  async anonymizeForErasure(
+    userId: string,
+    manager?: EntityManager,
+  ): Promise<{ stellarAddress: string | null; email: string | null }> {
+    const em = manager ?? this.usersRepository.manager;
+    const repo = em.getRepository(User);
+    const user = await repo.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User ${userId} not found`);
+    }
+
+    const tombstone = `erased:${userId}`;
+    // The entity types the nullable profile columns as `string` (matching the
+    // rest of the codebase), so the null-out payload is cast to satisfy the
+    // query types — TypeORM maps `null` to SQL NULL for these columns.
+    await repo.update(userId, {
+      // Tombstone values must satisfy the unique constraints — the user id
+      // suffix keeps them collision-free across erased accounts.
+      email: `${tombstone}@erased.invalid`,
+      stellarAddress: tombstone,
+      username: null,
+      googleId: null,
+      githubId: null,
+      avatarUrl: null,
+      bio: null,
+      socialLinks: null,
+      pushToken: null,
+      webhookUrl: null,
+      privacyLevel: PrivacyLevel.PRIVATE,
+    } as any);
+
+    return { stellarAddress: user.stellarAddress, email: user.email };
+  }
 
   // Minimal implementations for server startup
   async findByAddress(stellarAddress: string): Promise<User | null> {

--- a/BackEnd/test/integration/privacy-erasure.integration-spec.ts
+++ b/BackEnd/test/integration/privacy-erasure.integration-spec.ts
@@ -1,0 +1,271 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { join } from 'path';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ScheduleModule } from '@nestjs/schedule';
+import { LoggerModule } from '#src/common/logger/logger.module';
+import { PrivacyModule } from '#src/modules/privacy/privacy.module';
+import { ErasureService } from '#src/modules/privacy/erasure.service';
+import {
+  ErasureRequest,
+  ErasureStatus,
+} from '#src/modules/privacy/entities/erasure-request.entity';
+import { User } from '#src/modules/users/entities/user.entity';
+import { Submission } from '#src/modules/submissions/entities/submission.entity';
+import { Notification } from '#src/modules/notifications/entities/notification.entity';
+import { Payout } from '#src/modules/payouts/entities/payout.entity';
+import { ModerationItem } from '#src/modules/moderation/entities/moderation-item.entity';
+import { EventStore } from '#src/events/entities/event-store.entity';
+import { DataSource, Repository } from 'typeorm';
+import { Quest } from '#src/modules/quests/entities/quest.entity';
+
+describe('Privacy Erasure Integration', () => {
+  let module: TestingModule;
+  let erasureService: ErasureService;
+  let dataSource: DataSource;
+  let userRepo: Repository<User>;
+
+  beforeAll(async () => {
+    // Short grace period so execution can run within the test without waiting
+    // a week; the pipeline reads it once per request creation.
+    process.env.ERASURE_GRACE_PERIOD_MS = '100';
+
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          envFilePath: '.env.test',
+        }),
+        EventEmitterModule.forRoot(),
+        ScheduleModule.forRoot(),
+        LoggerModule.forRoot({
+          enableInterceptor: false,
+          enableErrorFilter: false,
+        }),
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: process.env.DB_HOST || 'localhost',
+          port: parseInt(process.env.DB_PORT || '5432'),
+          username: process.env.DB_USERNAME || 'postgres',
+          password: process.env.DB_PASSWORD || 'password',
+          database: process.env.DB_DATABASE || 'stellar_earn_test_integration',
+          entities: [
+            ErasureRequest,
+            User,
+            Submission,
+            Notification,
+            Payout,
+            ModerationItem,
+            EventStore,
+            Quest,
+          ],
+          autoLoadEntities: true,
+          synchronize: false,
+          dropSchema: true,
+          migrationsRun: true,
+          migrations: [
+            join(__dirname, '../../src/database/migrations/*.{ts,js}'),
+          ],
+        }),
+        PrivacyModule,
+      ],
+    }).compile();
+
+    erasureService = module.get<ErasureService>(ErasureService);
+    dataSource = module.get<DataSource>(DataSource);
+    userRepo = dataSource.getRepository(User);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.query(
+      'TRUNCATE "erasure_requests", "users", "submissions", "notifications", "payouts", "moderation_items", "event_store", "quests" RESTART IDENTITY CASCADE',
+    );
+  });
+
+  async function seedSubject(): Promise<User> {
+    return userRepo.save({
+      stellarAddress: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMN',
+      username: 'eraseme',
+      email: 'eraseme@example.com',
+      bio: 'private bio',
+      socialLinks: { twitter: '@eraseme' },
+      role: 'USER',
+    } as Partial<User>);
+  }
+
+  describe('request lifecycle', () => {
+    it('creates a request with a future scheduledFor and persists it', async () => {
+      const user = await seedSubject();
+
+      const request = await erasureService.requestErasure(user.id, {
+        requestedBy: user.id,
+      });
+
+      expect(request.status).toBe(ErasureStatus.REQUESTED);
+      expect(request.scheduledFor.getTime()).toBeGreaterThan(Date.now());
+      expect(request.subjectId).toBe(user.id);
+
+      const persisted = await dataSource
+        .getRepository(ErasureRequest)
+        .findOneByOrFail({ id: request.id });
+      expect(persisted.status).toBe(ErasureStatus.REQUESTED);
+    });
+
+    it('cancels within the grace window and never executes', async () => {
+      const user = await seedSubject();
+      const request = await erasureService.requestErasure(user.id, {
+        requestedBy: user.id,
+      });
+
+      const cancelled = await erasureService.cancelErasure(request.id, {
+        id: user.id,
+        role: 'USER',
+      });
+      expect(cancelled.status).toBe(ErasureStatus.CANCELLED);
+      expect(cancelled.cancelledAt).toBeInstanceOf(Date);
+
+      // Execution must skip cancelled requests.
+      const result = await erasureService.executeErasure(request.id);
+      expect(result.skipped).toBe(true);
+
+      const after = await dataSource
+        .getRepository(ErasureRequest)
+        .findOneByOrFail({ id: request.id });
+      expect(after.status).toBe(ErasureStatus.CANCELLED);
+      expect(after.executedAt).toBeNull();
+    });
+  });
+
+  describe('cross-module anonymization', () => {
+    it('anonymizes PII across modules in one transaction, retaining FKs', async () => {
+      const user = await seedSubject();
+      const quest = await dataSource.getRepository(Quest).save({
+        title: 'Quest with proof',
+        description: 'do the thing',
+        contractTaskId: 'task-1',
+        rewardAsset: 'XLM',
+        rewardAmount: 100,
+        verifierType: 'MANUAL',
+        verifierConfig: { verifiers: [] },
+        status: 'ACTIVE',
+        createdBy: user.id,
+      } as Partial<Quest>);
+
+      // Submission with submitter PII in the proof payload.
+      await dataSource.getRepository(Submission).save({
+        questId: quest.id,
+        userId: user.id,
+        proof: {
+          tweetUrl: 'https://x.com/eraseme/status/1',
+          email: 'eraseme@example.com',
+        },
+        status: 'APPROVED',
+        approvedBy: 'VERIFIER-ADDRESS',
+        approvedAt: new Date(),
+      } as Partial<Submission>);
+
+      // Notification row for the subject.
+      await dataSource.getRepository(Notification).save({
+        userId: user.id,
+        type: 'INFO',
+        title: 'Welcome',
+        message: 'hello eraseme',
+        priority: 'NORMAL',
+      } as Partial<Notification>);
+
+      // Payout retained for compliance — de-identified on erasure.
+      await dataSource.getRepository(Payout).save({
+        stellarAddress: user.stellarAddress!,
+        amount: 50,
+        asset: 'XLM',
+        status: 'PAID',
+        type: 'REWARD',
+        questId: quest.id,
+      } as Partial<Payout>);
+
+      // Moderation record with a snapshot of submitter content.
+      await dataSource.getRepository(ModerationItem).save({
+        targetType: 'SUBMISSION',
+        targetId: 'target-1',
+        userId: user.id,
+        textSnapshot: 'eraseme content',
+        imageUrls: ['https://cdn.example.com/eraseme.png'],
+        notes: 'reviewer note',
+        status: 'RESOLVED',
+      } as Partial<ModerationItem>);
+
+      // Request erasure and let the grace period elapse.
+      const request = await erasureService.requestErasure(user.id, {
+        requestedBy: user.id,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const result = await erasureService.executeErasure(request.id);
+      expect(result.status).toBe(ErasureStatus.COMPLETED);
+
+      // ── Referential-integrity assertions ─────────────────────────────────
+      const afterUser = await dataSource
+        .getRepository(User)
+        .findOneByOrFail({ id: user.id });
+      expect(afterUser.email).toMatch(/^erased:.*@erased\.invalid$/);
+      expect(afterUser.stellarAddress).toBe(`erased:${user.id}`);
+      expect(afterUser.username).toBeNull();
+      expect(afterUser.bio).toBeNull();
+      expect(afterUser.socialLinks).toBeNull();
+
+      // Submission row survives (quest integrity + reviewer decisions kept),
+      // but the proof payload is detached.
+      const submissions = await dataSource
+        .getRepository(Submission)
+        .findBy({ userId: user.id });
+      expect(submissions).toHaveLength(1);
+      expect(submissions[0].proof).toEqual({ erased: true });
+      expect(submissions[0].status).toBe('APPROVED');
+      expect(submissions[0].approvedBy).toBe('VERIFIER-ADDRESS');
+      expect(submissions[0].questId).toBe(quest.id);
+
+      // Notifications are deleted.
+      const notifications = await dataSource
+        .getRepository(Notification)
+        .findBy({ userId: user.id });
+      expect(notifications).toHaveLength(0);
+
+      // Payouts retained but de-identified.
+      const payouts = await dataSource.getRepository(Payout).find();
+      expect(payouts).toHaveLength(1);
+      expect(payouts[0].stellarAddress).toBe(`erased:${user.id}`);
+      expect(payouts[0].amount).toBe(50);
+
+      // Moderation record retained, PII detached.
+      const moderation = await dataSource
+        .getRepository(ModerationItem)
+        .findBy({ userId: user.id });
+      expect(moderation).toHaveLength(1);
+      expect(moderation[0].textSnapshot).toBeNull();
+      expect(moderation[0].imageUrls).toBeNull();
+      expect(moderation[0].notes).toBeNull();
+
+      // Audit record of the erasure written.
+      const audits = await dataSource
+        .getRepository(EventStore)
+        .findBy({ eventName: 'privacy.erasure.executed' });
+      expect(audits.length).toBeGreaterThanOrEqual(1);
+      expect(audits[0].sourceId).toBe(request.id);
+
+      // Request marked completed; re-run is a no-op (idempotent).
+      const afterRequest = await dataSource
+        .getRepository(ErasureRequest)
+        .findOneByOrFail({ id: request.id });
+      expect(afterRequest.status).toBe(ErasureStatus.COMPLETED);
+      expect(afterRequest.executedAt).toBeInstanceOf(Date);
+
+      const rerun = await erasureService.executeErasure(request.id);
+      expect(rerun.alreadyExecuted).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2337

Implements a right-to-erasure pipeline: users (or admins on their behalf) can request account erasure, cancel it within a cancellable grace window, and track its status. Once the grace period elapses, a BullMQ job anonymizes the user's PII across modules **inside a single transaction**, with idempotent execution.

### Request lifecycle
- New `privacy` module with `ErasureService` modelling: submit → grace period (cancellable) → execute → completed.
- `ErasureController` endpoints — request erasure, cancel within the grace window, check status (auth-guarded to the requesting user), and admin-initiated erasure (`POST /privacy/erasure/admin/requests`).
- `ErasureRequest` entity + TypeORM migration (`1860000000000-add-erasure-requests.ts`).

### Execution (cross-module anonymization)
- New `account-erasure` BullMQ queue + `AccountErasureProcessor` (via `AccountErasureListener`, scheduled for the end of the grace period).
- Anonymization runs inside a **single transaction** with a documented per-module policy:
  - `users`: email / stellarAddress / profile PII → per-user tombstone values; the row is retained so aggregate stats and foreign keys stay valid.
  - `submissions`: submitter PII and proof references detached; quest integrity and reviewer decisions preserved.
  - `notifications`: rows deleted.
  - `payouts`: retained for compliance but de-identified (actor → tombstone).
  - `moderation`: submitter PII detached from notes/snapshots.
  - audit: `privacy.erasure.executed` record written to the event store in the same transaction.
- Execution is idempotent and safe to re-run (completed/cancelled requests are no-ops; a failed transaction rolls back the claim so retries are clean).

### Tests & docs
- `erasure.service.spec.ts` unit tests: lifecycle, grace-window cancellation, idempotent execution, referential-integrity assertions.
- `privacy-erasure.integration-spec.ts` integration tests running migrations on a fresh schema and asserting cross-module anonymization + FK integrity.
- API and retention policy documented in `BackEnd/src/modules/privacy/README.md`; module CHANGELOGs updated.

### Affected files
- `BackEnd/src/modules/privacy/*` (new module: service, controller, entity, DTOs, module)
- `BackEnd/src/database/migrations/1860000000000-add-erasure-requests.ts` (new)
- `BackEnd/src/modules/jobs/processors/account-erasure.processor.ts`, `listeners/account-erasure.listener.ts` (new)
- `BackEnd/src/modules/jobs/{jobs.module,jobs.service,jobs.constants,job.types,job-retry-policy}.ts`, `services/job-scheduler.service.ts`
- `BackEnd/src/modules/users/users.service.ts`, `BackEnd/src/modules/submissions/submissions.service.ts`
- `BackEnd/src/app.module.ts`
