### PR TITLE
fix(a11y): force visible focus outlines globally

### DIFF
--- a/FrontEnd/my-app/app/globals.css
+++ b/FrontEnd/my-app/app/globals.css
@@ -115,8 +115,8 @@ body {
 
 /* Accessibility: Enhanced focus styles for keyboard navigation */
 *:focus-visible {
-  outline: 2px solid var(--theme-primary);
-  outline-offset: 2px;
+  outline: 2px solid var(--theme-primary) !important;
+  outline-offset: 2px !important;
 }
 
 /* Screen reader only class */


### PR DESCRIPTION

closes #2292
## Description
This PR resolves an accessibility issue where focus outlines were being suppressed globally, resulting in invisible keyboard navigation. Due to component-level CSS resets or utilities (such as `focus:outline-none`), our base focus styles were being overridden. 

By enforcing the `!important` modifier on the global `*:focus-visible` block, we guarantee that focus indicators remain strictly visible for keyboard navigation without breaking mouse/touch interactions (thanks to the `:focus-visible` pseudo-class).

## Changes Made
- Modified `FrontEnd/my-app/app/globals.css` to add `!important` to the `outline` and `outline-offset` CSS properties within the `*:focus-visible` selector.

## Acceptance Criteria
- [x] Implemented across the requested global CSS file.
- [x] Unit/integration test suites verified (all pass and are unaffected, no regressions).
- [x] Restores critical accessibility compliance (WCAG) for keyboard users.

## Testing
- Verified visually by simulating keyboard navigation (Tab-key traversal) on interactive elements. Focus rings are consistently rendered without being overwritten. 

