### PR TITLE
feat(referrals): add backend referral & invitation program with qualification-based reward attribution

### DIFF
--- a/BackEnd/src/app.module.ts
+++ b/BackEnd/src/app.module.ts
@@ -40,6 +40,7 @@ import { StellarModule } from './modules/stellar/stellar.module';
 import { MultiSigModule } from './modules/stellar/multisig/multisig.module';
 import { SubmissionsModule } from './modules/submissions/submissions.module';
 import { DisputesModule } from './modules/disputes/disputes.module';
+import { ReferralsModule } from './modules/referrals/referrals.module';
 import { TraceModule } from './modules/trace/trace.module';
 import { UsersModule } from './modules/users/users.module';
 import { WebhooksModule } from './modules/webhooks/webhooks.module';
@@ -104,6 +105,7 @@ const dataSourceProvider = shouldInitializeDatabaseConnection()
     StellarModule,
     SubmissionsModule,
     DisputesModule,
+    ReferralsModule,
     UsersModule,
     WebhooksModule,
     WebhooksOutboundModule,

--- a/BackEnd/src/database/data-source.ts
+++ b/BackEnd/src/database/data-source.ts
@@ -22,6 +22,8 @@ import { EventStore } from '../events/entities/event-store.entity';
 import { PoisonMessage } from '../events/entities/poison-message.entity';
 import { FailedWebhookEvent } from '../modules/webhooks/entities/failed-webhook-event.entity';
 import { Dispute } from '../modules/disputes/entities/dispute.entity';
+import { Referral } from '../modules/referrals/entities/referral.entity';
+import { ReferralReward } from '../modules/referrals/entities/referral-reward.entity';
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
@@ -114,6 +116,8 @@ export const dataSourceOptions: DataSourceOptions = {
     PoisonMessage,
     FailedWebhookEvent,
     Dispute,
+    Referral,
+    ReferralReward,
   ],
 
   migrations: [path.join(__dirname, 'migrations', '*.{ts,js}')],

--- a/BackEnd/src/database/migrations/1870000000000-add-referrals.ts
+++ b/BackEnd/src/database/migrations/1870000000000-add-referrals.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReferrals1870000000000 implements MigrationInterface {
+  name = 'AddReferrals1870000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."referrals_status_enum" AS ENUM('PENDING', 'QUALIFIED', 'REWARDED', 'REJECTED')`,
+    );
+
+    await queryRunner.query(
+      `CREATE TABLE "referrals" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "referrerId" uuid NOT NULL,
+        "referredUserId" uuid NOT NULL,
+        "code" character varying(64) NOT NULL,
+        "status" "public"."referrals_status_enum" NOT NULL DEFAULT 'PENDING',
+        "rejectionReason" text,
+        "qualifiedAt" TIMESTAMP WITH TIME ZONE,
+        "rewardedAt" TIMESTAMP WITH TIME ZONE,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_referrals_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_referrals_referredUserId" UNIQUE ("referredUserId")
+      )`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_referrals_referrer_status" ON "referrals" ("referrerId", "status")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_referrals_code" ON "referrals" ("code")`,
+    );
+
+    await queryRunner.query(
+      `CREATE TYPE "public"."referral_rewards_status_enum" AS ENUM('PENDING', 'CREDITED', 'FAILED', 'REJECTED')`,
+    );
+
+    await queryRunner.query(
+      `CREATE TABLE "referral_rewards" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "referralId" uuid NOT NULL,
+        "recipientId" uuid NOT NULL,
+        "amount" numeric(18,7) NOT NULL DEFAULT '50',
+        "asset" character varying(32) NOT NULL DEFAULT 'XLM',
+        "status" "public"."referral_rewards_status_enum" NOT NULL DEFAULT 'CREDITED',
+        "idempotencyKey" character varying(255) NOT NULL,
+        "notes" text,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_referral_rewards_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_referral_rewards_idempotencyKey" UNIQUE ("idempotencyKey")
+      )`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_referral_rewards_recipient" ON "referral_rewards" ("recipientId")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_referral_rewards_referral" ON "referral_rewards" ("referralId")`,
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_referral_rewards_referral"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_referral_rewards_recipient"`,
+    );
+    await queryRunner.query(`DROP TABLE "referral_rewards"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."referral_rewards_status_enum"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."idx_referrals_code"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_referrals_referrer_status"`,
+    );
+    await queryRunner.query(`DROP TABLE "referrals"`);
+    await queryRunner.query(`DROP TYPE "public"."referrals_status_enum"`);
+  }
+}

--- a/BackEnd/src/modules/auth/CHANGELOG.md
+++ b/BackEnd/src/modules/auth/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Capture optional `referralCode` during signup in `AuthService.verifyAndLogin` and `AuthService.loginOAuthUser`, linking pending attribution for new users (#2357).
+- Added `referralCode` optional field to `LoginDto` and `OAuthProfile`.
+
 ### Changed
 - `AuthController.login` now returns a typed `LoginResponseDto` instead of writing the response body manually via `@Res().json()`, so Nest's serialization/interceptor pipeline applies to the login response. `@Res({ passthrough: true })` is kept for setting the session cookies. Closes #1894.
 - Applied code-style formatting to `auth.module.ts` import block (no logic change).

--- a/BackEnd/src/modules/auth/auth.module.ts
+++ b/BackEnd/src/modules/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -14,6 +14,7 @@ import {
   getJwtPublicKeys,
 } from '../../common/utils/jwt-keys';
 import { UsersModule } from '../users/users.module';
+import { ReferralsModule } from '../referrals/referrals.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { UsersModule } from '../users/users.module';
     }),
     TypeOrmModule.forFeature([RefreshToken]),
     UsersModule,
+    forwardRef(() => ReferralsModule),
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, JwtAuthGuard, RolesGuard],

--- a/BackEnd/src/modules/auth/auth.service.ts
+++ b/BackEnd/src/modules/auth/auth.service.ts
@@ -3,6 +3,9 @@ import {
   Logger,
   UnauthorizedException,
   NotFoundException,
+  Optional,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
@@ -13,6 +16,7 @@ import { RefreshToken } from './entities/refresh-token.entity';
 import { LoginDto, ChallengeResponseDto } from './dto/auth.dto';
 import { Role } from '../../common/enums/role.enum';
 import { UsersService } from '../users/users.service';
+import { ReferralsService } from '../referrals/referrals.service';
 import {
   generateChallengeMessage,
   verifyStellarSignature,
@@ -34,6 +38,7 @@ export interface OAuthProfile {
   username: string;
   avatarUrl?: string;
   provider: 'google' | 'github';
+  referralCode?: string;
 }
 
 @Injectable()
@@ -46,6 +51,9 @@ export class AuthService {
     private readonly usersService: UsersService,
     @InjectRepository(RefreshToken)
     private readonly refreshTokenRepository: Repository<RefreshToken>,
+    @Optional()
+    @Inject(forwardRef(() => ReferralsService))
+    private readonly referralsService?: ReferralsService,
   ) {}
 
   /**
@@ -128,6 +136,7 @@ export class AuthService {
 
     verifyStellarSignature(stellarAddress, signature, challenge);
 
+    let isNewUser = false;
     let user = await this.usersService.findByAddress(stellarAddress);
     if (!user) {
       user = await this.usersService.create({
@@ -135,6 +144,17 @@ export class AuthService {
         username: stellarAddress,
         role: Role.USER,
       });
+      isNewUser = true;
+    }
+
+    if (isNewUser && dto.referralCode && this.referralsService) {
+      await this.referralsService
+        .recordAttribution(user.id, dto.referralCode)
+        .catch((err) => {
+          this.logger.warn(
+            `Failed to record referral attribution for user ${user.id}: ${err.message}`,
+          );
+        });
     }
 
     const tokens = await this.generateTokens(
@@ -322,6 +342,7 @@ export class AuthService {
       user = await this.usersService.findByEmail(profile.email);
     }
 
+    let isNewUser = false;
     if (!user) {
       user = await this.usersService.create({
         email: profile.email,
@@ -331,6 +352,17 @@ export class AuthService {
         avatarUrl: profile.avatarUrl,
         role: Role.USER,
       });
+      isNewUser = true;
+    }
+
+    if (isNewUser && profile.referralCode && this.referralsService) {
+      await this.referralsService
+        .recordAttribution(user.id, profile.referralCode)
+        .catch((err) => {
+          this.logger.warn(
+            `Failed to record referral attribution for user ${user.id}: ${err.message}`,
+          );
+        });
     }
 
     const tokens = await this.generateTokens(

--- a/BackEnd/src/modules/auth/dto/auth.dto.ts
+++ b/BackEnd/src/modules/auth/dto/auth.dto.ts
@@ -1,5 +1,11 @@
-import { IsString, IsNotEmpty, MaxLength, MinLength } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  MaxLength,
+  MinLength,
+  IsOptional,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsStellarAddress } from '../../../common/decorators/is-stellar-address.decorator';
 
 export class ChallengeRequestDto {
@@ -70,6 +76,14 @@ export class LoginDto {
   @MinLength(10)
   @MaxLength(1000)
   challenge: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional referral code used during initial signup',
+    example: 'REF-A1B2C3D4',
+  })
+  @IsOptional()
+  @IsString()
+  referralCode?: string;
 }
 
 export class UserResponseDto {

--- a/BackEnd/src/modules/cache/CHANGELOG.md
+++ b/BackEnd/src/modules/cache/CHANGELOG.md
@@ -6,6 +6,9 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Migrated distributed lock random value generator to native `crypto.randomUUID()` for reliable module loading.
+
 ### Added
 
 - Unified cache-aside primitives on `CacheService`: `getOrSet(key, ttl, tags, loader)` and `invalidateTag(tag)`, backed by the existing tag registry, giving consistent tag-based invalidation across the hot read paths (#2159).

--- a/BackEnd/src/modules/cache/cache.service.ts
+++ b/BackEnd/src/modules/cache/cache.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { CacheAnalyticsService } from './cache-analytics.service';
-import { v4 as uuidv4 } from 'uuid';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class CacheService {
@@ -183,7 +183,7 @@ export class CacheService {
 
   async acquireLock(key: string, ttlMs: number = 5000): Promise<string | null> {
     const lockKey = `lock:${key}`;
-    const lockValue = uuidv4();
+    const lockValue = crypto.randomUUID();
 
     try {
       const store =

--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Referral reward pipeline: new `REFERRALS` BullMQ queue (`QUEUES.REFERRALS`), `JobType.REFERRAL_REWARD` (with retry policy), and `ReferralRewardProcessor` for idempotent, anti-abuse referral reward processing (#2357).
 - Stuck payout recovery in `PayoutReconciliationProcessor.recoverStuckPayouts()` — an every-10-minute job that detects payouts stuck in PROCESSING (no transaction hash, crashed before submission) or RETRY_SCHEDULED (overdue, never re-driven) and resets them back to PENDING or DEAD_LETTER via `PayoutsService.forceResetPayout()`.
 - Account-erasure pipeline: new `ERASURE` BullMQ queue, `JobType.ACCOUNT_ERASURE` (with retry policy), `AccountErasureProcessor` and `AccountErasureListener`. The listener schedules the erasure job for the end of the grace period; the processor runs the idempotent, transactional anonymization via `ErasureService` (#2337).
 - Payout transactional-outbox relay in `PayoutProcessor.relayPayoutOutbox()` — an every-minute job that atomically claims PENDING `payout_outbox` rows (`PENDING → PROCESSING`), submits each via `StellarPaymentService` exactly once, and marks them DONE (or retries/parks on failure) (#2158).

--- a/BackEnd/src/modules/jobs/job-retry-policy.ts
+++ b/BackEnd/src/modules/jobs/job-retry-policy.ts
@@ -237,6 +237,20 @@ export const JOB_RETRY_POLICIES: Readonly<
     removeOnComplete: 25,
     removeOnFail: 50,
   },
+
+  // ── Referral Reward Processing ────────────────────────────────────────────
+  [JobType.REFERRAL_REWARD]: {
+    attempts: 5,
+    backoff: { type: 'exponential', delay: 5_000 },
+    nonRetryableErrors: [
+      'Referral not found',
+      'Self-referral detected',
+      'Circular referral detected',
+      'Referral already rewarded',
+    ],
+    removeOnComplete: 200,
+    removeOnFail: 200,
+  },
 };
 
 // ─── Utility Functions ────────────────────────────────────────────────────────

--- a/BackEnd/src/modules/jobs/job.types.ts
+++ b/BackEnd/src/modules/jobs/job.types.ts
@@ -39,6 +39,9 @@ export enum JobType {
 
   // Privacy / Right to Erasure
   ACCOUNT_ERASURE = 'privacy:account-erasure',
+
+  // Referral Reward Processing
+  REFERRAL_REWARD = 'referral:reward',
 }
 
 export enum JobPriority {
@@ -188,6 +191,14 @@ export interface DependencyFreshnessCheckPayload extends JobPayload {
   branch?: string;
 }
 
+export interface ReferralRewardJobPayload extends JobPayload {
+  referralId: string;
+  referrerId?: string;
+  referredUserId?: string;
+  amount?: number;
+  asset?: string;
+}
+
 export type AnyJobPayload =
   | PayoutProcessPayload
   | PayoutSettlePayload
@@ -204,4 +215,5 @@ export type AnyJobPayload =
   | MetricsCollectPayload
   | QuestDeadlineCheckPayload
   | QuestCompletionVerifyPayload
-  | DependencyFreshnessCheckPayload;
+  | DependencyFreshnessCheckPayload
+  | ReferralRewardJobPayload;

--- a/BackEnd/src/modules/jobs/jobs.constants.ts
+++ b/BackEnd/src/modules/jobs/jobs.constants.ts
@@ -17,6 +17,7 @@ export const QUEUES = {
   WEBHOOKS: 'webhooks',
   QUESTS: 'quests',
   ERASURE: 'erasure',
+  REFERRALS: 'referrals',
 };
 
 /**
@@ -84,5 +85,10 @@ export const JOB_QUEUE_CONFIG = {
     concurrency: 1,
     priority: 'LOW',
     timeout: 120000, // 2 minutes — bounded by the erasure transaction
+  },
+  [QUEUES.REFERRALS]: {
+    concurrency: 5,
+    priority: 'MEDIUM',
+    timeout: 60000,
   },
 };

--- a/BackEnd/src/modules/jobs/jobs.module.ts
+++ b/BackEnd/src/modules/jobs/jobs.module.ts
@@ -32,6 +32,9 @@ import { DataExport } from '../users/entities/data-export.entity';
 import { DataExportListener } from './listeners/data-export.listener';
 import { AccountErasureListener } from './listeners/account-erasure.listener';
 import { AccountErasureProcessor } from './processors/account-erasure.processor';
+import { ReferralRewardProcessor } from './processors/referral-reward.processor';
+import { Referral } from '../referrals/entities/referral.entity';
+import { ReferralReward } from '../referrals/entities/referral-reward.entity';
 import { Payout } from '../payouts/entities/payout.entity';
 import { PayoutOutbox } from '../payouts/entities/payout-outbox.entity';
 import { Quest } from '../quests/entities/quest.entity';
@@ -63,6 +66,8 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
       Submission,
       EventStore,
       User,
+      Referral,
+      ReferralReward,
       // Needed for IdempotencyService which is used by JobIdempotencyService
       IdempotencyKey,
     ]),
@@ -82,6 +87,11 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
       () =>
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         require('../privacy/privacy.module').PrivacyModule,
+    ),
+    forwardRef(
+      () =>
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../referrals/referrals.module').ReferralsModule,
     ),
   ],
   providers: [
@@ -109,6 +119,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     DataExportListener,
     AccountErasureListener,
     AccountErasureProcessor,
+    ReferralRewardProcessor,
     DependencyFreshnessService,
   ],
   controllers: [JobsController],
@@ -132,6 +143,7 @@ import { IdempotencyService } from '../payouts/services/idempotency.service';
     QuestStateReconciliationProcessor,
     DependencyProcessor,
     AccountErasureProcessor,
+    ReferralRewardProcessor,
     DependencyFreshnessService,
   ],
 })

--- a/BackEnd/src/modules/jobs/jobs.service.ts
+++ b/BackEnd/src/modules/jobs/jobs.service.ts
@@ -15,6 +15,7 @@ import { JobType } from './job.types';
 import { DataExportProcessor } from './processors/export.processor';
 import { PayoutProcessor } from './processors/payout.processor';
 import { AccountErasureProcessor } from './processors/account-erasure.processor';
+import { ReferralRewardProcessor } from './processors/referral-reward.processor';
 import {
   TracingService,
   TraceContext,
@@ -61,6 +62,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     private readonly dataExportProcessor?: DataExportProcessor,
     private readonly payoutProcessor?: PayoutProcessor,
     private readonly accountErasureProcessor?: AccountErasureProcessor,
+    private readonly referralRewardProcessor?: ReferralRewardProcessor,
   ) {}
 
   registerEmailProcessor(
@@ -93,6 +95,10 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     //    jobs can be enqueued via JobsService.addJob(QUEUES.PAYOUTS, ...).
     this.queues[QUEUES.PAYOUTS] = new Queue(QUEUES.PAYOUTS, redisConnection());
     this.queues[QUEUES.ERASURE] = new Queue(QUEUES.ERASURE, redisConnection());
+    this.queues[QUEUES.REFERRALS] = new Queue(
+      QUEUES.REFERRALS,
+      redisConnection(),
+    );
 
     this.createWorker(QUEUES.NOTIFICATIONS, this.handleNotification.bind(this));
     this.createWorker(QUEUES.ANALYTICS, this.handleAnalytics.bind(this));
@@ -131,6 +137,17 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
       this.createWorker(
         QUEUES.ERASURE,
         this.accountErasureProcessor.process.bind(this.accountErasureProcessor),
+      );
+    }
+
+    // ── Wire the ReferralRewardProcessor to the REFERRALS queue ─────────
+    if (
+      this.referralRewardProcessor &&
+      typeof this.referralRewardProcessor.process === 'function'
+    ) {
+      this.createWorker(
+        QUEUES.REFERRALS,
+        this.referralRewardProcessor.process.bind(this.referralRewardProcessor),
       );
     }
   }

--- a/BackEnd/src/modules/jobs/processors/referral-reward.processor.spec.ts
+++ b/BackEnd/src/modules/jobs/processors/referral-reward.processor.spec.ts
@@ -1,0 +1,140 @@
+import { ReferralRewardProcessor } from './referral-reward.processor';
+import { ReferralStatus } from '../../referrals/entities/referral.entity';
+import { ReferralRewardStatus } from '../../referrals/entities/referral-reward.entity';
+
+describe('ReferralRewardProcessor', () => {
+  let processor: ReferralRewardProcessor;
+  let referralRepository: any;
+  let referralRewardRepository: any;
+  let referralsService: any;
+  let usersService: any;
+
+  const mockJob: any = {
+    id: 'job-1',
+    timestamp: Date.now() - 100,
+    data: {
+      referralId: 'ref-1',
+      referrerId: 'user-a',
+      referredUserId: 'user-b',
+      amount: 50,
+      asset: 'XLM',
+    },
+  };
+
+  beforeEach(() => {
+    referralRepository = {
+      findOne: jest.fn(),
+      save: jest.fn((e) => Promise.resolve(e)),
+    };
+    referralRewardRepository = {
+      findOne: jest.fn(),
+      create: jest.fn((dto) => ({ ...dto, id: 'reward-1' })),
+      save: jest.fn((e) => Promise.resolve({ ...e, id: 'reward-1' })),
+    };
+    referralsService = {
+      isCircularAttribution: jest.fn().mockResolvedValue(false),
+      creditReward: jest.fn().mockResolvedValue({
+        id: 'reward-1',
+        referralId: 'ref-1',
+        recipientId: 'user-a',
+        amount: 50,
+        asset: 'XLM',
+        status: ReferralRewardStatus.CREDITED,
+      }),
+    };
+    usersService = {
+      applyReputationDeltaAtomic: jest.fn().mockResolvedValue({}),
+    };
+
+    processor = new ReferralRewardProcessor(
+      referralRepository,
+      referralRewardRepository,
+      referralsService,
+      usersService,
+    );
+  });
+
+  it('successfully processes referral reward job', async () => {
+    referralRepository.findOne.mockResolvedValue({
+      id: 'ref-1',
+      referrerId: 'user-a',
+      referredUserId: 'user-b',
+      status: ReferralStatus.QUALIFIED,
+    });
+
+    const result = await processor.process(mockJob);
+
+    expect(result.success).toBe(true);
+    expect(result.data.rewardId).toBe('reward-1');
+    expect(referralsService.creditReward).toHaveBeenCalledWith(
+      'ref-1',
+      50,
+      'XLM',
+    );
+  });
+
+  it('skips duplicate reward crediting when referral is already REWARDED (idempotency)', async () => {
+    referralRepository.findOne.mockResolvedValue({
+      id: 'ref-1',
+      referrerId: 'user-a',
+      referredUserId: 'user-b',
+      status: ReferralStatus.REWARDED,
+    });
+
+    const result = await processor.process(mockJob);
+
+    expect(result.success).toBe(true);
+    expect(result.data.alreadyRewarded).toBe(true);
+    expect(referralsService.creditReward).not.toHaveBeenCalled();
+  });
+
+  it('rejects self-referral abuse and marks referral REJECTED', async () => {
+    referralRepository.findOne.mockResolvedValue({
+      id: 'ref-1',
+      referrerId: 'user-a',
+      referredUserId: 'user-a', // self referral
+      status: ReferralStatus.QUALIFIED,
+    });
+
+    const result = await processor.process(mockJob);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Self-referral detected');
+    expect(referralRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: ReferralStatus.REJECTED,
+        rejectionReason: 'Self-referral detected',
+      }),
+    );
+    expect(referralsService.creditReward).not.toHaveBeenCalled();
+  });
+
+  it('rejects circular attribution abuse and marks referral REJECTED', async () => {
+    referralRepository.findOne.mockResolvedValue({
+      id: 'ref-1',
+      referrerId: 'user-a',
+      referredUserId: 'user-b',
+      status: ReferralStatus.QUALIFIED,
+    });
+    referralsService.isCircularAttribution.mockResolvedValue(true);
+
+    const result = await processor.process(mockJob);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Circular referral detected');
+    expect(referralRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: ReferralStatus.REJECTED,
+        rejectionReason: 'Circular referral detected',
+      }),
+    );
+  });
+
+  it('throws when referral does not exist', async () => {
+    referralRepository.findOne.mockResolvedValue(null);
+
+    await expect(processor.process(mockJob)).rejects.toThrow(
+      'Referral not found: ref-1',
+    );
+  });
+});

--- a/BackEnd/src/modules/jobs/processors/referral-reward.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/referral-reward.processor.ts
@@ -1,0 +1,176 @@
+import {
+  Injectable,
+  Logger,
+  Optional,
+  Inject,
+  forwardRef,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Job } from 'bullmq';
+import { JobResult } from '../job.types';
+import {
+  Referral,
+  ReferralStatus,
+} from '../../referrals/entities/referral.entity';
+import {
+  ReferralReward,
+  ReferralRewardStatus,
+} from '../../referrals/entities/referral-reward.entity';
+import { ReferralsService } from '../../referrals/referrals.service';
+import { UsersService } from '../../users/users.service';
+
+export interface ReferralRewardPayload {
+  referralId: string;
+  referrerId?: string;
+  referredUserId?: string;
+  amount?: number;
+  asset?: string;
+}
+
+/**
+ * Referral Reward Processor
+ *
+ * Processes referral qualification and credits rewards idempotently.
+ * Performs anti-abuse validation and moves the referral to REWARDED (or REJECTED).
+ */
+@Injectable()
+export class ReferralRewardProcessor {
+  private readonly logger = new Logger(ReferralRewardProcessor.name);
+
+  constructor(
+    @InjectRepository(Referral)
+    private readonly referralRepository: Repository<Referral>,
+    @InjectRepository(ReferralReward)
+    private readonly referralRewardRepository: Repository<ReferralReward>,
+    @Optional()
+    @Inject(forwardRef(() => ReferralsService))
+    private readonly referralsService?: ReferralsService,
+    @Optional()
+    @Inject(forwardRef(() => UsersService))
+    private readonly usersService?: UsersService,
+  ) {}
+
+  async process(job: Job<ReferralRewardPayload>): Promise<JobResult> {
+    const { referralId, amount = 50, asset = 'XLM' } = job.data;
+
+    this.logger.log(
+      `Processing referral reward job ${job.id}: referral=${referralId}, amount=${amount} ${asset}`,
+    );
+
+    try {
+      const referral = await this.referralRepository.findOne({
+        where: { id: referralId },
+      });
+
+      if (!referral) {
+        throw new Error(`Referral not found: ${referralId}`);
+      }
+
+      // Check if already rewarded
+      if (referral.status === ReferralStatus.REWARDED) {
+        this.logger.log(
+          `Referral ${referralId} is already rewarded. Skipping duplicate crediting.`,
+        );
+        return {
+          success: true,
+          data: {
+            referralId,
+            status: ReferralStatus.REWARDED,
+            alreadyRewarded: true,
+          },
+          duration: Date.now() - job.timestamp,
+        };
+      }
+
+      // Anti-abuse: self-referral
+      if (referral.referrerId === referral.referredUserId) {
+        referral.status = ReferralStatus.REJECTED;
+        referral.rejectionReason = 'Self-referral detected';
+        await this.referralRepository.save(referral);
+        this.logger.warn(
+          `Rejected referral ${referralId}: Self-referral detected`,
+        );
+        return {
+          success: false,
+          error: 'Self-referral detected',
+          data: { referralId, status: ReferralStatus.REJECTED },
+          duration: Date.now() - job.timestamp,
+        };
+      }
+
+      // Anti-abuse: circular attribution
+      const isCircular = this.referralsService
+        ? await this.referralsService.isCircularAttribution(
+            referral.referrerId,
+            referral.referredUserId,
+          )
+        : false;
+      if (isCircular) {
+        referral.status = ReferralStatus.REJECTED;
+        referral.rejectionReason = 'Circular referral detected';
+        await this.referralRepository.save(referral);
+        this.logger.warn(
+          `Rejected referral ${referralId}: Circular referral detected`,
+        );
+        return {
+          success: false,
+          error: 'Circular referral detected',
+          data: { referralId, status: ReferralStatus.REJECTED },
+          duration: Date.now() - job.timestamp,
+        };
+      }
+
+      // Credit reward idempotently
+      let reward: ReferralReward;
+      if (this.referralsService) {
+        reward = await this.referralsService.creditReward(
+          referralId,
+          amount,
+          asset,
+        );
+      } else {
+        const idempotencyKey = `referral-reward:${referral.id}`;
+        const existing = await this.referralRewardRepository.findOne({
+          where: { idempotencyKey },
+        });
+        if (existing) {
+          reward = existing;
+        } else {
+          reward = this.referralRewardRepository.create({
+            referralId: referral.id,
+            recipientId: referral.referrerId,
+            amount,
+            asset,
+            status: ReferralRewardStatus.CREDITED,
+            idempotencyKey,
+            notes: `Referral reward for user ${referral.referredUserId}`,
+          });
+          reward = await this.referralRewardRepository.save(reward);
+          referral.status = ReferralStatus.REWARDED;
+          referral.rewardedAt = new Date();
+          await this.referralRepository.save(referral);
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          referralId,
+          rewardId: reward.id,
+          recipientId: reward.recipientId,
+          amount: reward.amount,
+          asset: reward.asset,
+          status: ReferralStatus.REWARDED,
+        },
+        duration: Date.now() - job.timestamp,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error processing referral reward for referral ${referralId}: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+}

--- a/BackEnd/src/modules/jobs/services/job-scheduler.service.ts
+++ b/BackEnd/src/modules/jobs/services/job-scheduler.service.ts
@@ -478,6 +478,7 @@ export class JobSchedulerService implements OnModuleInit, OnModuleDestroy {
       [JobType.DEPENDENCY_FRESHNESS_CHECK]: 'maintenance',
       [JobType.QUEST_STATE_RECONCILE]: 'quests',
       [JobType.ACCOUNT_ERASURE]: 'erasure',
+      [JobType.REFERRAL_REWARD]: 'referrals',
     };
     return queueMap[jobType] || 'default';
   }

--- a/BackEnd/src/modules/referrals/CHANGELOG.md
+++ b/BackEnd/src/modules/referrals/CHANGELOG.md
@@ -1,0 +1,19 @@
+# referrals module changelog
+
+All notable changes to the `referrals` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Created `referrals` backend module with `ReferralsService`, `ReferralsController`, and `ReferralsModule`.
+- Implemented stable, unique referral code generation per user (`generateReferralCode` and `getReferralCode`).
+- Implemented referral attribution during signup with full anti-abuse protection (rejection of self-referral, duplicate attributions, and circular chains of any depth).
+- Added `Referral` entity tracking `referrerId`, `referredUserId`, `code`, `status` (`PENDING`, `QUALIFIED`, `REWARDED`, `REJECTED`), `rejectionReason`, `qualifiedAt`, and `rewardedAt`.
+- Added `ReferralReward` ledger entity storing idempotent reward disbursements (`CREDITED`, `FAILED`, `REJECTED`, `PENDING`).
+- Added database migration `1870000000000-add-referrals.ts` defining PostgreSQL tables, enums, and optimized indexes.
+- Added API endpoints: `GET /referrals/code`, `GET /referrals`, `GET /referrals/rewards`, `GET /referrals/stats`, and `POST /referrals/attribute`.
+- Implemented milestone qualification hook `handleQualifyingSubmission` transitioning pending referrals to `QUALIFIED` on first approved submission and enqueuing reward jobs.
+- Implemented idempotent reward crediting in `creditReward` with idempotency keys.
+- Comprehensive unit and integration test coverage (`referrals.service.spec.ts`, `referrals.controller.spec.ts`, `referrals.integration.spec.ts`).

--- a/BackEnd/src/modules/referrals/dto/referral.dto.ts
+++ b/BackEnd/src/modules/referrals/dto/referral.dto.ts
@@ -1,0 +1,138 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+import { ReferralStatus } from '../entities/referral.entity';
+import { ReferralRewardStatus } from '../entities/referral-reward.entity';
+
+export class ReferralCodeResponseDto {
+  @ApiProperty({
+    description: 'Unique referral code for the user',
+    example: 'REF-A1B2C3D4',
+  })
+  code: string;
+
+  @ApiProperty({
+    description: 'Full referral link that can be shared',
+    example: 'https://stellarearn.com/signup?ref=REF-A1B2C3D4',
+  })
+  referralLink: string;
+
+  @ApiProperty({
+    description: 'Owner user ID of the referral code',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  referrerId: string;
+}
+
+export class ReferralItemDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174001' })
+  referredUserId: string;
+
+  @ApiProperty({ example: 'REF-A1B2C3D4' })
+  code: string;
+
+  @ApiProperty({ enum: ReferralStatus, example: ReferralStatus.PENDING })
+  status: ReferralStatus;
+
+  @ApiPropertyOptional({ nullable: true, example: null })
+  rejectionReason?: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  qualifiedAt?: Date | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  rewardedAt?: Date | null;
+
+  @ApiProperty()
+  createdAt: Date;
+}
+
+export class ReferralListResponseDto {
+  @ApiProperty({ type: [ReferralItemDto] })
+  referrals: ReferralItemDto[];
+
+  @ApiProperty({ example: 5 })
+  total: number;
+
+  @ApiProperty({ example: 2 })
+  pending: number;
+
+  @ApiProperty({ example: 1 })
+  qualified: number;
+
+  @ApiProperty({ example: 2 })
+  rewarded: number;
+}
+
+export class ReferralRewardItemDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174001' })
+  referralId: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174002' })
+  recipientId: string;
+
+  @ApiProperty({ example: 50 })
+  amount: number | string;
+
+  @ApiProperty({ example: 'XLM' })
+  asset: string;
+
+  @ApiProperty({
+    enum: ReferralRewardStatus,
+    example: ReferralRewardStatus.CREDITED,
+  })
+  status: ReferralRewardStatus;
+
+  @ApiProperty({
+    example: 'referral-reward:123e4567-e89b-12d3-a456-426614174001',
+  })
+  idempotencyKey: string;
+
+  @ApiProperty()
+  createdAt: Date;
+}
+
+export class ReferralRewardsResponseDto {
+  @ApiProperty({ type: [ReferralRewardItemDto] })
+  rewards: ReferralRewardItemDto[];
+
+  @ApiProperty({ example: 100 })
+  totalAmount: number;
+
+  @ApiProperty({ example: 2 })
+  totalRewards: number;
+}
+
+export class AttributeReferralDto {
+  @ApiProperty({
+    description: 'Referral code provided during invitation attribution',
+    example: 'REF-A1B2C3D4',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(3)
+  @MaxLength(64)
+  code: string;
+}
+
+export class ReferralStatsResponseDto {
+  @ApiProperty({ example: 5 })
+  totalReferrals: number;
+
+  @ApiProperty({ example: 2 })
+  pendingReferrals: number;
+
+  @ApiProperty({ example: 1 })
+  qualifiedReferrals: number;
+
+  @ApiProperty({ example: 2 })
+  rewardedReferrals: number;
+
+  @ApiProperty({ example: 100 })
+  totalRewardsCredited: number;
+}

--- a/BackEnd/src/modules/referrals/entities/referral-reward.entity.ts
+++ b/BackEnd/src/modules/referrals/entities/referral-reward.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Referral } from './referral.entity';
+
+export enum ReferralRewardStatus {
+  PENDING = 'PENDING',
+  CREDITED = 'CREDITED',
+  FAILED = 'FAILED',
+  REJECTED = 'REJECTED',
+}
+
+@Entity('referral_rewards')
+@Index('idx_referral_rewards_recipient', ['recipientId'])
+@Index('idx_referral_rewards_referral', ['referralId'])
+@Index('idx_referral_rewards_idempotency_key', ['idempotencyKey'], {
+  unique: true,
+})
+export class ReferralReward {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  referralId: string;
+
+  @ManyToOne(() => Referral, (referral) => referral.rewards, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'referralId' })
+  referral: Referral;
+
+  @Column({ type: 'uuid' })
+  recipientId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'recipientId' })
+  recipient: User;
+
+  @Column({ type: 'numeric', precision: 18, scale: 7, default: 50 })
+  amount: number | string;
+
+  @Column({ type: 'varchar', length: 32, default: 'XLM' })
+  asset: string;
+
+  @Column({
+    type: 'enum',
+    enum: ReferralRewardStatus,
+    default: ReferralRewardStatus.CREDITED,
+  })
+  status: ReferralRewardStatus;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  idempotencyKey: string;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/BackEnd/src/modules/referrals/entities/referral.entity.ts
+++ b/BackEnd/src/modules/referrals/entities/referral.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { ReferralReward } from './referral-reward.entity';
+
+export enum ReferralStatus {
+  PENDING = 'PENDING',
+  QUALIFIED = 'QUALIFIED',
+  REWARDED = 'REWARDED',
+  REJECTED = 'REJECTED',
+}
+
+@Entity('referrals')
+@Index('idx_referrals_referrer_status', ['referrerId', 'status'])
+@Index('idx_referrals_referred_user', ['referredUserId'], { unique: true })
+@Index('idx_referrals_code', ['code'])
+export class Referral {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  referrerId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'referrerId' })
+  referrer: User;
+
+  @Column({ type: 'uuid', unique: true })
+  referredUserId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'referredUserId' })
+  referredUser: User;
+
+  @Column({ type: 'varchar', length: 64 })
+  code: string;
+
+  @Column({
+    type: 'enum',
+    enum: ReferralStatus,
+    default: ReferralStatus.PENDING,
+  })
+  status: ReferralStatus;
+
+  @Column({ type: 'text', nullable: true })
+  rejectionReason: string | null;
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  qualifiedAt: Date | null;
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  rewardedAt: Date | null;
+
+  @OneToMany(() => ReferralReward, (reward) => reward.referral)
+  rewards: ReferralReward[];
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/BackEnd/src/modules/referrals/referrals.controller.spec.ts
+++ b/BackEnd/src/modules/referrals/referrals.controller.spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReferralsController } from './referrals.controller';
+import { ReferralsService } from './referrals.service';
+import { ReferralStatus } from './entities/referral.entity';
+import { ReferralRewardStatus } from './entities/referral-reward.entity';
+import type { AuthUser } from '../auth/auth.service';
+
+describe('ReferralsController', () => {
+  let controller: ReferralsController;
+  let service: ReferralsService;
+
+  const mockUser: AuthUser = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    stellarAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    role: 'USER',
+  };
+
+  const mockReferralsService = {
+    getReferralCode: jest.fn(() => ({
+      code: 'REF-123E4567',
+      referralLink: 'https://stellarearn.com/signup?ref=REF-123E4567',
+      referrerId: mockUser.id,
+    })),
+    getReferralsForUser: jest.fn(() =>
+      Promise.resolve({
+        referrals: [
+          {
+            id: 'ref-1',
+            referredUserId: 'user-2',
+            code: 'REF-123E4567',
+            status: ReferralStatus.PENDING,
+            rejectionReason: null,
+            qualifiedAt: null,
+            rewardedAt: null,
+            createdAt: new Date(),
+          },
+        ],
+        total: 1,
+        pending: 1,
+        qualified: 0,
+        rewarded: 0,
+      }),
+    ),
+    getRewardsForUser: jest.fn(() =>
+      Promise.resolve({
+        rewards: [
+          {
+            id: 'reward-1',
+            referralId: 'ref-1',
+            recipientId: mockUser.id,
+            amount: 50,
+            asset: 'XLM',
+            status: ReferralRewardStatus.CREDITED,
+            idempotencyKey: 'referral-reward:ref-1',
+            createdAt: new Date(),
+          },
+        ],
+        totalAmount: 50,
+        totalRewards: 1,
+      }),
+    ),
+    getReferralStats: jest.fn(() =>
+      Promise.resolve({
+        totalReferrals: 1,
+        pendingReferrals: 1,
+        qualifiedReferrals: 0,
+        rewardedReferrals: 0,
+        totalRewardsCredited: 0,
+      }),
+    ),
+    recordAttribution: jest.fn(() =>
+      Promise.resolve({
+        id: 'new-ref-id',
+        status: ReferralStatus.PENDING,
+        code: 'REF-99999999',
+      }),
+    ),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReferralsController],
+      providers: [
+        {
+          provide: ReferralsService,
+          useValue: mockReferralsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ReferralsController>(ReferralsController);
+    service = module.get<ReferralsService>(ReferralsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('returns my referral code and link', () => {
+    const result = controller.getMyReferralCode(mockUser);
+    expect(result.code).toBe('REF-123E4567');
+    expect(service.getReferralCode).toHaveBeenCalledWith(mockUser);
+  });
+
+  it('returns my referrals list and status breakdown', async () => {
+    const result = await controller.getMyReferrals(mockUser);
+    expect(result.total).toBe(1);
+    expect(result.pending).toBe(1);
+    expect(service.getReferralsForUser).toHaveBeenCalledWith(mockUser.id);
+  });
+
+  it('returns my credited rewards ledger', async () => {
+    const result = await controller.getMyRewards(mockUser);
+    expect(result.totalAmount).toBe(50);
+    expect(service.getRewardsForUser).toHaveBeenCalledWith(mockUser.id);
+  });
+
+  it('returns my referral statistics', async () => {
+    const result = await controller.getMyStats(mockUser);
+    expect(result.totalReferrals).toBe(1);
+    expect(service.getReferralStats).toHaveBeenCalledWith(mockUser.id);
+  });
+
+  it('attributes a referral code for current user', async () => {
+    const result = await controller.attributeReferral(
+      { code: 'REF-99999999' },
+      mockUser,
+    );
+    expect(result.success).toBe(true);
+    expect(result.referralId).toBe('new-ref-id');
+    expect(service.recordAttribution).toHaveBeenCalledWith(
+      mockUser.id,
+      'REF-99999999',
+    );
+  });
+});

--- a/BackEnd/src/modules/referrals/referrals.controller.ts
+++ b/BackEnd/src/modules/referrals/referrals.controller.ts
@@ -1,0 +1,152 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { AuthUser } from '../auth/auth.service';
+import { ReferralsService } from './referrals.service';
+import {
+  AttributeReferralDto,
+  ReferralCodeResponseDto,
+  ReferralListResponseDto,
+  ReferralRewardsResponseDto,
+  ReferralStatsResponseDto,
+} from './dto/referral.dto';
+
+@ApiTags('referrals')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('referrals')
+export class ReferralsController {
+  constructor(private readonly referralsService: ReferralsService) {}
+
+  @Get('code')
+  @ApiOperation({
+    summary: 'Get my unique referral code and sharable invitation link',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Referral code and invitation link retrieved successfully',
+    type: ReferralCodeResponseDto,
+  })
+  getMyReferralCode(@CurrentUser() user: AuthUser): ReferralCodeResponseDto {
+    return this.referralsService.getReferralCode(user);
+  }
+
+  @Get('my-code')
+  @ApiOperation({
+    summary: 'Alias for getting my referral code and link',
+  })
+  @ApiResponse({
+    status: 200,
+    type: ReferralCodeResponseDto,
+  })
+  getMyReferralCodeAlias(
+    @CurrentUser() user: AuthUser,
+  ): ReferralCodeResponseDto {
+    return this.referralsService.getReferralCode(user);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'List my referred users and their qualification/reward status',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of referrals retrieved successfully',
+    type: ReferralListResponseDto,
+  })
+  getMyReferrals(
+    @CurrentUser() user: AuthUser,
+  ): Promise<ReferralListResponseDto> {
+    return this.referralsService.getReferralsForUser(user.id);
+  }
+
+  @Get('my-referrals')
+  @ApiOperation({
+    summary: 'Alias for listing my referrals',
+  })
+  @ApiResponse({
+    status: 200,
+    type: ReferralListResponseDto,
+  })
+  getMyReferralsAlias(
+    @CurrentUser() user: AuthUser,
+  ): Promise<ReferralListResponseDto> {
+    return this.referralsService.getReferralsForUser(user.id);
+  }
+
+  @Get('rewards')
+  @ApiOperation({
+    summary: 'View credited referral rewards ledger',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Reward ledger retrieved successfully',
+    type: ReferralRewardsResponseDto,
+  })
+  getMyRewards(
+    @CurrentUser() user: AuthUser,
+  ): Promise<ReferralRewardsResponseDto> {
+    return this.referralsService.getRewardsForUser(user.id);
+  }
+
+  @Get('stats')
+  @ApiOperation({
+    summary: 'Get referral performance statistics',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Referral stats retrieved successfully',
+    type: ReferralStatsResponseDto,
+  })
+  getMyStats(@CurrentUser() user: AuthUser): Promise<ReferralStatsResponseDto> {
+    return this.referralsService.getReferralStats(user.id);
+  }
+
+  @Post('attribute')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Record a referral code attribution for the current user',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Referral attribution successfully recorded',
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Invalid referral code, self-referral, or circular attribution',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'User has already been referred',
+  })
+  async attributeReferral(
+    @Body() dto: AttributeReferralDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const referral = await this.referralsService.recordAttribution(
+      user.id,
+      dto.code,
+    );
+    return {
+      success: true,
+      referralId: referral.id,
+      status: referral.status,
+      code: referral.code,
+    };
+  }
+}

--- a/BackEnd/src/modules/referrals/referrals.module.ts
+++ b/BackEnd/src/modules/referrals/referrals.module.ts
@@ -1,0 +1,21 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Referral } from './entities/referral.entity';
+import { ReferralReward } from './entities/referral-reward.entity';
+import { User } from '../users/entities/user.entity';
+import { ReferralsService } from './referrals.service';
+import { ReferralsController } from './referrals.controller';
+import { UsersModule } from '../users/users.module';
+import { JobsModule } from '../jobs/jobs.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Referral, ReferralReward, User]),
+    forwardRef(() => UsersModule),
+    forwardRef(() => JobsModule),
+  ],
+  controllers: [ReferralsController],
+  providers: [ReferralsService],
+  exports: [ReferralsService],
+})
+export class ReferralsModule {}

--- a/BackEnd/src/modules/referrals/referrals.service.spec.ts
+++ b/BackEnd/src/modules/referrals/referrals.service.spec.ts
@@ -1,0 +1,479 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ReferralsService } from './referrals.service';
+import { Referral, ReferralStatus } from './entities/referral.entity';
+import {
+  ReferralReward,
+  ReferralRewardStatus,
+} from './entities/referral-reward.entity';
+import { User } from '../users/entities/user.entity';
+
+describe('ReferralsService', () => {
+  let service: ReferralsService;
+  let referralsRepository: any;
+  let referralRewardsRepository: any;
+  let usersRepository: any;
+  let configService: any;
+  let usersService: any;
+  let jobsService: any;
+  let eventEmitter: any;
+
+  const mockUserA: User = {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    username: 'userA',
+    stellarAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  } as any;
+
+  const mockUserB: User = {
+    id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    username: 'userB',
+    stellarAddress: 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+  } as any;
+
+  const mockUserC: User = {
+    id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    username: 'userC',
+    stellarAddress: 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+  } as any;
+
+  beforeEach(() => {
+    referralsRepository = {
+      create: jest.fn((dto) => ({ ...dto, id: 'mock-referral-id' })),
+      save: jest.fn((entity) =>
+        Promise.resolve({
+          ...entity,
+          id: entity.id || 'mock-referral-id',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      ),
+      findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+    };
+
+    referralRewardsRepository = {
+      create: jest.fn((dto) => ({ ...dto, id: 'mock-reward-id' })),
+      save: jest.fn((entity) =>
+        Promise.resolve({
+          ...entity,
+          id: entity.id || 'mock-reward-id',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      ),
+      findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+    };
+
+    usersRepository = {
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn(),
+      })),
+    };
+
+    configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'APP_URL') return 'https://stellarearn.com';
+        return undefined;
+      }),
+    };
+
+    usersService = {
+      applyReputationDeltaAtomic: jest.fn().mockResolvedValue({}),
+    };
+
+    jobsService = {
+      addJob: jest.fn().mockResolvedValue({ id: 'job-123' }),
+    };
+
+    eventEmitter = {
+      emit: jest.fn(),
+    };
+
+    service = new ReferralsService(
+      referralsRepository,
+      referralRewardsRepository,
+      usersRepository,
+      configService,
+      usersService,
+      jobsService,
+      eventEmitter,
+    );
+  });
+
+  describe('generateReferralCode & getReferralCode', () => {
+    it('generates a stable, unique referral code from user ID', () => {
+      const codeA = service.generateReferralCode(mockUserA.id);
+      expect(codeA).toBe('REF-AAAAAAAA');
+
+      const codeB = service.generateReferralCode(mockUserB.id);
+      expect(codeB).toBe('REF-BBBBBBBB');
+
+      const response = service.getReferralCode(mockUserA);
+      expect(response.code).toBe('REF-AAAAAAAA');
+      expect(response.referralLink).toBe(
+        'https://stellarearn.com/signup?ref=REF-AAAAAAAA',
+      );
+      expect(response.referrerId).toBe(mockUserA.id);
+    });
+  });
+
+  describe('resolveCode', () => {
+    it('resolves a referral code by user ID prefix', async () => {
+      usersRepository.createQueryBuilder = jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockUserA),
+      }));
+
+      const resolved = await service.resolveCode('REF-AAAAAAAA');
+      expect(resolved).toEqual(mockUserA);
+    });
+
+    it('resolves by username if prefix query is empty', async () => {
+      usersRepository.createQueryBuilder = jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      }));
+      usersRepository.findOne = jest.fn().mockResolvedValue(mockUserB);
+
+      const resolved = await service.resolveCode('userB');
+      expect(resolved).toEqual(mockUserB);
+    });
+
+    it('returns null for unknown referral code', async () => {
+      usersRepository.createQueryBuilder = jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      }));
+      usersRepository.findOne = jest.fn().mockResolvedValue(null);
+
+      const resolved = await service.resolveCode('REF-UNKNOWN');
+      expect(resolved).toBeNull();
+    });
+  });
+
+  describe('isCircularAttribution', () => {
+    it('detects self-loop (A -> A)', async () => {
+      const isCircular = await service.isCircularAttribution(
+        mockUserA.id,
+        mockUserA.id,
+      );
+      expect(isCircular).toBe(true);
+    });
+
+    it('detects direct 2-node circular attribution (A -> B -> A)', async () => {
+      // User B was referred by User A
+      referralsRepository.findOne.mockImplementation(({ where }: any) => {
+        if (where.referredUserId === mockUserB.id) {
+          return Promise.resolve({
+            id: 'ref-1',
+            referrerId: mockUserA.id,
+            referredUserId: mockUserB.id,
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      // Now User B tries to refer User A
+      const isCircular = await service.isCircularAttribution(
+        mockUserB.id,
+        mockUserA.id,
+      );
+      expect(isCircular).toBe(true);
+    });
+
+    it('detects transitive 3-node circular attribution (A -> B -> C -> A)', async () => {
+      // User B was referred by A; User C was referred by B
+      referralsRepository.findOne.mockImplementation(({ where }: any) => {
+        if (where.referredUserId === mockUserC.id) {
+          return Promise.resolve({
+            id: 'ref-bc',
+            referrerId: mockUserB.id,
+            referredUserId: mockUserC.id,
+          });
+        }
+        if (where.referredUserId === mockUserB.id) {
+          return Promise.resolve({
+            id: 'ref-ab',
+            referrerId: mockUserA.id,
+            referredUserId: mockUserB.id,
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      // User C tries to refer User A
+      const isCircular = await service.isCircularAttribution(
+        mockUserC.id,
+        mockUserA.id,
+      );
+      expect(isCircular).toBe(true);
+    });
+
+    it('allows valid acyclic referral chain (A -> B, B -> C, C -> D)', async () => {
+      referralsRepository.findOne.mockImplementation(({ where }: any) => {
+        if (where.referredUserId === mockUserC.id) {
+          return Promise.resolve({
+            id: 'ref-bc',
+            referrerId: mockUserB.id,
+            referredUserId: mockUserC.id,
+          });
+        }
+        if (where.referredUserId === mockUserB.id) {
+          return Promise.resolve({
+            id: 'ref-ab',
+            referrerId: mockUserA.id,
+            referredUserId: mockUserB.id,
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      // User C referring a new User D
+      const isCircular = await service.isCircularAttribution(
+        mockUserC.id,
+        'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      );
+      expect(isCircular).toBe(false);
+    });
+  });
+
+  describe('recordAttribution', () => {
+    it('successfully records pending attribution for a new referred user', async () => {
+      jest.spyOn(service, 'resolveCode').mockResolvedValue(mockUserA);
+      referralsRepository.findOne.mockResolvedValue(null);
+
+      const referral = await service.recordAttribution(
+        mockUserB.id,
+        'REF-AAAAAAAA',
+      );
+
+      expect(referral.referrerId).toBe(mockUserA.id);
+      expect(referral.referredUserId).toBe(mockUserB.id);
+      expect(referral.status).toBe(ReferralStatus.PENDING);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'referral.created',
+        expect.objectContaining({
+          referrerId: mockUserA.id,
+          referredUserId: mockUserB.id,
+        }),
+      );
+    });
+
+    it('rejects empty referral code', async () => {
+      await expect(service.recordAttribution(mockUserB.id, '')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects invalid/unrecognized referral code', async () => {
+      jest.spyOn(service, 'resolveCode').mockResolvedValue(null);
+      referralsRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.recordAttribution(mockUserB.id, 'REF-INVALID'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects self-referral (referring yourself)', async () => {
+      jest.spyOn(service, 'resolveCode').mockResolvedValue(mockUserA);
+      referralsRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.recordAttribution(mockUserA.id, 'REF-AAAAAAAA'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects duplicate attribution when user was already referred', async () => {
+      referralsRepository.findOne.mockResolvedValue({
+        id: 'existing-ref',
+        referredUserId: mockUserB.id,
+      });
+
+      await expect(
+        service.recordAttribution(mockUserB.id, 'REF-AAAAAAAA'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects circular attribution', async () => {
+      jest.spyOn(service, 'resolveCode').mockResolvedValue(mockUserB);
+      referralsRepository.findOne.mockResolvedValueOnce(null); // not referred yet as User A
+      jest.spyOn(service, 'isCircularAttribution').mockResolvedValue(true);
+
+      await expect(
+        service.recordAttribution(mockUserA.id, 'REF-BBBBBBBB'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('handleQualifyingSubmission', () => {
+    it('qualifies a pending referral and enqueues reward processing job', async () => {
+      const pendingReferral: Referral = {
+        id: 'ref-100',
+        referrerId: mockUserA.id,
+        referredUserId: mockUserB.id,
+        code: 'REF-AAAAAAAA',
+        status: ReferralStatus.PENDING,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any;
+
+      referralsRepository.findOne.mockResolvedValue(pendingReferral);
+
+      const result = await service.handleQualifyingSubmission(
+        mockUserB.id,
+        'submission-999',
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.status).toBe(ReferralStatus.QUALIFIED);
+      expect(result?.qualifiedAt).toBeInstanceOf(Date);
+      expect(jobsService.addJob).toHaveBeenCalledWith(
+        'referrals',
+        expect.objectContaining({
+          referralId: 'ref-100',
+          referrerId: mockUserA.id,
+          referredUserId: mockUserB.id,
+        }),
+        {},
+        'referral:reward',
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'referral.qualified',
+        expect.objectContaining({
+          referralId: 'ref-100',
+          submissionId: 'submission-999',
+        }),
+      );
+    });
+
+    it('returns null if the user was not referred or already qualified', async () => {
+      referralsRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.handleQualifyingSubmission(
+        mockUserC.id,
+        'sub-1',
+      );
+      expect(result).toBeNull();
+      expect(jobsService.addJob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('creditReward', () => {
+    it('idempotently credits referral reward to referrer and updates status to REWARDED', async () => {
+      const qualifiedReferral: Referral = {
+        id: 'ref-200',
+        referrerId: mockUserA.id,
+        referredUserId: mockUserB.id,
+        code: 'REF-AAAAAAAA',
+        status: ReferralStatus.QUALIFIED,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any;
+
+      referralsRepository.findOne.mockResolvedValue(qualifiedReferral);
+      referralRewardsRepository.findOne.mockResolvedValue(null); // not credited yet
+
+      const reward = await service.creditReward('ref-200', 50, 'XLM');
+
+      expect(reward).toBeDefined();
+      expect(reward.status).toBe(ReferralRewardStatus.CREDITED);
+      expect(reward.amount).toBe(50);
+      expect(reward.idempotencyKey).toBe('referral-reward:ref-200');
+      expect(qualifiedReferral.status).toBe(ReferralStatus.REWARDED);
+      expect(qualifiedReferral.rewardedAt).toBeInstanceOf(Date);
+      expect(usersService.applyReputationDeltaAtomic).toHaveBeenCalledWith(
+        mockUserA.id,
+        50,
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'referral.rewarded',
+        expect.objectContaining({
+          referralId: 'ref-200',
+          recipientId: mockUserA.id,
+          amount: 50,
+        }),
+      );
+    });
+
+    it('returns existing reward without double-crediting when called multiple times (idempotency)', async () => {
+      const rewardedReferral: Referral = {
+        id: 'ref-200',
+        referrerId: mockUserA.id,
+        referredUserId: mockUserB.id,
+        status: ReferralStatus.REWARDED,
+        rewardedAt: new Date(),
+      } as any;
+
+      const existingReward: ReferralReward = {
+        id: 'reward-already-credited',
+        referralId: 'ref-200',
+        recipientId: mockUserA.id,
+        amount: 50,
+        asset: 'XLM',
+        status: ReferralRewardStatus.CREDITED,
+        idempotencyKey: 'referral-reward:ref-200',
+      } as any;
+
+      referralsRepository.findOne.mockResolvedValue(rewardedReferral);
+      referralRewardsRepository.findOne.mockResolvedValue(existingReward);
+
+      const reward = await service.creditReward('ref-200', 50, 'XLM');
+
+      expect(reward).toBe(existingReward);
+      expect(referralRewardsRepository.create).not.toHaveBeenCalled();
+      expect(usersService.applyReputationDeltaAtomic).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException if referral does not exist', async () => {
+      referralsRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.creditReward('non-existent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('query methods', () => {
+    it('getReferralsForUser calculates correct status counts', async () => {
+      referralsRepository.find.mockResolvedValue([
+        { id: '1', status: ReferralStatus.PENDING, code: 'REF-A' },
+        { id: '2', status: ReferralStatus.QUALIFIED, code: 'REF-A' },
+        { id: '3', status: ReferralStatus.REWARDED, code: 'REF-A' },
+      ]);
+
+      const res = await service.getReferralsForUser(mockUserA.id);
+      expect(res.total).toBe(3);
+      expect(res.pending).toBe(1);
+      expect(res.qualified).toBe(1);
+      expect(res.rewarded).toBe(1);
+      expect(res.referrals.length).toBe(3);
+    });
+
+    it('getRewardsForUser calculates total reward sum', async () => {
+      referralRewardsRepository.find.mockResolvedValue([
+        {
+          id: '1',
+          amount: '50',
+          asset: 'XLM',
+          status: ReferralRewardStatus.CREDITED,
+        },
+        {
+          id: '2',
+          amount: 50,
+          asset: 'XLM',
+          status: ReferralRewardStatus.CREDITED,
+        },
+      ]);
+
+      const res = await service.getRewardsForUser(mockUserA.id);
+      expect(res.totalRewards).toBe(2);
+      expect(res.totalAmount).toBe(100);
+    });
+  });
+});

--- a/BackEnd/src/modules/referrals/referrals.service.ts
+++ b/BackEnd/src/modules/referrals/referrals.service.ts
@@ -1,0 +1,526 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+  forwardRef,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Repository } from 'typeorm';
+import { Referral, ReferralStatus } from './entities/referral.entity';
+import {
+  ReferralReward,
+  ReferralRewardStatus,
+} from './entities/referral-reward.entity';
+import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
+import { JobsService } from '../jobs/jobs.service';
+import { QUEUES } from '../jobs/jobs.constants';
+import { JobType } from '../jobs/job.types';
+import {
+  ReferralCodeResponseDto,
+  ReferralListResponseDto,
+  ReferralRewardsResponseDto,
+  ReferralStatsResponseDto,
+} from './dto/referral.dto';
+
+@Injectable()
+export class ReferralsService {
+  private readonly logger = new Logger(ReferralsService.name);
+
+  constructor(
+    @InjectRepository(Referral)
+    private readonly referralsRepository: Repository<Referral>,
+    @InjectRepository(ReferralReward)
+    private readonly referralRewardsRepository: Repository<ReferralReward>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    private readonly configService: ConfigService,
+    @Optional()
+    @Inject(forwardRef(() => UsersService))
+    private readonly usersService?: UsersService,
+    @Optional()
+    @Inject(forwardRef(() => JobsService))
+    private readonly jobsService?: JobsService,
+    @Optional()
+    private readonly eventEmitter?: EventEmitter2,
+  ) {}
+
+  /**
+   * Generates a stable, unique referral code for a user based on their ID.
+   */
+  generateReferralCode(userId: string): string {
+    const cleanId = userId.replace(/-/g, '').toUpperCase();
+    const slice =
+      cleanId.length >= 8 ? cleanId.slice(0, 8) : cleanId.padEnd(8, '0');
+    return `REF-${slice}`;
+  }
+
+  /**
+   * Returns referral code and sharable invitation link for the authenticated user.
+   */
+  getReferralCode(user: { id: string }): ReferralCodeResponseDto {
+    const code = this.generateReferralCode(user.id);
+    const baseUrl =
+      this.configService.get<string>('APP_URL') ||
+      process.env.APP_URL ||
+      'https://stellarearn.com';
+    const referralLink = `${baseUrl.replace(/\/$/, '')}/signup?ref=${code}`;
+
+    return {
+      code,
+      referralLink,
+      referrerId: user.id,
+    };
+  }
+
+  /**
+   * Resolves a referral code to its owning User entity.
+   */
+  async resolveCode(code: string): Promise<User | null> {
+    if (!code || typeof code !== 'string') {
+      return null;
+    }
+
+    const trimmed = code.trim();
+    if (!trimmed) return null;
+
+    let searchPrefix = trimmed;
+    if (trimmed.toUpperCase().startsWith('REF-')) {
+      searchPrefix = trimmed.slice(4).trim();
+    }
+
+    // 1. Match by user ID prefix
+    if (searchPrefix.length >= 4) {
+      const userByPrefix = await this.usersRepository
+        .createQueryBuilder('user')
+        .where("UPPER(REPLACE(user.id::text, '-', '')) LIKE :prefix", {
+          prefix: `${searchPrefix.toUpperCase()}%`,
+        })
+        .getOne();
+
+      if (userByPrefix) {
+        return userByPrefix;
+      }
+    }
+
+    // 2. Match by exact username
+    const userByUsername = await this.usersRepository.findOne({
+      where: { username: trimmed },
+    });
+    if (userByUsername) {
+      return userByUsername;
+    }
+
+    // 3. Match by exact stellarAddress
+    if (trimmed.length === 56 && trimmed.startsWith('G')) {
+      const userByAddress = await this.usersRepository.findOne({
+        where: { stellarAddress: trimmed },
+      });
+      if (userByAddress) {
+        return userByAddress;
+      }
+    }
+
+    // 4. Match by exact user ID
+    if (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        trimmed,
+      )
+    ) {
+      const userById = await this.usersRepository.findOne({
+        where: { id: trimmed },
+      });
+      if (userById) {
+        return userById;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Checks if attributing `referrerId` as the referrer for `candidateReferredUserId`
+   * would introduce a circular referral relationship of any depth.
+   */
+  async isCircularAttribution(
+    referrerId: string,
+    candidateReferredUserId: string,
+  ): Promise<boolean> {
+    if (referrerId === candidateReferredUserId) {
+      return true;
+    }
+
+    const visited = new Set<string>();
+    let currentId: string | null = referrerId;
+
+    while (currentId) {
+      if (currentId === candidateReferredUserId) {
+        return true;
+      }
+
+      if (visited.has(currentId)) {
+        break;
+      }
+      visited.add(currentId);
+
+      const parentReferral = await this.referralsRepository.findOne({
+        where: { referredUserId: currentId },
+      });
+
+      if (!parentReferral) {
+        break;
+      }
+
+      currentId = parentReferral.referrerId;
+    }
+
+    return false;
+  }
+
+  /**
+   * Records a pending attribution for a referred user using a referral code.
+   * Performs anti-abuse checks: rejection of self-referrals, duplicate attributions,
+   * and circular chains.
+   */
+  async recordAttribution(
+    referredUserId: string,
+    referralCode: string,
+  ): Promise<Referral> {
+    if (!referralCode || !referralCode.trim()) {
+      throw new BadRequestException('Referral code is required');
+    }
+
+    // Duplicate check: each user can be referred at most once
+    const existing = await this.referralsRepository.findOne({
+      where: { referredUserId },
+    });
+    if (existing) {
+      throw new ConflictException('User has already been referred');
+    }
+
+    const referrer = await this.resolveCode(referralCode);
+    if (!referrer) {
+      throw new BadRequestException('Invalid referral code');
+    }
+
+    // Self-referral check
+    if (referrer.id === referredUserId) {
+      throw new BadRequestException('Self-referral is not allowed');
+    }
+
+    // Circular attribution check
+    const isCircular = await this.isCircularAttribution(
+      referrer.id,
+      referredUserId,
+    );
+    if (isCircular) {
+      throw new BadRequestException(
+        'Circular referral attribution is not allowed',
+      );
+    }
+
+    const referral = this.referralsRepository.create({
+      referrerId: referrer.id,
+      referredUserId,
+      code: referralCode.trim().toUpperCase(),
+      status: ReferralStatus.PENDING,
+    });
+
+    const saved = await this.referralsRepository.save(referral);
+
+    this.logger.log(
+      `Recorded referral attribution: referrer=${referrer.id}, referred=${referredUserId}, code=${saved.code}`,
+    );
+
+    this.eventEmitter?.emit('referral.created', {
+      referralId: saved.id,
+      referrerId: saved.referrerId,
+      referredUserId: saved.referredUserId,
+      code: saved.code,
+    });
+
+    return saved;
+  }
+
+  /**
+   * Lists referrals made by a given user (referrer).
+   */
+  async getReferralsForUser(
+    referrerId: string,
+  ): Promise<ReferralListResponseDto> {
+    const referrals = await this.referralsRepository.find({
+      where: { referrerId },
+      order: { createdAt: 'DESC' },
+    });
+
+    const total = referrals.length;
+    const pending = referrals.filter(
+      (r) => r.status === ReferralStatus.PENDING,
+    ).length;
+    const qualified = referrals.filter(
+      (r) => r.status === ReferralStatus.QUALIFIED,
+    ).length;
+    const rewarded = referrals.filter(
+      (r) => r.status === ReferralStatus.REWARDED,
+    ).length;
+
+    return {
+      referrals: referrals.map((r) => ({
+        id: r.id,
+        referredUserId: r.referredUserId,
+        code: r.code,
+        status: r.status,
+        rejectionReason: r.rejectionReason,
+        qualifiedAt: r.qualifiedAt,
+        rewardedAt: r.rewardedAt,
+        createdAt: r.createdAt,
+      })),
+      total,
+      pending,
+      qualified,
+      rewarded,
+    };
+  }
+
+  /**
+   * Returns credited rewards ledger for a given user.
+   */
+  async getRewardsForUser(
+    recipientId: string,
+  ): Promise<ReferralRewardsResponseDto> {
+    const rewards = await this.referralRewardsRepository.find({
+      where: { recipientId },
+      order: { createdAt: 'DESC' },
+    });
+
+    const totalAmount = rewards.reduce(
+      (sum, r) => sum + Number(r.amount || 0),
+      0,
+    );
+
+    return {
+      rewards: rewards.map((r) => ({
+        id: r.id,
+        referralId: r.referralId,
+        recipientId: r.recipientId,
+        amount: Number(r.amount),
+        asset: r.asset,
+        status: r.status,
+        idempotencyKey: r.idempotencyKey,
+        createdAt: r.createdAt,
+      })),
+      totalAmount,
+      totalRewards: rewards.length,
+    };
+  }
+
+  /**
+   * Returns referral performance statistics for a given user.
+   */
+  async getReferralStats(userId: string): Promise<ReferralStatsResponseDto> {
+    const referrals = await this.referralsRepository.find({
+      where: { referrerId: userId },
+    });
+    const rewards = await this.referralRewardsRepository.find({
+      where: { recipientId: userId, status: ReferralRewardStatus.CREDITED },
+    });
+
+    const totalRewardsCredited = rewards.reduce(
+      (sum, r) => sum + Number(r.amount || 0),
+      0,
+    );
+
+    return {
+      totalReferrals: referrals.length,
+      pendingReferrals: referrals.filter(
+        (r) => r.status === ReferralStatus.PENDING,
+      ).length,
+      qualifiedReferrals: referrals.filter(
+        (r) => r.status === ReferralStatus.QUALIFIED,
+      ).length,
+      rewardedReferrals: referrals.filter(
+        (r) => r.status === ReferralStatus.REWARDED,
+      ).length,
+      totalRewardsCredited,
+    };
+  }
+
+  /**
+   * Qualifying-event hook: Called when a referred user accomplishes a qualifying
+   * milestone (such as their first approved submission). Transitions referral to
+   * QUALIFIED and enqueues reward processing.
+   */
+  async handleQualifyingSubmission(
+    userId: string,
+    submissionId?: string,
+  ): Promise<Referral | null> {
+    const referral = await this.referralsRepository.findOne({
+      where: {
+        referredUserId: userId,
+        status: ReferralStatus.PENDING,
+      },
+    });
+
+    if (!referral) {
+      return null;
+    }
+
+    referral.status = ReferralStatus.QUALIFIED;
+    referral.qualifiedAt = new Date();
+    const updated = await this.referralsRepository.save(referral);
+
+    this.logger.log(
+      `Referral qualified for user ${userId} (referral ${referral.id}, submission ${submissionId || 'milestone'})`,
+    );
+
+    this.eventEmitter?.emit('referral.qualified', {
+      referralId: updated.id,
+      referrerId: updated.referrerId,
+      referredUserId: updated.referredUserId,
+      submissionId,
+      qualifiedAt: updated.qualifiedAt,
+    });
+
+    // Enqueue reward processing in background queue if available, otherwise credit directly
+    if (this.jobsService) {
+      try {
+        await this.jobsService.addJob(
+          QUEUES.REFERRALS,
+          {
+            referralId: updated.id,
+            referrerId: updated.referrerId,
+            referredUserId: updated.referredUserId,
+            amount: 50,
+            asset: 'XLM',
+          },
+          {},
+          JobType.REFERRAL_REWARD,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Failed to enqueue referral reward job for ${updated.id}, crediting directly: ${err.message}`,
+        );
+        await this.creditReward(updated.id).catch((directErr) => {
+          this.logger.error(
+            `Direct reward crediting failed for ${updated.id}: ${directErr.message}`,
+          );
+        });
+      }
+    } else {
+      await this.creditReward(updated.id).catch((directErr) => {
+        this.logger.error(
+          `Direct reward crediting failed for ${updated.id}: ${directErr.message}`,
+        );
+      });
+    }
+
+    return updated;
+  }
+
+  /**
+   * Idempotently credits a referral reward to the referrer.
+   * Performs anti-abuse validations, records the ledger entry, and marks the
+   * referral as REWARDED.
+   */
+  async creditReward(
+    referralId: string,
+    amount: number = 50,
+    asset: string = 'XLM',
+  ): Promise<ReferralReward> {
+    const referral = await this.referralsRepository.findOne({
+      where: { id: referralId },
+    });
+
+    if (!referral) {
+      throw new NotFoundException(`Referral not found: ${referralId}`);
+    }
+
+    const idempotencyKey = `referral-reward:${referral.id}`;
+
+    // Check if reward was already credited
+    const existingReward = await this.referralRewardsRepository.findOne({
+      where: { idempotencyKey },
+    });
+
+    if (existingReward) {
+      if (referral.status !== ReferralStatus.REWARDED) {
+        referral.status = ReferralStatus.REWARDED;
+        referral.rewardedAt = referral.rewardedAt || new Date();
+        await this.referralsRepository.save(referral);
+      }
+      return existingReward;
+    }
+
+    // Anti-abuse checks before reward crediting
+    if (referral.referrerId === referral.referredUserId) {
+      referral.status = ReferralStatus.REJECTED;
+      referral.rejectionReason = 'Self-referral detected';
+      await this.referralsRepository.save(referral);
+      throw new BadRequestException('Self-referral detected');
+    }
+
+    const isCircular = await this.isCircularAttribution(
+      referral.referrerId,
+      referral.referredUserId,
+    );
+    if (isCircular) {
+      referral.status = ReferralStatus.REJECTED;
+      referral.rejectionReason = 'Circular referral detected';
+      await this.referralsRepository.save(referral);
+      throw new BadRequestException('Circular referral detected');
+    }
+
+    const reward = this.referralRewardsRepository.create({
+      referralId: referral.id,
+      recipientId: referral.referrerId,
+      amount,
+      asset,
+      status: ReferralRewardStatus.CREDITED,
+      idempotencyKey,
+      notes: `Referral reward for user ${referral.referredUserId}`,
+    });
+
+    const savedReward = await this.referralRewardsRepository.save(reward);
+
+    referral.status = ReferralStatus.REWARDED;
+    referral.rewardedAt = new Date();
+    if (!referral.qualifiedAt) {
+      referral.qualifiedAt = new Date();
+    }
+    await this.referralsRepository.save(referral);
+
+    if (this.usersService) {
+      try {
+        await this.usersService.applyReputationDeltaAtomic(
+          referral.referrerId,
+          amount,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `Could not apply XP reward to user ${referral.referrerId}: ${e.message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Credited referral reward ${savedReward.id} (${amount} ${asset}) to referrer ${referral.referrerId}`,
+    );
+
+    this.eventEmitter?.emit('referral.rewarded', {
+      rewardId: savedReward.id,
+      referralId: referral.id,
+      recipientId: referral.referrerId,
+      amount,
+      asset,
+      rewardedAt: referral.rewardedAt,
+    });
+
+    return savedReward;
+  }
+}

--- a/BackEnd/src/modules/submissions/CHANGELOG.md
+++ b/BackEnd/src/modules/submissions/CHANGELOG.md
@@ -10,6 +10,9 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Integrated referral milestone qualification hook into `SubmissionsService.processApproval`, triggering qualification and reward processing for referred submitters (#2357).
+
 ### Fixed
 
 - Submission lookups now throw typed `SubmissionNotFoundException` / `QuestNotFoundException` instead of generic `NotFoundException`, producing clean 404 responses via `AppExceptionFilter` instead of falling through as 500s.

--- a/BackEnd/src/modules/submissions/submissions.module.ts
+++ b/BackEnd/src/modules/submissions/submissions.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -12,6 +12,7 @@ import { Submission } from './entities/submission.entity';
 import { VerificationDedupService } from '../../common/services/verification-dedup.service';
 import { Quest } from '../quests/entities/quest.entity';
 import { User } from '../users/entities/user.entity';
+import { ReferralsModule } from '../referrals/referrals.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { User } from '../users/entities/user.entity';
     NotificationsModule,
     StellarModule,
     CacheModule,
+    forwardRef(() => ReferralsModule),
   ],
   controllers: [SubmissionsController],
   providers: [

--- a/BackEnd/src/modules/submissions/submissions.service.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.ts
@@ -5,9 +5,13 @@ import {
   ForbiddenException,
   ConflictException,
   InternalServerErrorException,
+  Optional,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, EntityManager, Repository } from 'typeorm';
+import { ReferralsService } from '../referrals/referrals.service';
 
 /**
  * Sentinel error thrown inside the capacity-gate transaction when the
@@ -80,6 +84,9 @@ export class SubmissionsService {
     private eventEmitter: EventEmitter2,
     private metricsService: MetricsService,
     private verificationDedup: VerificationDedupService,
+    @Optional()
+    @Inject(forwardRef(() => ReferralsService))
+    private referralsService?: ReferralsService,
   ) {}
 
   /**
@@ -445,6 +452,16 @@ export class SubmissionsService {
       approvedBy: verifierId,
       approvedAt,
     });
+
+    if (this.referralsService) {
+      await this.referralsService
+        .handleQualifyingSubmission(submission.userId, submissionId)
+        .catch((err) => {
+          this.logger.warn(
+            `Failed to handle referral qualification for user ${submission.userId}: ${err.message}`,
+          );
+        });
+    }
 
     // Emit SLA metrics for submission review time
     this.metricsService.incrementCounter('submission_review_total');

--- a/BackEnd/test/referrals.integration.spec.ts
+++ b/BackEnd/test/referrals.integration.spec.ts
@@ -1,0 +1,444 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ReferralsService } from '../src/modules/referrals/referrals.service';
+import { ReferralsController } from '../src/modules/referrals/referrals.controller';
+import {
+  Referral,
+  ReferralStatus,
+} from '../src/modules/referrals/entities/referral.entity';
+import {
+  ReferralReward,
+  ReferralRewardStatus,
+} from '../src/modules/referrals/entities/referral-reward.entity';
+import { User } from '../src/modules/users/entities/user.entity';
+import { UsersService } from '../src/modules/users/users.service';
+import { JobsService } from '../src/modules/jobs/jobs.service';
+import { ReferralRewardProcessor } from '../src/modules/jobs/processors/referral-reward.processor';
+import { SubmissionsService } from '../src/modules/submissions/submissions.service';
+import { Submission } from '../src/modules/submissions/entities/submission.entity';
+import { Quest } from '../src/modules/quests/entities/quest.entity';
+import { StellarSubmissionService } from '../src/modules/stellar/stellar-submission.service';
+import { NotificationsService } from '../src/modules/notifications/notifications.service';
+import { MetricsService } from '../src/common/services/metrics.service';
+import { VerificationDedupService } from '../src/common/services/verification-dedup.service';
+
+describe('Referral Program Integration Test', () => {
+  let module: TestingModule;
+  let referralsService: ReferralsService;
+  let referralsController: ReferralsController;
+  let rewardProcessor: ReferralRewardProcessor;
+  let submissionsService: SubmissionsService;
+
+  // In-memory data stores for integration testing
+  const usersStore = new Map<string, User>();
+  const referralsStore = new Map<string, Referral>();
+  const rewardsStore = new Map<string, ReferralReward>();
+  const submissionsStore = new Map<string, Submission>();
+  const questsStore = new Map<string, Quest>();
+
+  const userA: User = {
+    id: '11111111-1111-1111-1111-111111111111',
+    stellarAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    username: 'userA',
+    role: 'USER',
+    xp: 0,
+    level: 1,
+    calculateLevel: () => 1,
+  } as any;
+
+  const userB: User = {
+    id: '22222222-2222-2222-2222-222222222222',
+    stellarAddress: 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    username: 'userB',
+    role: 'USER',
+    xp: 0,
+    level: 1,
+    calculateLevel: () => 1,
+  } as any;
+
+  const mockQuest: Quest = {
+    id: 'quest-101',
+    contractTaskId: 'contract-task-1',
+    title: 'First Onboarding Task',
+    rewardAmount: 100,
+    createdBy: userA.id,
+    verifiers: [{ id: 'verifier-1' }],
+  } as any;
+
+  const verifierUser: User = {
+    id: 'verifier-1',
+    stellarAddress: 'GVERIFIER1111111111111111111111111111111111111111111111',
+    username: 'verifier1',
+    role: 'VERIFIER',
+  } as any;
+
+  beforeAll(async () => {
+    usersStore.set(userA.id, userA);
+    usersStore.set(userB.id, userB);
+    usersStore.set(verifierUser.id, verifierUser);
+    questsStore.set(mockQuest.id, mockQuest);
+
+    const mockReferralsRepo = {
+      create: jest.fn((dto) => {
+        const entity = new Referral();
+        Object.assign(entity, dto);
+        entity.id = entity.id || `ref-${referralsStore.size + 1}`;
+        entity.createdAt = new Date();
+        entity.updatedAt = new Date();
+        return entity;
+      }),
+      save: jest.fn((entity: Referral) => {
+        entity.id = entity.id || `ref-${referralsStore.size + 1}`;
+        referralsStore.set(entity.id, entity);
+        return Promise.resolve(entity);
+      }),
+      findOne: jest.fn(({ where }: any) => {
+        for (const ref of referralsStore.values()) {
+          let match = true;
+          if (where.id && ref.id !== where.id) match = false;
+          if (
+            where.referredUserId &&
+            ref.referredUserId !== where.referredUserId
+          )
+            match = false;
+          if (where.referrerId && ref.referrerId !== where.referrerId)
+            match = false;
+          if (where.status && ref.status !== where.status) match = false;
+          if (match) return Promise.resolve(ref);
+        }
+        return Promise.resolve(null);
+      }),
+      find: jest.fn(({ where }: any = {}) => {
+        const results: Referral[] = [];
+        for (const ref of referralsStore.values()) {
+          let match = true;
+          if (where?.referrerId && ref.referrerId !== where.referrerId)
+            match = false;
+          if (
+            where?.referredUserId &&
+            ref.referredUserId !== where.referredUserId
+          )
+            match = false;
+          if (where?.status && ref.status !== where.status) match = false;
+          if (match) results.push(ref);
+        }
+        return Promise.resolve(results);
+      }),
+    };
+
+    const mockRewardsRepo = {
+      create: jest.fn((dto) => {
+        const entity = new ReferralReward();
+        Object.assign(entity, dto);
+        entity.id = entity.id || `reward-${rewardsStore.size + 1}`;
+        entity.createdAt = new Date();
+        entity.updatedAt = new Date();
+        return entity;
+      }),
+      save: jest.fn((entity: ReferralReward) => {
+        entity.id = entity.id || `reward-${rewardsStore.size + 1}`;
+        rewardsStore.set(entity.id, entity);
+        return Promise.resolve(entity);
+      }),
+      findOne: jest.fn(({ where }: any) => {
+        for (const r of rewardsStore.values()) {
+          let match = true;
+          if (where.id && r.id !== where.id) match = false;
+          if (where.idempotencyKey && r.idempotencyKey !== where.idempotencyKey)
+            match = false;
+          if (where.referralId && r.referralId !== where.referralId)
+            match = false;
+          if (where.recipientId && r.recipientId !== where.recipientId)
+            match = false;
+          if (match) return Promise.resolve(r);
+        }
+        return Promise.resolve(null);
+      }),
+      find: jest.fn(({ where }: any = {}) => {
+        const results: ReferralReward[] = [];
+        for (const r of rewardsStore.values()) {
+          let match = true;
+          if (where?.recipientId && r.recipientId !== where.recipientId)
+            match = false;
+          if (where?.referralId && r.referralId !== where.referralId)
+            match = false;
+          if (match) results.push(r);
+        }
+        return Promise.resolve(results);
+      }),
+    };
+
+    const mockUsersRepo = {
+      findOne: jest.fn(({ where }: any) => {
+        for (const u of usersStore.values()) {
+          if (where.id && u.id === where.id) return Promise.resolve(u);
+          if (where.username && u.username === where.username)
+            return Promise.resolve(u);
+          if (where.stellarAddress && u.stellarAddress === where.stellarAddress)
+            return Promise.resolve(u);
+        }
+        return Promise.resolve(null);
+      }),
+      createQueryBuilder: jest.fn(() => ({
+        where: jest.fn((_clause, params) => {
+          const prefix = params?.prefix?.replace(/[%]/g, '').toUpperCase();
+          for (const u of usersStore.values()) {
+            if (
+              prefix &&
+              u.id.replace(/-/g, '').toUpperCase().startsWith(prefix)
+            ) {
+              return {
+                getOne: () => Promise.resolve(u),
+              };
+            }
+          }
+          return { getOne: () => Promise.resolve(null) };
+        }),
+      })),
+    };
+
+    const mockSubmissionsRepo = {
+      create: jest.fn((dto) => ({
+        ...dto,
+        id: 'sub-1',
+        createdAt: new Date(),
+      })),
+      save: jest.fn((e) => {
+        submissionsStore.set(e.id, e);
+        return Promise.resolve(e);
+      }),
+      findOne: jest.fn(({ where }: any) => {
+        if (where.id)
+          return Promise.resolve(submissionsStore.get(where.id) || null);
+        return Promise.resolve(null);
+      }),
+      createQueryBuilder: jest.fn(() => ({
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 1 }),
+      })),
+    };
+
+    const mockQuestsRepo = {
+      findOne: jest.fn(({ where }: any) => {
+        if (where.id) return Promise.resolve(questsStore.get(where.id) || null);
+        return Promise.resolve(null);
+      }),
+    };
+
+    module = await Test.createTestingModule({
+      controllers: [ReferralsController],
+      providers: [
+        ReferralsService,
+        ReferralRewardProcessor,
+        SubmissionsService,
+        {
+          provide: getRepositoryToken(Referral),
+          useValue: mockReferralsRepo,
+        },
+        {
+          provide: getRepositoryToken(ReferralReward),
+          useValue: mockRewardsRepo,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUsersRepo,
+        },
+        {
+          provide: getRepositoryToken(Submission),
+          useValue: mockSubmissionsRepo,
+        },
+        {
+          provide: getRepositoryToken(Quest),
+          useValue: mockQuestsRepo,
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key) => {
+              if (key === 'APP_URL') return 'https://stellarearn.com';
+              return null;
+            }),
+          },
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            findById: jest.fn((id) =>
+              Promise.resolve(usersStore.get(id) || null),
+            ),
+            applyReputationDeltaAtomic: jest.fn((id, delta) => {
+              const u = usersStore.get(id);
+              if (u) u.xp = (u.xp || 0) + delta;
+              return Promise.resolve({ userId: id, newXp: u?.xp });
+            }),
+          },
+        },
+        {
+          provide: JobsService,
+          useValue: {
+            addJob: jest.fn((queue, data) =>
+              rewardProcessor.process({
+                id: 'bullmq-job-1',
+                timestamp: Date.now(),
+                data,
+              } as any),
+            ),
+          },
+        },
+        {
+          provide: EventEmitter2,
+          useValue: { emit: jest.fn() },
+        },
+        {
+          provide: StellarSubmissionService,
+          useValue: {
+            approveSubmission: jest
+              .fn()
+              .mockResolvedValue({ hash: '0xtxhash' }),
+          },
+        },
+        {
+          provide: NotificationsService,
+          useValue: {
+            sendSubmissionApproved: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: MetricsService,
+          useValue: {
+            incrementCounter: jest.fn(),
+            observeHistogram: jest.fn(),
+          },
+        },
+        {
+          provide: VerificationDedupService,
+          useValue: {
+            executeWithDedup: jest.fn((_key, fn) => fn()),
+          },
+        },
+      ],
+    }).compile();
+
+    referralsService = module.get<ReferralsService>(ReferralsService);
+    referralsController = module.get<ReferralsController>(ReferralsController);
+    rewardProcessor = module.get<ReferralRewardProcessor>(
+      ReferralRewardProcessor,
+    );
+    submissionsService = module.get<SubmissionsService>(SubmissionsService);
+  });
+
+  it('Flow: Referral Code Generation -> Signup Attribution -> Anti-Abuse -> Qualifying Milestone -> Idempotent Reward Ledger', async () => {
+    // 1. User A obtains their referral code
+    const codeDto = referralsController.getMyReferralCode({
+      id: userA.id,
+      stellarAddress: userA.stellarAddress ?? '',
+      role: userA.role,
+    });
+    expect(codeDto.code).toBe('REF-11111111');
+    expect(codeDto.referralLink).toBe(
+      'https://stellarearn.com/signup?ref=REF-11111111',
+    );
+
+    // 2. Anti-abuse check: User A cannot refer themselves
+    await expect(
+      referralsService.recordAttribution(userA.id, 'REF-11111111'),
+    ).rejects.toThrow(BadRequestException);
+
+    // 3. User B signs up using User A's referral code
+    const attributionResult = await referralsController.attributeReferral(
+      { code: 'REF-11111111' },
+      {
+        id: userB.id,
+        stellarAddress: userB.stellarAddress ?? '',
+        role: userB.role,
+      },
+    );
+    expect(attributionResult.success).toBe(true);
+    expect(attributionResult.status).toBe(ReferralStatus.PENDING);
+
+    // Verify attribution state in User A's referrals list
+    const userAReferrals = await referralsController.getMyReferrals({
+      id: userA.id,
+      stellarAddress: userA.stellarAddress ?? '',
+      role: userA.role,
+    });
+    expect(userAReferrals.total).toBe(1);
+    expect(userAReferrals.pending).toBe(1);
+    expect(userAReferrals.referrals[0].referredUserId).toBe(userB.id);
+
+    // 4. Anti-abuse check: Duplicate referral for User B is rejected
+    await expect(
+      referralsService.recordAttribution(userB.id, 'REF-11111111'),
+    ).rejects.toThrow(ConflictException);
+
+    // 5. Anti-abuse check: Circular attribution (User A using User B's code) is rejected
+    const userBCode = referralsService.generateReferralCode(userB.id);
+    expect(userBCode).toBe('REF-22222222');
+    await expect(
+      referralsService.recordAttribution(userA.id, userBCode),
+    ).rejects.toThrow(BadRequestException);
+
+    // 6. User B submits work and verifier approves the submission (Qualifying Milestone)
+    const initialSubmission: Submission = {
+      id: 'sub-user-b-1',
+      userId: userB.id,
+      questId: mockQuest.id,
+      user: userB,
+      quest: mockQuest,
+      status: 'PENDING',
+      createdAt: new Date(Date.now() - 60000),
+    } as any;
+    submissionsStore.set(initialSubmission.id, initialSubmission);
+
+    // Verifier approves the submission
+    await submissionsService.approveSubmission(
+      initialSubmission.id,
+      { notes: 'Great work on first task' },
+      'verifier-1',
+    );
+
+    // Verify that the referral transitioned to QUALIFIED and then REWARDED
+    const updatedReferral = await referralsService.getReferralsForUser(
+      userA.id,
+    );
+    expect(updatedReferral.rewarded).toBe(1);
+    expect(updatedReferral.pending).toBe(0);
+    expect(updatedReferral.referrals[0].status).toBe(ReferralStatus.REWARDED);
+
+    // 7. Verify reward ledger for User A
+    const userARewards = await referralsController.getMyRewards({
+      id: userA.id,
+      stellarAddress: userA.stellarAddress ?? '',
+      role: userA.role,
+    });
+    expect(userARewards.totalRewards).toBe(1);
+    expect(userARewards.totalAmount).toBe(50);
+    expect(userARewards.rewards[0].asset).toBe('XLM');
+    expect(userARewards.rewards[0].status).toBe(ReferralRewardStatus.CREDITED);
+
+    // 8. Idempotency test: Re-executing reward crediting for the same referral produces no duplicate ledger entry
+    const reProcessResult = await rewardProcessor.process({
+      id: 'bullmq-retry-job',
+      timestamp: Date.now(),
+      data: {
+        referralId: updatedReferral.referrals[0].id,
+      },
+    } as any);
+    expect(reProcessResult.success).toBe(true);
+    expect(reProcessResult.data.alreadyRewarded).toBe(true);
+
+    const userARewardsAfterRetry = await referralsController.getMyRewards({
+      id: userA.id,
+      stellarAddress: userA.stellarAddress ?? '',
+      role: userA.role,
+    });
+    expect(userARewardsAfterRetry.totalRewards).toBe(1);
+    expect(userARewardsAfterRetry.totalAmount).toBe(50);
+  });
+});


### PR DESCRIPTION
### Overview
Closes #2357

Implements a full backend referral and invitation program with qualification-based reward attribution, anti-abuse protections, BullMQ asynchronous reward processing, and ledger-based tracking.

### Key Changes
1. **Domain Models & Migrations (`src/modules/referrals/entities/`, `src/database/migrations/`)**:
   - `Referral` entity: tracks referrer, referred user, referral code, status (`PENDING`, `QUALIFIED`, `REWARDED`, `REJECTED`), rejection reasons, qualification timestamp, and reward timestamp.
   - `ReferralReward` entity: append-only ledger of credited rewards with unique idempotency keys (`referral-reward:${referralId}`).
   - TypeORM migration `1870000000000-add-referrals.ts` defining PostgreSQL tables, enums, unique constraints, and indexes.

2. **Core Service Logic (`src/modules/referrals/referrals.service.ts`)**:
   - Unique, deterministic referral code generation (`generateReferralCode`) with prefix resolution (`resolveCode`).
   - Attribution recording upon signup (`recordAttribution`) with strict validation.
   - Anti-abuse checks: rejection of self-referral, rejection of duplicate referral attribution, and graph cycle detection (`isCircularAttribution`) traversing referrer ancestry to prevent cyclical collusion chains.
   - Milestone qualification hook (`handleQualifyingSubmission`): triggers when a referred user's first submission is approved, transitioning the referral to `QUALIFIED` and enqueuing a background reward job.
   - Idempotent reward crediting (`creditReward`): records reward in ledger, marks referral `REWARDED`, and atomically awards reputation/XP to the referrer.

3. **REST Endpoints (`src/modules/referrals/referrals.controller.ts`)**:
   - `GET /referrals/code`: Returns authenticated user's referral code and invitation link.
   - `GET /referrals`: Returns list of referrals with status counts (`total`, `pending`, `qualified`, `rewarded`).
   - `GET /referrals/rewards`: Returns user's credited reward history and total payout sum.
   - `GET /referrals/stats`: Returns summary statistics.
   - `POST /referrals/attribute`: Manual attribution for authenticated users.

4. **Background Job Processing (`src/modules/jobs/`)**:
   - Added `QUEUES.REFERRALS` to BullMQ constants and initialized worker in `JobsService`.
   - Added `JobType.REFERRAL_REWARD` with explicit exponential backoff and retry policy in `job-retry-policy.ts`.
   - Implemented `ReferralRewardProcessor` with pre-flight anti-abuse validation and idempotent ledger crediting.

5. **Integration with Auth & Submissions**:
   - Wired referral code capture during wallet login (`verifyAndLogin`) and OAuth login (`loginOAuthUser`).
   - Wired qualification event hook in `SubmissionsService.processApproval`.

6. **Testing**:
   - Unit tests: `referrals.service.spec.ts`, `referrals.controller.spec.ts`, `referral-reward.processor.spec.ts`.
   - Integration test: `test/referrals.integration.spec.ts` covering the end-to-end referral lifecycle (code generation -> signup attribution -> anti-abuse checks -> submission approval milestone -> BullMQ reward processing -> idempotency).

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`