### PR TITLE
test(postmortems): add CRUD unit tests for service and controller

### DIFF
--- a/BackEnd/src/modules/postmortems/postmortems.controller.spec.ts
+++ b/BackEnd/src/modules/postmortems/postmortems.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { PostmortemController } from './postmortems.controller';
 import { PostmortemService } from './postmortems.service';
 import {
@@ -85,6 +86,23 @@ describe('PostmortemController', () => {
       expect(result).toEqual(mockPostmortemResponse);
       expect(service.create).toHaveBeenCalledWith(dto);
     });
+
+    it('should propagate BadRequestException from the service', async () => {
+      jest
+        .spyOn(service, 'create')
+        .mockRejectedValue(new BadRequestException('Invalid input'));
+
+      const dto: CreatePostmortemDto = {
+        incidentId: 'invalid-id',
+        title: 'Test',
+        incidentDate: new Date(),
+        startTime: new Date(),
+        endTime: new Date(),
+        severity: IncidentSeverity.HIGH,
+      };
+
+      await expect(controller.create(dto)).rejects.toThrow(BadRequestException);
+    });
   });
 
   describe('getById', () => {
@@ -142,6 +160,29 @@ describe('PostmortemController', () => {
 
       expect(result.data).toHaveLength(1);
     });
+
+    it('should pass query filters and pagination to the service', async () => {
+      const query = {
+        status: PostmortemStatus.DRAFT,
+        searchTerm: 'database',
+        limit: 10,
+        offset: 5,
+        sortBy: 'incidentDate' as const,
+        sortOrder: 'ASC' as const,
+      };
+      const mockList = {
+        data: [mockPostmortemResponse],
+        total: 1,
+        limit: 10,
+        offset: 5,
+      };
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue(mockList);
+
+      const result = await controller.list(query);
+
+      expect(result).toEqual(mockList);
+      expect(listSpy).toHaveBeenCalledWith(query);
+    });
   });
 
   describe('update', () => {
@@ -155,6 +196,16 @@ describe('PostmortemController', () => {
 
       expect(result.title).toBe('Updated Title');
       expect(service.update).toHaveBeenCalledWith('test-id-123', dto);
+    });
+
+    it('should propagate NotFoundException from the service', async () => {
+      jest
+        .spyOn(service, 'update')
+        .mockRejectedValue(new NotFoundException('Postmortem not found'));
+
+      await expect(
+        controller.update('nonexistent', { title: 'New Title' }),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/BackEnd/src/modules/postmortems/postmortems.service.spec.ts
+++ b/BackEnd/src/modules/postmortems/postmortems.service.spec.ts
@@ -118,6 +118,37 @@ describe('PostmortemService', () => {
       expect(repository.save).toHaveBeenCalled();
     });
 
+    it('should serialize array and default fields to JSON', async () => {
+      const dto: CreatePostmortemDto = {
+        incidentId: '2024-01-15-1430',
+        title: 'Test Incident',
+        incidentDate: new Date('2024-01-15T14:30:00Z'),
+        startTime: new Date('2024-01-15T14:30:00Z'),
+        endTime: new Date('2024-01-15T14:50:00Z'),
+        severity: IncidentSeverity.HIGH,
+        servicesAffected: ['api', 'worker'],
+        contributingFactors: ['high load'],
+      };
+
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+      const createSpy = jest
+        .spyOn(repository, 'create')
+        .mockReturnValue(mockPostmortemEntity);
+      jest.spyOn(repository, 'save').mockResolvedValue(mockPostmortemEntity);
+
+      await service.create(dto);
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          servicesAffected: JSON.stringify(['api', 'worker']),
+          contributingFactors: JSON.stringify(['high load']),
+          actionItems: JSON.stringify([]),
+          totalActionItems: 0,
+          completedActionItems: 0,
+        }),
+      );
+    });
+
     it('should throw BadRequestException for invalid incident ID', async () => {
       const dto: CreatePostmortemDto = {
         incidentId: 'invalid-id',
@@ -237,6 +268,73 @@ describe('PostmortemService', () => {
 
       expect(result.data).toHaveLength(1);
     });
+
+    it('should cap the limit at 100', async () => {
+      jest
+        .spyOn(repository, 'findAndCount')
+        .mockResolvedValue([[mockPostmortemEntity], 1]);
+
+      const result = await service.list({ limit: 1000 });
+
+      expect(result.limit).toBe(100);
+      expect(repository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+
+    it('should apply a search term to the title', async () => {
+      jest
+        .spyOn(repository, 'findAndCount')
+        .mockResolvedValue([[mockPostmortemEntity], 1]);
+
+      await service.list({ searchTerm: 'database' });
+
+      expect(repository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ title: expect.anything() }),
+        }),
+      );
+    });
+
+    it('should pass sort options and offset through to the repository', async () => {
+      jest
+        .spyOn(repository, 'findAndCount')
+        .mockResolvedValue([[mockPostmortemEntity], 1]);
+
+      await service.list({
+        sortBy: 'incidentDate',
+        sortOrder: 'ASC',
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(repository.findAndCount).toHaveBeenCalledWith({
+        where: {},
+        take: 10,
+        skip: 5,
+        order: { incidentDate: 'ASC' },
+      });
+    });
+
+    it('should combine severity and status filters', async () => {
+      jest
+        .spyOn(repository, 'findAndCount')
+        .mockResolvedValue([[mockPostmortemEntity], 1]);
+
+      await service.list({
+        severity: IncidentSeverity.HIGH,
+        status: PostmortemStatus.DRAFT,
+      });
+
+      expect(repository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            severity: IncidentSeverity.HIGH,
+            status: PostmortemStatus.DRAFT,
+          },
+        }),
+      );
+    });
   });
 
   describe('update', () => {
@@ -269,6 +367,86 @@ describe('PostmortemService', () => {
         BadRequestException,
       );
     });
+
+    it('should allow closing a postmortem with all action items complete', async () => {
+      const complete = {
+        ...mockPostmortemEntity,
+        completedActionItems: mockPostmortemEntity.totalActionItems,
+      };
+      jest.spyOn(repository, 'findOne').mockResolvedValue(complete);
+      const saveSpy = jest
+        .spyOn(repository, 'save')
+        .mockImplementation((entity) => Promise.resolve(entity));
+
+      const result = await service.update('test-id-123', {
+        status: PostmortemStatus.CLOSED,
+      });
+
+      expect(result.status).toBe(PostmortemStatus.CLOSED);
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: PostmortemStatus.CLOSED,
+          closedAt: expect.any(Date),
+        }),
+      );
+    });
+
+    it('should reset action item counters when action items are updated', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockPostmortemEntity);
+      const saveSpy = jest
+        .spyOn(repository, 'save')
+        .mockImplementation((entity) => Promise.resolve(entity));
+
+      const actionItems = [
+        {
+          id: 'A1',
+          action: 'Add index',
+          owner: 'Alice',
+          dueDate: new Date('2024-01-20'),
+          priority: 'P0' as const,
+        },
+        {
+          id: 'A2',
+          action: 'Add monitoring',
+          owner: 'Bob',
+          dueDate: new Date('2024-01-21'),
+          priority: 'P1' as const,
+        },
+      ];
+
+      const result = await service.update('test-id-123', { actionItems });
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionItems: JSON.stringify(actionItems),
+          totalActionItems: 2,
+          completedActionItems: 0,
+        }),
+      );
+      expect(result.totalActionItems).toBe(2);
+      expect(result.completedActionItems).toBe(0);
+    });
+
+    it('should serialize updated array fields to JSON', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockPostmortemEntity);
+      const saveSpy = jest
+        .spyOn(repository, 'save')
+        .mockImplementation((entity) => Promise.resolve(entity));
+
+      await service.update('test-id-123', {
+        whatWentWell: ['Well done'],
+        attendees: ['john'],
+        tags: ['database'],
+      });
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          whatWentWell: JSON.stringify(['Well done']),
+          attendees: JSON.stringify(['john']),
+          tags: JSON.stringify(['database']),
+        }),
+      );
+    });
   });
 
   describe('addActionItem', () => {
@@ -288,6 +466,51 @@ describe('PostmortemService', () => {
       expect(result).toBeDefined();
       expect(repository.save).toHaveBeenCalled();
     });
+
+    it('should throw NotFoundException if postmortem not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.addActionItem('nonexistent', {
+          action: 'Test action',
+          owner: 'Test Owner',
+          dueDate: new Date('2024-01-20'),
+          priority: 'P1',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('completeActionItem', () => {
+    it('should mark an action item as complete', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockPostmortemEntity);
+      const saveSpy = jest
+        .spyOn(repository, 'save')
+        .mockImplementation((entity) => Promise.resolve(entity));
+
+      const result = await service.completeActionItem('test-id-123', 'A1');
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ completedActionItems: 1 }),
+      );
+      expect(result.completedActionItems).toBe(1);
+    });
+
+    it('should throw NotFoundException if action item not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockPostmortemEntity);
+
+      await expect(
+        service.completeActionItem('test-id-123', 'A99'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException if postmortem not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.completeActionItem('nonexistent', 'A1'),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('getStatistics', () => {
@@ -303,6 +526,38 @@ describe('PostmortemService', () => {
       expect(stats.averageTTD).toBeGreaterThanOrEqual(0);
       expect(stats.averageTTM).toBeGreaterThanOrEqual(0);
       expect(stats.averageTTR).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('findRelatedIncidents', () => {
+    it('should return postmortems with related root causes, excluding self', async () => {
+      const related = { ...mockPostmortemEntity, id: 'related-id' };
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockPostmortemEntity);
+      jest
+        .spyOn(repository, 'find')
+        .mockResolvedValue([mockPostmortemEntity, related]);
+
+      const result = await service.findRelatedIncidents('test-id-123');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('related-id');
+    });
+
+    it('should return an empty list when no related postmortems exist', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockPostmortemEntity);
+      jest.spyOn(repository, 'find').mockResolvedValue([mockPostmortemEntity]);
+
+      const result = await service.findRelatedIncidents('test-id-123');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw NotFoundException if postmortem not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.findRelatedIncidents('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 


### PR DESCRIPTION
## Linked Issue

Closes #2212

> **Required:** Every PR must be linked to an open issue. PRs without a linked issue will not be reviewed.

---

## Description

Adds the missing unit test coverage for the postmortems module's CRUD flows.

**What changed?**

- `BackEnd/src/modules/postmortems/postmortems.service.spec.ts` — extended with cases for:
  - `create`: JSON serialization of array/default fields (`servicesAffected`, `contributingFactors`, `actionItems`, counters).
  - `list`: limit capped at 100, `searchTerm` → `ILike` filter, `sortBy`/`sortOrder`/`offset` passthrough, combined `severity` + `status` filters.
  - `update`: successful close when all action items are complete (sets `closedAt`), action item counter reset, array field serialization.
  - `addActionItem`: `NotFoundException` when the postmortem does not exist.
  - `completeActionItem` (new block): marks an item complete and increments the counter; `NotFoundException` for missing action item and missing postmortem.
  - `findRelatedIncidents` (new block): returns root-cause matches excluding self; empty result; `NotFoundException`.
- `BackEnd/src/modules/postmortems/postmortems.controller.spec.ts` — extended with:
  - `list`: asserts the full query (filters + pagination + sort) is forwarded to the service.
  - `create`: `BadRequestException` propagated from the service.
  - `update`: `NotFoundException` propagated from the service.

**Why was it changed?**

The postmortems module had no test coverage for its create/list/update flows (issue #2212). The tests guard the CRUD contract, validation rules, and error behavior so regressions are caught in CI.

**How was it implemented?**

Unit tests following the project's existing NestJS testing conventions: `Test.createTestingModule` with a mocked TypeORM repository (`getRepositoryToken`) and `jest.spyOn` on service/controller collaborators. No production code was changed.

---

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Security fix
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [x] Tests only
- [ ] Configuration / DevOps change

---

## Contract Changelog Discipline

> **Required for changes under `contracts/earn-quest/src/**` or any contract storage, event, or interface change.**

- [x] No contract implementation changes - not applicable
- [ ] Updated `contracts/earn-quest/CHANGELOG.md` under `## [Unreleased]`
- [ ] If breaking, added a `### Breaking Changes` entry with impact, affected files, and migration steps
- [ ] If breaking, used Conventional Commit breaking metadata (`type(scope)!:`) in the PR title or commit history
- [ ] If breaking, included a `BREAKING CHANGE:` explanation below

**BREAKING CHANGE details (required for breaking contract changes):**

```text
BREAKING CHANGE:
```

---

## Test Evidence

> **Required:** All PRs must include test evidence. PRs missing this section will be blocked from merging.

### Unit Tests

- [x] New unit tests added for changed logic
- [x] All existing unit tests pass (`npm run test`)
- [x] Coverage does not regress (`npm run test:cov`)

**Test output / screenshot:**

```
PASS src/modules/postmortems/postmortems.service.spec.ts
PASS src/modules/postmortems/postmortems.controller.spec.ts

Test Suites: 2 passed, 2 total
Tests:       49 passed, 49 total
Snapshots:   0 total
```

Targeted run after the change:

```
npx jest src/modules/postmortems
```

### E2E / Integration Tests

- [ ] E2E tests added or updated (`npm run test:e2e`) — not applicable, unit-only change
- [ ] Tested manually against a local environment

**Endpoints tested:**

| Method | Endpoint | Expected | Result |
|--------|----------|----------|--------|
| —      | — (no production code / endpoint changes) | — | n/a |

---

## Swagger / API Documentation

> **Required for any endpoint changes.**

- [x] No API changes - Swagger update not applicable
- [ ] New endpoints documented with `@ApiOperation`, `@ApiResponse`, and `@ApiBearerAuth` decorators
- [ ] Updated DTOs annotated with `@ApiProperty` / `@ApiPropertyOptional`
- [ ] Swagger UI verified locally at `/api/docs` and responses are accurate
- [ ] Breaking changes to existing contracts are documented in the description above

---

## Error Handling Checklist

> All items below must be verified before requesting review.

### HTTP Exceptions

- [x] Appropriate NestJS HTTP exceptions used (`NotFoundException`, `BadRequestException`, `ForbiddenException`, `UnauthorizedException`, `ConflictException`, etc.) — verified by new tests (`BadRequestException` on create validation/duplicates, `NotFoundException` on missing postmortem/action item)
- [x] No raw `Error` thrown where an HTTP exception is expected
- [ ] Global exception filter handles all unhandled errors gracefully
- [ ] Error responses follow the project's standard error shape

### Input Validation (DTOs)

- [x] All incoming request bodies and query params have a corresponding DTO — `CreatePostmortemDto` / `UpdatePostmortemDto` / `PostmortemQueryDto` (unchanged)
- [x] DTOs use `class-validator` decorators (`@IsString`, `@IsUUID`, `@IsNotEmpty`, `@IsOptional`, etc.)
- [ ] `class-transformer` decorators applied where necessary (`@Transform`, `@Type`, `@Expose`)
- [ ] `ValidationPipe` is applied globally or at the controller level - raw unvalidated input is never used

### Guards & Authorization

- [x] Endpoints requiring authentication are protected with `@UseGuards(JwtAuthGuard)` or equivalent — `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles(Role.ADMIN)` (unchanged)
- [x] Admin-only endpoints use the appropriate admin guard / role check
- [ ] Public endpoints are explicitly marked with `@Public()` decorator where applicable
- [ ] Throttler guard behaviour verified - rate limits are not unintentionally bypassed

### Logging

- [ ] Significant operations and state transitions are logged using the project's Winston logger (`LoggerService`) — no production code changes
- [ ] Errors are logged at `error` level with stack traces
- [x] No sensitive data (passwords, secrets, private keys, tokens) is included in log output
- [ ] Incoming request / response logging is handled by the global `LoggerMiddleware` - no duplicate logs added

### Stellar / Soroban Contract Interactions

- [x] Contract calls wrapped in try/catch with descriptive error messages — no contract interactions in changed code
- [ ] Horizon / Soroban RPC failures do not crash the service - fallback or retry logic applied where appropriate
- [ ] Transaction signing uses environment-provided keys only - no hardcoded secrets

---

## Database / Migration

- [x] No database changes - not applicable
- [ ] TypeORM migration created and tested (`npm run typeorm:generate-migration`)
- [ ] Migration is reversible (down migration implemented)
- [ ] Seed data updated if required (`seed.ts`)

---

## Breaking Type / Model Changes (Frontend — FE-068)

> Required if your PR modifies any file under `FrontEnd/my-app/lib/types/**`,
> `FrontEnd/my-app/lib/api/**`, `FrontEnd/my-app/lib/schemas/**`,
> `FrontEnd/my-app/lib/validation/**`, or `FrontEnd/my-app/context/walletTypes.ts`.
>
> Full policy: [`FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md`](../FrontEnd/my-app/docs/TYPE_CHANGES_POLICY.md)

- [x] My PR touches **none** of the watched type/model paths — not applicable.
- [ ] I classified my change as: ☐ `breaking-types` ☐ `breaking-runtime` ☐ `added` ☐ `changed` ☐ `deprecated` ☐ `removed` ☐ `fixed` ☐ `security`
- [ ] I added a bullet to `## [Unreleased]` in [`FrontEnd/my-app/CHANGELOG.md`](../FrontEnd/my-app/CHANGELOG.md) **OR** a new file in [`FrontEnd/my-app/.changeset/`](../FrontEnd/my-app/.changeset/README.md).
- [ ] If breaking, my entry includes a before/after `Migration:` code block.
- [ ] `cd FrontEnd/my-app && npm run changelog:check` passes locally.
- [ ] If I am asserting this change is non-breaking despite touching a watched file, I added the `changelog-skip` label or `[changelog-skip]` to the PR title.

---

## Final Pre-Merge Checklist

- [ ] Branch is up to date with `main` / `master` — branched from `feat/validate-dispute-state-transitions`; will rebase/merge `main` before merge
- [x] Linting passes (`npm run lint`) — `npx eslint src/modules/postmortems/**` clean
- [x] Formatting passes (`npm run format`) — `npx prettier --check "src/modules/postmortems/**/*.ts"` clean
- [x] No `console.log` / debug statements left in production code
- [x] No hardcoded secrets, API keys, or environment-specific values in source code
- [ ] `.env.example` updated if new environment variables were introduced — none introduced
- [ ] `BackEnd/README.md` or `ReadMe Frontend.md` updated if setup steps changed — none changed
- [x] Self-review completed - I have read through every line of the diff

---

## Screenshots / Recordings (if applicable)

<!-- Attach screenshots or screen recordings for UI changes or Swagger updates -->

N/A — test-only change.

---

## Additional Notes for Reviewer

- No production code was modified; the diff is limited to the two spec files listed in the issue.
- The module changelog gate is intentionally not triggered: `scripts/backend-changelog.js` excludes `*.spec.ts` files from the "implementation surface" check.
- `npm run build` (TypeScript compile) passes to confirm no type regressions.
- Pre-existing unstaged deletion of `BackEnd/scripts/benchmark-soroban-read-cache.ts` was left out of this PR.