### PR TITLE
feat(referrals): add backend referral & invitation program

### DIFF
--- a/BackEnd/src/app.module.ts
+++ b/BackEnd/src/app.module.ts
@@ -36,6 +36,7 @@ import { PrivacyModule } from './modules/privacy/privacy.module';
 import { QueryMonitoringModule } from './modules/query-monitoring/query-monitoring.module';
 import { QuestsModule } from './modules/quests/quests.module';
 import { QuotaModule } from './modules/quota/quota.module';
+import { ReferralsModule } from './modules/referrals/referrals.module';
 import { StellarModule } from './modules/stellar/stellar.module';
 import { MultiSigModule } from './modules/stellar/multisig/multisig.module';
 import { SubmissionsModule } from './modules/submissions/submissions.module';
@@ -101,6 +102,7 @@ const dataSourceProvider = shouldInitializeDatabaseConnection()
     QueryMonitoringModule,
     QuestsModule,
     QuotaModule,
+    ReferralsModule,
     StellarModule,
     SubmissionsModule,
     DisputesModule,

--- a/BackEnd/src/database/migrations/1870000000000-add-referrals.ts
+++ b/BackEnd/src/database/migrations/1870000000000-add-referrals.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: referral & invitation program tables (#2357).
+ *
+ * `referral_codes` holds each user's stable, unique code. `referrals` is the
+ * attribution ledger (unique on `referredUserId`, so a user is attributable to
+ * at most one referrer). `referral_rewards` is the credited-reward ledger
+ * (unique on `referralId` — the idempotency guard against double-crediting).
+ */
+export class AddReferrals1870000000000 implements MigrationInterface {
+  name = 'AddReferrals1870000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "referral_codes" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "code" character varying(32) NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_referral_codes_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_referral_codes_user" UNIQUE ("userId"),
+        CONSTRAINT "UQ_referral_codes_code" UNIQUE ("code")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "referrals" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "referrerUserId" uuid NOT NULL,
+        "referredUserId" uuid NOT NULL,
+        "code" character varying(32) NOT NULL,
+        "status" character varying NOT NULL DEFAULT 'PENDING',
+        "rejectionReason" text,
+        "qualifiedAt" TIMESTAMP WITH TIME ZONE,
+        "rewardedAt" TIMESTAMP WITH TIME ZONE,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_referrals_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_referrals_referred_user" UNIQUE ("referredUserId")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_referral_referrer" ON "referrals" ("referrerUserId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_referral_status" ON "referrals" ("status")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "referral_rewards" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "referralId" uuid NOT NULL,
+        "referrerUserId" uuid NOT NULL,
+        "referredUserId" uuid NOT NULL,
+        "amount" bigint NOT NULL,
+        "assetCode" character varying(12) NOT NULL DEFAULT 'XLM',
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_referral_rewards_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_referral_rewards_referral" UNIQUE ("referralId")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_referral_reward_referrer" ON "referral_rewards" ("referrerUserId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "referral_rewards"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "referrals"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "referral_codes"`);
+  }
+}

--- a/BackEnd/src/modules/auth/CHANGELOG.md
+++ b/BackEnd/src/modules/auth/CHANGELOG.md
@@ -12,6 +12,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 - `AuthService.validateUser` now tolerates missing users by falling back to a default caller identity instead of bubbling `NotFoundException`.
 ### Added
 
+- `LoginDto` accepts an optional `referralCode`; on first-time signup `AuthService.verifyAndLogin` records a pending referral attribution (invalid/self/circular/duplicate codes are ignored so signup never fails). Part of the referral program (#2357).
 - Partial indexes (`WHERE "deletedAt" IS NULL`) on `RefreshToken` for `userId` and `familyId` columns to speed up active-session queries (#2000).
 
 ### Fixed

--- a/BackEnd/src/modules/auth/auth.module.ts
+++ b/BackEnd/src/modules/auth/auth.module.ts
@@ -14,6 +14,7 @@ import {
   getJwtPublicKeys,
 } from '../../common/utils/jwt-keys';
 import { UsersModule } from '../users/users.module';
+import { ReferralsModule } from '../referrals/referrals.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { UsersModule } from '../users/users.module';
     }),
     TypeOrmModule.forFeature([RefreshToken]),
     UsersModule,
+    ReferralsModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, JwtAuthGuard, RolesGuard],

--- a/BackEnd/src/modules/auth/auth.service.ts
+++ b/BackEnd/src/modules/auth/auth.service.ts
@@ -13,6 +13,7 @@ import { RefreshToken } from './entities/refresh-token.entity';
 import { LoginDto, ChallengeResponseDto } from './dto/auth.dto';
 import { Role } from '../../common/enums/role.enum';
 import { UsersService } from '../users/users.service';
+import { ReferralsService } from '../referrals/referrals.service';
 import {
   generateChallengeMessage,
   verifyStellarSignature,
@@ -44,6 +45,7 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly usersService: UsersService,
+    private readonly referralsService: ReferralsService,
     @InjectRepository(RefreshToken)
     private readonly refreshTokenRepository: Repository<RefreshToken>,
   ) {}
@@ -135,6 +137,13 @@ export class AuthService {
         username: stellarAddress,
         role: Role.USER,
       });
+      // New signup: attribute to a referrer when a valid code is supplied.
+      // Invalid/self/circular/duplicate codes are ignored (no-op) so signup
+      // never fails on referral handling.
+      await this.referralsService.recordSignupAttribution(
+        user.id,
+        dto.referralCode,
+      );
     }
 
     const tokens = await this.generateTokens(

--- a/BackEnd/src/modules/auth/dto/auth.dto.ts
+++ b/BackEnd/src/modules/auth/dto/auth.dto.ts
@@ -1,5 +1,11 @@
-import { IsString, IsNotEmpty, MaxLength, MinLength } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsStellarAddress } from '../../../common/decorators/is-stellar-address.decorator';
 
 export class ChallengeRequestDto {
@@ -70,6 +76,15 @@ export class LoginDto {
   @MinLength(10)
   @MaxLength(1000)
   challenge: string;
+
+  @ApiPropertyOptional({
+    description: 'Referral code used to attribute this signup (optional)',
+    maxLength: 32,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  referralCode?: string;
 }
 
 export class UserResponseDto {

--- a/BackEnd/src/modules/jobs/CHANGELOG.md
+++ b/BackEnd/src/modules/jobs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `ReferralRewardProcessor` (`processors/referral-reward.processor.ts`) — credits a qualified referral's reward exactly once. Idempotency is enforced by the unique `ReferralReward.referralId`, and self-referrals are rejected/dead-lettered at credit time. Provided by `ReferralsModule`; invoked in-process (no BullMQ worker runs) with the persisted rows keeping state queryable for a future queue-backed worker (#2357).
 - Stuck payout recovery in `PayoutReconciliationProcessor.recoverStuckPayouts()` — an every-10-minute job that detects payouts stuck in PROCESSING (no transaction hash, crashed before submission) or RETRY_SCHEDULED (overdue, never re-driven) and resets them back to PENDING or DEAD_LETTER via `PayoutsService.forceResetPayout()`.
 - Account-erasure pipeline: new `ERASURE` BullMQ queue, `JobType.ACCOUNT_ERASURE` (with retry policy), `AccountErasureProcessor` and `AccountErasureListener`. The listener schedules the erasure job for the end of the grace period; the processor runs the idempotent, transactional anonymization via `ErasureService` (#2337).
 - Payout transactional-outbox relay in `PayoutProcessor.relayPayoutOutbox()` — an every-minute job that atomically claims PENDING `payout_outbox` rows (`PENDING → PROCESSING`), submits each via `StellarPaymentService` exactly once, and marks them DONE (or retries/parks on failure) (#2158).

--- a/BackEnd/src/modules/jobs/processors/referral-reward.processor.spec.ts
+++ b/BackEnd/src/modules/jobs/processors/referral-reward.processor.spec.ts
@@ -1,0 +1,93 @@
+import { QueryFailedError, Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ReferralRewardProcessor } from './referral-reward.processor';
+import {
+  Referral,
+  ReferralStatus,
+} from '../../referrals/entities/referral.entity';
+import { ReferralReward } from '../../referrals/entities/referral-reward.entity';
+
+type MockRepo<T> = Partial<Record<keyof Repository<T>, jest.Mock>>;
+
+describe('ReferralRewardProcessor', () => {
+  let processor: ReferralRewardProcessor;
+  let referrals: MockRepo<Referral>;
+  let rewards: MockRepo<ReferralReward>;
+
+  beforeEach(() => {
+    referrals = {
+      findOne: jest.fn(),
+      save: jest.fn((x) => Promise.resolve(x)),
+    };
+    rewards = {
+      create: jest.fn((x) => x),
+      save: jest.fn((x) => Promise.resolve(x)),
+    };
+    const config = {
+      get: jest.fn((_k: string, d?: unknown) => d),
+    } as unknown as ConfigService;
+    processor = new ReferralRewardProcessor(
+      referrals as unknown as Repository<Referral>,
+      rewards as unknown as Repository<ReferralReward>,
+      config,
+    );
+  });
+
+  it('credits a qualified referral exactly once and marks it rewarded', async () => {
+    referrals.findOne!.mockResolvedValue({
+      id: 'ref-1',
+      referrerUserId: 'a',
+      referredUserId: 'b',
+      status: ReferralStatus.QUALIFIED,
+    });
+
+    await processor.process('ref-1');
+
+    expect(rewards.save).toHaveBeenCalledTimes(1);
+    expect(referrals.save).toHaveBeenCalledWith(
+      expect.objectContaining({ status: ReferralStatus.REWARDED }),
+    );
+  });
+
+  it('is a no-op when the referral is already rewarded', async () => {
+    referrals.findOne!.mockResolvedValue({
+      id: 'ref-1',
+      status: ReferralStatus.REWARDED,
+    });
+    await processor.process('ref-1');
+    expect(rewards.save).not.toHaveBeenCalled();
+  });
+
+  it('treats a duplicate reward insert as an idempotent no-op', async () => {
+    referrals.findOne!.mockResolvedValue({
+      id: 'ref-1',
+      referrerUserId: 'a',
+      referredUserId: 'b',
+      status: ReferralStatus.QUALIFIED,
+    });
+    rewards.save!.mockRejectedValue(
+      new QueryFailedError('insert', [], new Error('duplicate key')),
+    );
+
+    await processor.process('ref-1');
+
+    // The reward insert raced/duplicated, so the referral is not re-marked.
+    expect(referrals.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects a self-referral at credit time instead of rewarding', async () => {
+    referrals.findOne!.mockResolvedValue({
+      id: 'ref-1',
+      referrerUserId: 'same',
+      referredUserId: 'same',
+      status: ReferralStatus.QUALIFIED,
+    });
+
+    await processor.process('ref-1');
+
+    expect(rewards.save).not.toHaveBeenCalled();
+    expect(referrals.save).toHaveBeenCalledWith(
+      expect.objectContaining({ status: ReferralStatus.REJECTED }),
+    );
+  });
+});

--- a/BackEnd/src/modules/jobs/processors/referral-reward.processor.ts
+++ b/BackEnd/src/modules/jobs/processors/referral-reward.processor.ts
@@ -1,0 +1,93 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { QueryFailedError, Repository } from 'typeorm';
+import {
+  Referral,
+  ReferralStatus,
+} from '../../referrals/entities/referral.entity';
+import { ReferralReward } from '../../referrals/entities/referral-reward.entity';
+
+/**
+ * Credits the referrer's reward for a qualified referral, exactly once.
+ *
+ * Idempotency is enforced at the storage layer: `ReferralReward.referralId` is
+ * unique, so a duplicate qualifying event that re-enqueues the same referral
+ * cannot double-credit — the second insert is caught and treated as a no-op.
+ * Anti-abuse re-validation (self-referral) runs before crediting; a failing
+ * referral is moved to `REJECTED` (dead-lettered) instead of rewarded.
+ *
+ * Implemented as a plain injectable (invoked in-process) because the platform
+ * does not run a BullMQ worker; the persisted referral/reward rows keep state
+ * queryable and let a future queue-backed worker resume from them.
+ */
+@Injectable()
+export class ReferralRewardProcessor {
+  private readonly logger = new Logger(ReferralRewardProcessor.name);
+
+  constructor(
+    @InjectRepository(Referral)
+    private readonly referrals: Repository<Referral>,
+    @InjectRepository(ReferralReward)
+    private readonly rewards: Repository<ReferralReward>,
+    private readonly config: ConfigService,
+  ) {}
+
+  private rewardAmount(): string {
+    // Documented, configurable reward (default 10 XLM = 100_000_000 stroops).
+    return this.config.get<string>('REFERRAL_REWARD_STROOPS', '100000000');
+  }
+
+  /** Enqueue point: fire-and-forget so callers are never blocked on delivery. */
+  enqueue(referralId: string): void {
+    void this.process(referralId).catch((err) =>
+      this.logger.error(
+        `Referral reward processing failed for ${referralId}: ${(err as Error).message}`,
+      ),
+    );
+  }
+
+  /** Idempotently credits the reward for a qualified referral. */
+  async process(referralId: string): Promise<void> {
+    const referral = await this.referrals.findOne({
+      where: { id: referralId },
+    });
+    if (!referral || referral.status === ReferralStatus.REWARDED) {
+      return; // unknown or already rewarded — nothing to do
+    }
+
+    // Anti-abuse re-validation at credit time.
+    if (referral.referrerUserId === referral.referredUserId) {
+      referral.status = ReferralStatus.REJECTED;
+      referral.rejectionReason = 'self-referral';
+      await this.referrals.save(referral);
+      this.logger.warn(
+        `Referral ${referralId} rejected at credit time (self-referral)`,
+      );
+      return;
+    }
+
+    try {
+      await this.rewards.save(
+        this.rewards.create({
+          referralId: referral.id,
+          referrerUserId: referral.referrerUserId,
+          referredUserId: referral.referredUserId,
+          amount: this.rewardAmount(),
+        }),
+      );
+    } catch (err) {
+      // Unique(referralId) violation => already credited by a concurrent run.
+      if (err instanceof QueryFailedError) {
+        this.logger.log(`Referral ${referralId} already credited; skipping`);
+        return;
+      }
+      throw err;
+    }
+
+    referral.status = ReferralStatus.REWARDED;
+    referral.rewardedAt = new Date();
+    await this.referrals.save(referral);
+    this.logger.log(`Credited referral reward for ${referralId}`);
+  }
+}

--- a/BackEnd/src/modules/referrals/CHANGELOG.md
+++ b/BackEnd/src/modules/referrals/CHANGELOG.md
@@ -1,0 +1,38 @@
+# referrals module changelog
+
+All notable changes to the `referrals` backend module are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this module adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Initial referral & invitation program (#2357):
+  - `ReferralCode`, `Referral`, and `ReferralReward` entities plus a migration.
+  - `ReferralsService`: generates a stable, unique per-user code; resolves a code
+    to its owner; records signup attribution with anti-abuse checks
+    (self-referral, unknown code, duplicate attribution, and circular
+    attribution are all rejected); a qualifying-milestone hook that moves a
+    referral to `qualified` and enqueues reward crediting; and queries for a
+    user's referrals and reward ledger.
+  - `ReferralsController`: authenticated endpoints for the caller's referral
+    code/link, their referrals and statuses, and credited rewards.
+  - `ReferralRewardProcessor` (in `jobs/processors/`): idempotent reward
+    crediting keyed by the unique `ReferralReward.referralId`; self-referrals
+    are rejected at credit time.
+  - Integrated into signup (`AuthService`) and approval (`SubmissionsService`)
+    flows.
+
+## Program rules
+
+- Each user has one stable referral code (`GET /referrals/me/code`, which also
+  returns a shareable `link`).
+- A new user may be attributed to at most one referrer (enforced by a unique
+  constraint on `Referral.referredUserId`).
+- Rejected attributions: self-referral, unknown code, already-attributed user,
+  and circular attribution (A refers B while B already referred A).
+- A referral qualifies on the referred user's **first approved submission** and
+  is then rewarded **exactly once** (unique `ReferralReward.referralId`).
+- Reward amount is configurable via `REFERRAL_REWARD_STROOPS` (default
+  `100000000`, i.e. 10 XLM).

--- a/BackEnd/src/modules/referrals/entities/referral-code.entity.ts
+++ b/BackEnd/src/modules/referrals/entities/referral-code.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+/**
+ * Stable, unique referral code for a user.
+ *
+ * A row is created once on first request and returned thereafter, so a user's
+ * code never changes. Both `userId` and `code` are unique, which keeps
+ * generation collision-free and lets a code be resolved back to its owner.
+ */
+@Entity('referral_codes')
+export class ReferralCode {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid', unique: true })
+  userId: string;
+
+  @Column({ type: 'varchar', length: 32, unique: true })
+  code: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/BackEnd/src/modules/referrals/entities/referral-reward.entity.ts
+++ b/BackEnd/src/modules/referrals/entities/referral-reward.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Immutable ledger of credited referral rewards.
+ *
+ * The unique constraint on `referralId` is the idempotency guard: a referral
+ * can be credited at most once, so re-processing the same qualifying event
+ * never double-credits.
+ */
+@Index('idx_referral_reward_referrer', ['referrerUserId'])
+@Entity('referral_rewards')
+export class ReferralReward {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The referral this reward settles. Unique — one reward per referral. */
+  @Column({ type: 'uuid', unique: true })
+  referralId: string;
+
+  @Column({ type: 'uuid' })
+  referrerUserId: string;
+
+  @Column({ type: 'uuid' })
+  referredUserId: string;
+
+  /** Reward amount in the smallest asset unit (stroops for XLM-based assets). */
+  @Column({ type: 'bigint' })
+  amount: string;
+
+  @Column({ type: 'varchar', length: 12, default: 'XLM' })
+  assetCode: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/BackEnd/src/modules/referrals/entities/referral.entity.ts
+++ b/BackEnd/src/modules/referrals/entities/referral.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Attribution lifecycle for a single referred user.
+ *
+ * `PENDING` on signup → `QUALIFIED` once the referred user hits the qualifying
+ * milestone (their first approved submission) → `REWARDED` once the referrer's
+ * reward is credited (exactly once). `REJECTED` covers anti-abuse failures
+ * (self-referral, circular/duplicate attribution).
+ */
+export enum ReferralStatus {
+  PENDING = 'PENDING',
+  QUALIFIED = 'QUALIFIED',
+  REWARDED = 'REWARDED',
+  REJECTED = 'REJECTED',
+}
+
+/**
+ * One attribution row per referred user. The unique constraint on
+ * `referredUserId` is what makes a signup attributable to at most one referrer
+ * (duplicate attribution is impossible at the storage layer).
+ */
+@Index('idx_referral_referrer', ['referrerUserId'])
+@Index('idx_referral_status', ['status'])
+@Entity('referrals')
+export class Referral {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The user who owns the referral code (the inviter). */
+  @Column({ type: 'uuid' })
+  referrerUserId: string;
+
+  /** The newly signed-up user attributed to the referrer. At most one per user. */
+  @Column({ type: 'uuid', unique: true })
+  referredUserId: string;
+
+  /** The referral code that was used at signup. */
+  @Column({ type: 'varchar', length: 32 })
+  code: string;
+
+  @Column({
+    type: 'enum',
+    enum: ReferralStatus,
+    default: ReferralStatus.PENDING,
+  })
+  status: ReferralStatus;
+
+  /** Populated when a referral is rejected by anti-abuse checks. */
+  @Column({ type: 'text', nullable: true })
+  rejectionReason: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  qualifiedAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  rewardedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/BackEnd/src/modules/referrals/referrals.controller.ts
+++ b/BackEnd/src/modules/referrals/referrals.controller.ts
@@ -1,0 +1,56 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { AuthUser } from '../auth/auth.service';
+import { ReferralsService } from './referrals.service';
+
+/**
+ * Authenticated referral program API: the caller's code/link, the referrals
+ * they have driven, and the rewards credited to them.
+ */
+@ApiTags('Referrals')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('referrals')
+@ApiResponse({ status: 401, description: 'Authentication required' })
+export class ReferralsController {
+  constructor(private readonly referrals: ReferralsService) {}
+
+  @Get('me/code')
+  @ApiOperation({
+    summary: 'Get my referral code and shareable invitation link',
+  })
+  @ApiResponse({
+    status: 200,
+    description: "The caller's referral code and link",
+  })
+  getMyCode(@CurrentUser() user: AuthUser) {
+    return this.referrals.getMyReferralInfo(user.id);
+  }
+
+  @Get('me/referrals')
+  @ApiOperation({ summary: 'List the referrals I have made and their status' })
+  @ApiResponse({
+    status: 200,
+    description: 'Referrals attributed to the caller',
+  })
+  getMyReferrals(@CurrentUser() user: AuthUser) {
+    return this.referrals.listMyReferrals(user.id);
+  }
+
+  @Get('me/rewards')
+  @ApiOperation({ summary: 'View referral rewards credited to me' })
+  @ApiResponse({
+    status: 200,
+    description: 'Referral reward ledger for the caller',
+  })
+  getMyRewards(@CurrentUser() user: AuthUser) {
+    return this.referrals.listMyRewards(user.id);
+  }
+}

--- a/BackEnd/src/modules/referrals/referrals.module.ts
+++ b/BackEnd/src/modules/referrals/referrals.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReferralCode } from './entities/referral-code.entity';
+import { Referral } from './entities/referral.entity';
+import { ReferralReward } from './entities/referral-reward.entity';
+import { ReferralsService } from './referrals.service';
+import { ReferralsController } from './referrals.controller';
+import { ReferralRewardProcessor } from '../jobs/processors/referral-reward.processor';
+
+/**
+ * Referral & invitation program (backend). Exposes the referral API and the
+ * attribution/qualification/reward logic consumed by the auth and submissions
+ * flows. The reward processor is provided here (it owns the referral/reward
+ * repositories) and is also registered in the jobs module.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([ReferralCode, Referral, ReferralReward])],
+  controllers: [ReferralsController],
+  providers: [ReferralsService, ReferralRewardProcessor],
+  exports: [ReferralsService],
+})
+export class ReferralsModule {}

--- a/BackEnd/src/modules/referrals/referrals.service.spec.ts
+++ b/BackEnd/src/modules/referrals/referrals.service.spec.ts
@@ -1,0 +1,119 @@
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ReferralsService } from './referrals.service';
+import { ReferralCode } from './entities/referral-code.entity';
+import { Referral, ReferralStatus } from './entities/referral.entity';
+import { ReferralReward } from './entities/referral-reward.entity';
+import { ReferralRewardProcessor } from '../jobs/processors/referral-reward.processor';
+
+type MockRepo<T> = Partial<Record<keyof Repository<T>, jest.Mock>>;
+
+function repo<T>(): MockRepo<T> {
+  return {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    create: jest.fn((x) => x),
+    save: jest.fn((x) => Promise.resolve({ id: 'ref-1', ...x })),
+  };
+}
+
+describe('ReferralsService', () => {
+  let service: ReferralsService;
+  let codes: MockRepo<ReferralCode>;
+  let referrals: MockRepo<Referral>;
+  let rewards: MockRepo<ReferralReward>;
+  let processor: { enqueue: jest.Mock };
+
+  beforeEach(() => {
+    codes = repo<ReferralCode>();
+    referrals = repo<Referral>();
+    rewards = repo<ReferralReward>();
+    processor = { enqueue: jest.fn() };
+    const config = {
+      get: jest.fn((_k: string, d?: unknown) => d),
+    } as unknown as ConfigService;
+    service = new ReferralsService(
+      codes as unknown as Repository<ReferralCode>,
+      referrals as unknown as Repository<Referral>,
+      rewards as unknown as Repository<ReferralReward>,
+      config,
+      processor as unknown as ReferralRewardProcessor,
+    );
+  });
+
+  describe('recordSignupAttribution', () => {
+    it('creates a pending attribution for a valid code', async () => {
+      codes.findOne!.mockResolvedValue({ userId: 'referrer', code: 'ABC123' });
+      referrals.findOne!.mockResolvedValue(null); // no duplicate, no circular
+
+      const result = await service.recordSignupAttribution('newuser', 'ABC123');
+
+      expect(referrals.save).toHaveBeenCalledTimes(1);
+      expect(referrals.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          referrerUserId: 'referrer',
+          referredUserId: 'newuser',
+          status: ReferralStatus.PENDING,
+        }),
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it('is a no-op when no code is supplied', async () => {
+      const result = await service.recordSignupAttribution(
+        'newuser',
+        undefined,
+      );
+      expect(result).toBeNull();
+      expect(referrals.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects self-referral', async () => {
+      codes.findOne!.mockResolvedValue({ userId: 'newuser', code: 'SELF' });
+      const result = await service.recordSignupAttribution('newuser', 'SELF');
+      expect(result).toBeNull();
+      expect(referrals.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects a duplicate attribution (returns the existing one)', async () => {
+      codes.findOne!.mockResolvedValue({ userId: 'referrer', code: 'ABC' });
+      const existing = { id: 'existing' } as Referral;
+      referrals.findOne!.mockResolvedValueOnce(existing); // duplicate lookup hits
+      const result = await service.recordSignupAttribution('newuser', 'ABC');
+      expect(result).toBe(existing);
+      expect(referrals.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects circular attribution', async () => {
+      codes.findOne!.mockResolvedValue({ userId: 'referrer', code: 'ABC' });
+      referrals
+        .findOne!.mockResolvedValueOnce(null) // no duplicate
+        .mockResolvedValueOnce({ id: 'circular' }); // newuser previously referred referrer
+      const result = await service.recordSignupAttribution('newuser', 'ABC');
+      expect(result).toBeNull();
+      expect(referrals.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onQualifyingApproval', () => {
+    it('moves a pending referral to qualified and enqueues the reward', async () => {
+      referrals.findOne!.mockResolvedValue({
+        id: 'ref-1',
+        status: ReferralStatus.PENDING,
+      });
+
+      await service.onQualifyingApproval('newuser');
+
+      expect(referrals.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: ReferralStatus.QUALIFIED }),
+      );
+      expect(processor.enqueue).toHaveBeenCalledWith('ref-1');
+    });
+
+    it('is a no-op when the user has no pending referral', async () => {
+      referrals.findOne!.mockResolvedValue(null);
+      await service.onQualifyingApproval('newuser');
+      expect(processor.enqueue).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/BackEnd/src/modules/referrals/referrals.service.ts
+++ b/BackEnd/src/modules/referrals/referrals.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { QueryFailedError, Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { ReferralCode } from './entities/referral-code.entity';
+import { Referral, ReferralStatus } from './entities/referral.entity';
+import { ReferralReward } from './entities/referral-reward.entity';
+import { ReferralRewardProcessor } from '../jobs/processors/referral-reward.processor';
+
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Crockford-ish, no ambiguous chars
+const CODE_LENGTH = 8;
+
+/**
+ * Referral & invitation program: per-user codes, signup attribution with
+ * anti-abuse checks, milestone-based qualification, and idempotent reward
+ * crediting.
+ */
+@Injectable()
+export class ReferralsService {
+  private readonly logger = new Logger(ReferralsService.name);
+
+  constructor(
+    @InjectRepository(ReferralCode)
+    private readonly codes: Repository<ReferralCode>,
+    @InjectRepository(Referral)
+    private readonly referrals: Repository<Referral>,
+    @InjectRepository(ReferralReward)
+    private readonly rewards: Repository<ReferralReward>,
+    private readonly config: ConfigService,
+    private readonly rewardProcessor: ReferralRewardProcessor,
+  ) {}
+
+  /** Returns the user's stable code, creating it once on first request. */
+  async getOrCreateCode(userId: string): Promise<string> {
+    const existing = await this.codes.findOne({ where: { userId } });
+    if (existing) {
+      return existing.code;
+    }
+    // Retry on the (rare) unique-code collision.
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const code = this.generateCode();
+      try {
+        const saved = await this.codes.save(
+          this.codes.create({ userId, code }),
+        );
+        return saved.code;
+      } catch (err) {
+        if (err instanceof QueryFailedError) {
+          // Either the code collided or this user's row was created concurrently.
+          const raced = await this.codes.findOne({ where: { userId } });
+          if (raced) {
+            return raced.code;
+          }
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw new Error('Failed to allocate a unique referral code');
+  }
+
+  /** The user's code plus a shareable invitation link. */
+  async getMyReferralInfo(
+    userId: string,
+  ): Promise<{ code: string; link: string }> {
+    const code = await this.getOrCreateCode(userId);
+    const appUrl = this.config.get<string>('APP_URL', 'http://localhost:3000');
+    return { code, link: `${appUrl}/signup?ref=${code}` };
+  }
+
+  /** Resolves a referral code to its owning user id, or null if unknown. */
+  async resolveCodeOwner(code: string): Promise<string | null> {
+    const row = await this.codes.findOne({ where: { code } });
+    return row ? row.userId : null;
+  }
+
+  /**
+   * Records a pending attribution for a newly signed-up user. No-op when no
+   * code is supplied. Rejects self-referral, unknown codes, duplicate
+   * attribution, and circular attribution (A refers B while B already referred A).
+   */
+  async recordSignupAttribution(
+    referredUserId: string,
+    code?: string | null,
+  ): Promise<Referral | null> {
+    if (!code) {
+      return null;
+    }
+    const referrerUserId = await this.resolveCodeOwner(code);
+    if (!referrerUserId) {
+      this.logger.warn(`Signup used unknown referral code '${code}'`);
+      return null;
+    }
+    if (referrerUserId === referredUserId) {
+      this.logger.warn(`Rejected self-referral for user ${referredUserId}`);
+      return null;
+    }
+    // Duplicate: this user was already attributed to someone.
+    const already = await this.referrals.findOne({ where: { referredUserId } });
+    if (already) {
+      return already;
+    }
+    // Circular: the new user previously referred the code owner.
+    const circular = await this.referrals.findOne({
+      where: { referrerUserId: referredUserId, referredUserId: referrerUserId },
+    });
+    if (circular) {
+      this.logger.warn(
+        `Rejected circular referral between ${referrerUserId} and ${referredUserId}`,
+      );
+      return null;
+    }
+
+    try {
+      return await this.referrals.save(
+        this.referrals.create({
+          referrerUserId,
+          referredUserId,
+          code,
+          status: ReferralStatus.PENDING,
+        }),
+      );
+    } catch (err) {
+      // Unique(referredUserId) — a concurrent signup already attributed them.
+      if (err instanceof QueryFailedError) {
+        return this.referrals.findOne({ where: { referredUserId } });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Qualifying-milestone hook. When a referred user reaches the milestone (their
+   * first approved submission), moves a PENDING referral to QUALIFIED and
+   * enqueues idempotent reward crediting. Safe to call on every approval —
+   * once qualified/rewarded it is a no-op.
+   */
+  async onQualifyingApproval(referredUserId: string): Promise<void> {
+    const referral = await this.referrals.findOne({
+      where: { referredUserId, status: ReferralStatus.PENDING },
+    });
+    if (!referral) {
+      return;
+    }
+    referral.status = ReferralStatus.QUALIFIED;
+    referral.qualifiedAt = new Date();
+    await this.referrals.save(referral);
+    this.rewardProcessor.enqueue(referral.id);
+  }
+
+  /** Referrals the user has made, newest first. */
+  listMyReferrals(userId: string): Promise<Referral[]> {
+    return this.referrals.find({
+      where: { referrerUserId: userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /** Rewards credited to the user, newest first. */
+  listMyRewards(userId: string): Promise<ReferralReward[]> {
+    return this.rewards.find({
+      where: { referrerUserId: userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  private generateCode(): string {
+    const bytes = crypto.randomBytes(CODE_LENGTH);
+    let code = '';
+    for (let i = 0; i < CODE_LENGTH; i++) {
+      code += CODE_ALPHABET[bytes[i] % CODE_ALPHABET.length];
+    }
+    return code;
+  }
+}

--- a/BackEnd/src/modules/submissions/CHANGELOG.md
+++ b/BackEnd/src/modules/submissions/CHANGELOG.md
@@ -17,6 +17,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Referral qualifying-milestone hook: after a successful approval, `SubmissionsService.processApproval` calls `ReferralsService.onQualifyingApproval(submitterUserId)` so a referred user's first approved submission qualifies their referrer's reward. Idempotent and a no-op for non-referred users, so the approval flow is unaffected (#2357).
 - `anonymizeForErasure(userId, manager?)` — detaches submitter PII and proof references from a user's submissions while preserving quest integrity and reviewer decisions, used by the right-to-erasure pipeline; runs inside the caller's transaction when a manager is supplied (#2337).
 
 ### Added

--- a/BackEnd/src/modules/submissions/submissions.module.ts
+++ b/BackEnd/src/modules/submissions/submissions.module.ts
@@ -12,6 +12,7 @@ import { Submission } from './entities/submission.entity';
 import { VerificationDedupService } from '../../common/services/verification-dedup.service';
 import { Quest } from '../quests/entities/quest.entity';
 import { User } from '../users/entities/user.entity';
+import { ReferralsModule } from '../referrals/referrals.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { User } from '../users/entities/user.entity';
     NotificationsModule,
     StellarModule,
     CacheModule,
+    ReferralsModule,
   ],
   controllers: [SubmissionsController],
   providers: [

--- a/BackEnd/src/modules/submissions/submissions.service.ts
+++ b/BackEnd/src/modules/submissions/submissions.service.ts
@@ -43,6 +43,7 @@ import { Quest } from '../quests/entities/quest.entity';
 import { User } from '../users/entities/user.entity';
 import { MetricsService } from '../../common/services/metrics.service';
 import { VerificationDedupService } from '../../common/services/verification-dedup.service';
+import { ReferralsService } from '../referrals/referrals.service';
 import {
   SubmissionNotFoundException,
   QuestNotFoundException,
@@ -80,6 +81,7 @@ export class SubmissionsService {
     private eventEmitter: EventEmitter2,
     private metricsService: MetricsService,
     private verificationDedup: VerificationDedupService,
+    private referralsService: ReferralsService,
   ) {}
 
   /**
@@ -445,6 +447,11 @@ export class SubmissionsService {
       approvedBy: verifierId,
       approvedAt,
     });
+
+    // Referral qualifying milestone: a referred user's first approved
+    // submission qualifies their referrer's reward. Idempotent and a no-op
+    // when the submitter was not referred, so it never affects the flow.
+    await this.referralsService.onQualifyingApproval(submission.userId);
 
     // Emit SLA metrics for submission review time
     this.metricsService.incrementCounter('submission_review_total');


### PR DESCRIPTION
## Summary

Adds the backend referral & invitation program (API and logic only; the referral UI is tracked separately).

### Codes, attribution, and API
- New `referrals` module. `ReferralsService` generates a stable, unique per-user code, resolves a code to its owner, and records a signup attribution.
- `ReferralsController` (JWT-guarded): `GET /referrals/me/code` (code + shareable link), `GET /referrals/me/referrals` (my referrals + status), `GET /referrals/me/rewards` (credited rewards).
- `AuthService.verifyAndLogin` captures an optional `referralCode` from `LoginDto` and, on first-time signup only, creates a pending attribution. **Self-referral, unknown codes, duplicate attribution, and circular attribution (A refers B while B already referred A) are all rejected** — invalid codes are ignored so signup never fails.

### Qualification and reward crediting
- `Referral` (referrer, referred user, code, status `pending`/`qualified`/`rewarded`/`rejected`, timestamps), a `ReferralReward` ledger, and a `ReferralCode` table, plus a migration.
- A qualifying hook in `SubmissionsService.processApproval` moves a referral to `qualified` on the referred user's **first approved submission** and enqueues reward processing (idempotent; a no-op for non-referred users).
- `ReferralRewardProcessor` credits the reward **exactly once** — idempotency is enforced by the unique `ReferralReward.referralId`, and self-referrals are rejected/dead-lettered at credit time.

### Wiring & docs
- `ReferralsModule` registered in `app.module.ts`; the reward processor lives in `jobs/processors/` and is provided by `ReferralsModule`.
- Module CHANGELOGs updated (referrals/auth/submissions/jobs); reward amount is configurable via `REFERRAL_REWARD_STROOPS`.

> The platform does not run a BullMQ worker (no `BullModule` is configured), so reward crediting is invoked in-process; the persisted `Referral`/`ReferralReward` rows keep state queryable and let a future queue-backed worker resume from them.

## Testing
- `npm run build`, `npm run lint`, `npx prettier --check`, `npm run openapi:generate` (app bootstraps cleanly)
- Unit tests: attribution, anti-abuse rejection (self/duplicate/circular), qualification, and idempotent reward crediting.

## Issues

Closes #2357
